### PR TITLE
Add self-review step to task workflows; rename task-workflow → task-issue

### DIFF
--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -1,0 +1,91 @@
+# Self-Review Agent
+
+Reviews implementation code for a task. Reads the diff since implementation started, checks against the spec and design, writes structured findings into the progress file, and issues APPROVE or REJECT.
+
+Used in the automated self-review loop inside `/task` and `/task-workflow` — runs after Verify, before the task is declared done.
+
+## Mindset: maximally skeptical, but justified
+
+**Presumption of guilt.** Your job is to find problems before the user does.
+
+APPROVE is only issued if you **actively** checked every checklist item and found no violations — not "didn't notice anything bad."
+
+Every suspicion — **investigate via Read/grep**, don't guess.
+
+A passing test doesn't mean it's correct. Mentally comment out the production fix: does the test fail? If not → test is cosmetic → REJECT.
+
+## Instructions
+
+1. Read `AGENTS.md` — current project rules
+2. Read the progress file (path passed in prompt) — find `base_commit` and current round
+3. Get the diff: `git diff <base_commit>..HEAD`
+4. Read spec — only `## Acceptance Criteria`
+5. Read design doc — architecture and decomposition
+6. Run through the checklist below
+7. Count existing `## Self-Review` sections in the progress file to determine round N
+8. **Append** a `## Self-Review (Round N)` section to the progress file (do not replace existing sections)
+9. Output your verdict to stdout as well
+
+## Checklist
+
+### 1. Spec conformance
+- Every AC from the spec is covered by the diff?
+- No changes outside the spec scope (scope creep)?
+
+### 2. Design conformance
+- Implementation architecture matches the design?
+- All files from the decomposition are present and changed?
+- No architectural decisions made on-the-fly without being reflected in the design?
+
+### 3. Test coverage
+- Every non-trivial function / branch has a test?
+- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block?
+- Tests verify invariants, not cosmetics?
+  - Mental test: comment out the production fix → does the test fail? If not → cosmetic → **REJECT**
+- No `unwrap()` in tests without justification?
+- All assertions specific — no vacuous `assert!(true)`?
+
+### 4. Safety and correctness
+- `unsafe` blocks: each one justified with a comment?
+- `unwrap()` / `expect()`: only with clear reasoning? Production code should use `?` or explicit error handling.
+- Clones where `&T` would suffice?
+- Error handling: `?` propagation consistent? No silenced errors (`let _ = ...`)?
+- No `#[allow(clippy::...)]` without justification comment?
+
+### 5. Style (AGENTS.md rules)
+- All new source files in Rust (`.rs`)?
+- `cargo fmt` applied (no formatting drift)?
+- No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
+
+## What you do NOT check
+
+- Formatting — that's `cargo fmt`; if CI is green, skip
+- Subjective preferences — only objective violations
+
+## Findings format (written to progress file)
+
+Append **exactly** this section to the progress file:
+
+```markdown
+## Self-Review (Round N)
+
+**Verdict:** APPROVE | REJECT
+
+| # | File:line | Severity | Finding | Status |
+|---|-----------|----------|---------|--------|
+| 1 | src/foo.rs:42 | major | Description | ⬜ Open |
+| 2 | src/bar.rs:10 | nit | Unused import | ⬜ Open |
+```
+
+Severity levels: `blocker` · `major` · `minor` · `nit`
+
+- For APPROVE: table is empty (no rows) or contains only already-resolved items.
+- For REJECT: at least one `blocker` or `major` row with `⬜ Open` status.
+
+## Rules
+
+- **"What was checked" is required** — name the specific ACs, files, components you verified.
+- On REJECT — every violation must have an exact file and line number.
+- Maximum 10 findings per round. If more exist, list the 10 most severe.
+- Don't invent problems. If unsure, read the code before raising a finding.
+- On re-review (round > 1): check that previously `✅ Fixed` or `⚠️ Objected` items are not re-raised. Focus only on remaining `⬜ Open` items plus anything newly introduced.

--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: task-workflow
-description: "Full ticket workflow: ticket → interview → spec → design → design-review → impl → verify. Steps are strictly ordered and cannot be skipped."
+name: task-issue
+description: "Full ticket workflow: ticket → interview → spec → design → design-review → impl → verify → self-review. Steps are strictly ordered and cannot be skipped."
 disable-model-invocation: true
 argument-hint: "[issue-number]"
