### PR TITLE
feat(task-skill): activate deferred plans by moving files before proceeding

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -23,6 +23,24 @@ ls ai-docs/plans/*.progress.md 2>/dev/null
 
 ---
 
+## ⚡ Second: check for deferred plan activation
+
+If `$ARGUMENTS` contains words like "activate", "start", "proceed" **and** a matching plan exists in `ai-docs/plans/deferred/`:
+
+1. Identify the matching `*.spec.md` (and `*.design.md` if present) in `ai-docs/plans/deferred/`.
+2. Move them to `ai-docs/plans/`:
+   ```bash
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.spec.md ai-docs/plans/
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.design.md ai-docs/plans/     # if exists
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.progress.md ai-docs/plans/   # if exists
+   ```
+3. Update `ai-docs/plans/INDEX.md`: move the plan row from the **Deferred plans** table to the **Active plans** table and mark its status as `🟢 ready` (or `🟡 spec-only` if no design).
+4. Tell the user: "Activated plan [name] — moved spec (and design) to `ai-docs/plans/`."
+5. If a `.progress.md` was moved: treat it as an active task — read it and resume from `## Next action` (same as the RESUME path above).
+6. Otherwise (no progress file): skip Steps 1–7 and jump directly to Step 8 (spec + design already exist).
+
+---
+
 ### Step 1: Get the task description
 
 If `$ARGUMENTS` is provided — use it as the initial task description.


### PR DESCRIPTION
## Summary

- Adds a second pre-check in `/task` skill: if arguments contain "activate"/"start"/"proceed" and a matching plan exists in `ai-docs/plans/deferred/`, the skill moves spec, design, and progress files to `ai-docs/plans/` before doing anything else.
- Updates `INDEX.md` to move the plan row from Deferred to Active.
- If a progress file was moved, resumes from `## Next action`; otherwise jumps straight to Step 8.

## Test plan

- [ ] Run `/task activate runtime plan` with the runtime plan in `deferred/` — verify files are moved and INDEX.md is updated before implementation starts.
- [ ] Run `/task activate ...` with a plan that has a progress file — verify it resumes rather than restarting.
- [ ] Run `/task <unrelated description>` — verify the new section is skipped entirely.