### PR TITLE
docs: escalate branch-before-commit rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 ## Workflow
 
 - Merge PRs with a merge commit (`gh pr merge --merge`). Never squash or rebase-merge.
+- **Never commit to local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any commits. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
+  - Recovery (commits on local master, not yet pushed): `git checkout -b feat/...` → `git checkout master && git reset --hard origin/master` → push feature branch and open PR from it.
 - Run `cargo build` before committing so `Cargo.lock` is refreshed and included in the commit when it changes.
 - Plan first. Tests before prod code (TDD). Lint changed files.
 - Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -24,7 +24,7 @@ Before any `git push`: run `git branch --show-current` and confirm it is **not**
 
 If "submit PR" is requested and commits are already pushed to origin/master: stop and tell the user — there is no recovery without a force push, which branch protection may block.
 
-**Escalated?** no
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — testing — any sufficiently large file requires unit tests
 


### PR DESCRIPTION
## Summary

- Adds the never-commit-to-master / always-create-feature-branch rule to the `Workflow` section of `AGENTS.md`, including the full recovery procedure for commits accidentally landed on local master
- Marks the corresponding `learnings.md` entry as `Escalated? AGENTS.md`

## Test plan

- [ ] Verify `AGENTS.md` Workflow section contains the new branch rule and recovery steps
- [ ] Verify `ai-docs/learnings.md` entry 2 shows `Escalated? AGENTS.md`