-allowed-tools: Bash(gh issue view *) Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(rustfmt *)
+allowed-tools: Bash(gh issue view *) Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(git diff *) Bash(git rev-parse *)
 ---
 
 Full workflow for working on a task (issue). Steps execute **strictly in sequence** — proceeding to N+1 before N is complete is FORBIDDEN.
@@ -88,10 +88,14 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 > First action: verify both spec and design (with GO verdict) exist. Missing = previous steps incomplete.
 
 - Create `ai-docs/plans/YYYY-MM-DD-name.progress.md` at start (see `/context-reset` for format)
+- **Record base commit** in the progress file immediately:
+  ```
+  base_commit: <output of `git rev-parse HEAD`>
+  ```
 - After each subtask:
   1. `cargo build` — must compile
   2. `cargo test test_name` — if subtask adds tests
-  3. `rustfmt` changed files; `cargo clippy -- -D warnings`
+  3. `cargo fmt`; `cargo clippy -- -D warnings`
   4. Update `.progress.md`
   5. If N=3 of M≥5 → handoff via Task (see `/context-reset`)
 - Unknown API → read sources → grep codebase → ask user. Don't guess.
@@ -110,9 +114,45 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-5. On ALL PASS → delete `.progress.md`
+5. On ALL PASS → proceed to Step 10
 
-**FORBIDDEN:** declaring done with uncovered ACs · skipping design review · writing code before confirmed spec
+### Step 10: Self-review loop (max 3 rounds)
+
+Spawn the self-review agent:
+
+```
+Task(subagent_type="general-purpose", prompt="
+  Read .claude/agents/self-review.md and follow it.
+  Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
+  Design: ai-docs/plans/YYYY-MM-DD-name.design.md
+  Progress: ai-docs/plans/YYYY-MM-DD-name.progress.md
+  base_commit is recorded in the progress file.
+")
+```
+
+**On APPROVE:** delete `.progress.md` → done.
+
+**On REJECT:** proceed to Step 11. After Step 11, loop back here.
+
+**After round 3 with REJECT:** surface all remaining `⬜ Open` findings to the user and ask how to proceed. Do not delete `.progress.md` until resolved.
+
+### Step 11: Review fixes
+
+For each `⬜ Open` finding in the latest `## Self-Review (Round N)` section of the progress file:
+
+- **Fix it** → mark `✅ Fixed` in the progress file, implement the change.
+- **Object to it** (finding is wrong or intentionally out of scope):
+  - `nit` / `minor`: agent may object autonomously — write reason, mark `⚠️ Objected: <reason>`.
+  - `major` / `blocker`: **surface to user first** before objecting. User must approve the objection.
+
+After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
+1. `cargo build` — must compile
+2. `cargo test` — all green
+3. `cargo clippy -- -D warnings` — clean
+4. Update `.progress.md`
+5. Return to Step 10.
+
+**FORBIDDEN:** declaring done with uncovered ACs · skipping design review · writing code before confirmed spec · deleting `.progress.md` before self-review APPROVE
 
 ## Gate checklist
 
@@ -123,5 +163,8 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 | Step 5 | All decisions confirmed? Every AC verifiable? |
 | Step 6 | Spec saved? ACs confirmed? |
 | Step 8 | Design doc with GO? Test Design section present? |
+| Step 8 start | `base_commit` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
 | Step 9 | `cargo test` green? clippy clean? All ACs covered? |
+| Step 10 | Self-review APPROVE before deleting progress file? |
+| Step 11 | `major`/`blocker` objections confirmed by user? |

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: task
-description: "Full task workflow from user description: interview → spec → design → design-review → impl → verify. Use when the user describes a task directly (no GitHub issue). Steps are strictly ordered and cannot be skipped."
+description: "Full task workflow from user description: interview → spec → design → design-review → impl → verify → self-review. Use when the user describes a task directly (no GitHub issue). Steps are strictly ordered and cannot be skipped."
 disable-model-invocation: true
 argument-hint: "[short task description]"
-allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(rustfmt *)
+allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(git diff *) Bash(git rev-parse *)
 ---
 
 Full workflow for a user-described task. Steps execute **strictly in sequence** — proceeding to N+1 before N is complete is FORBIDDEN.
@@ -118,10 +118,14 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 > First action: verify both spec and design (with GO verdict) exist. Missing = previous steps incomplete.
 
 - Create `ai-docs/plans/YYYY-MM-DD-name.progress.md` at start (see `/context-reset` for format)
+- **Record base commit** in the progress file immediately:
+  ```
+  base_commit: <output of `git rev-parse HEAD`>
+  ```
 - After each subtask:
   1. `cargo build` — must compile
   2. `cargo test test_name` — if subtask adds tests
-  3. `rustfmt` changed files; `cargo clippy -- -D warnings`
+  3. `cargo fmt`; `cargo clippy -- -D warnings`
   4. Update `.progress.md`
   5. If N=3 of M≥5 → handoff via Task (see `/context-reset`)
 - Unknown API → read sources → grep codebase → ask user. Don't guess.
@@ -140,9 +144,45 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-5. On ALL PASS → delete `.progress.md`
+5. On ALL PASS → proceed to Step 10
 
-**FORBIDDEN:** declaring done with uncovered ACs · skipping design review · writing code before confirmed spec
+### Step 10: Self-review loop (max 3 rounds)
+
+Spawn the self-review agent:
+
+```
+Task(subagent_type="general-purpose", prompt="
+  Read .claude/agents/self-review.md and follow it.
+  Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
+  Design: ai-docs/plans/YYYY-MM-DD-name.design.md
+  Progress: ai-docs/plans/YYYY-MM-DD-name.progress.md
+  base_commit is recorded in the progress file.
+")
+```
+
+**On APPROVE:** delete `.progress.md` → done.
+
+**On REJECT:** proceed to Step 11. After Step 11, loop back here.
+
+**After round 3 with REJECT:** surface all remaining `⬜ Open` findings to the user and ask how to proceed. Do not delete `.progress.md` until resolved.
+
+### Step 11: Review fixes
+
+For each `⬜ Open` finding in the latest `## Self-Review (Round N)` section of the progress file:
+
+- **Fix it** → mark `✅ Fixed` in the progress file, implement the change.
+- **Object to it** (finding is wrong or intentionally out of scope):
+  - `nit` / `minor`: agent may object autonomously — write reason, mark `⚠️ Objected: <reason>`.
+  - `major` / `blocker`: **surface to user first** before objecting. User must approve the objection.
+
+After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
+1. `cargo build` — must compile
+2. `cargo test` — all green
+3. `cargo clippy -- -D warnings` — clean
+4. Update `.progress.md`
+5. Return to Step 10.
+
+**FORBIDDEN:** declaring done with uncovered ACs · skipping design review · writing code before confirmed spec · deleting `.progress.md` before self-review APPROVE
 
 ## Gate checklist
 
@@ -153,5 +193,8 @@ Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
 | Step 5 | All decisions confirmed? Every AC verifiable? |
 | Step 6 | Spec saved? ACs confirmed? |
 | Step 8 | Design doc with GO? Test Design section present? |
+| Step 8 start | `base_commit` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
 | Step 9 | `cargo test` green? clippy clean? All ACs covered? |
+| Step 10 | Self-review APPROVE before deleting progress file? |
+| Step 11 | `major`/`blocker` objections confirmed by user? |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,12 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +157,6 @@ dependencies = [
  "quartzite-core",
  "quote",
  "syn",
- "trybuild",
 ]
 
 [[package]]
@@ -255,15 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,28 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,36 +282,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "target-triple"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
 ]
 
 [[package]]
@@ -383,55 +315,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "trybuild"
-version = "1.0.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
-dependencies = [
- "glob",
- "serde",
- "serde_derive",
- "serde_json",
- "target-triple",
- "termcolor",
- "toml",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "winnow"
@@ -447,9 +334,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"


### PR DESCRIPTION
## Summary

- **New agent** `.claude/agents/self-review.md`: maximally-skeptical post-verify reviewer that diffs since `base_commit`, checks spec/design/test/safety conformance, and appends structured `APPROVE`/`REJECT` findings to the progress file.
- **Rename `/task-workflow` → `/task-issue`**: updated with self-review loop (Steps 10–11), `base_commit` recording at impl start, `cargo fmt` fix, and expanded `allowed-tools`.
- **`/task` skill updated** identically: Steps 10–11 added, same tooling fixes.
- **`Cargo.lock` refreshed**: `trybuild` and its transitive deps removed (dependency was dropped in #4 but lock file wasn't regenerated).

## Test plan

- [ ] Verify `/task-issue` resumes an active `.progress.md` correctly
- [ ] Verify self-review agent appends `## Self-Review (Round N)` without overwriting prior rounds
- [ ] Verify REJECT → fix loop stops after round 3 and surfaces findings to user
- [ ] `cargo build` passes with refreshed lock file