### PR TITLE
docs: add let-chains rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 
 - Merge PRs with a merge commit (`gh pr merge --merge`). Never squash or rebase-merge.
 - **Never commit to local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any commits. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
-  - Recovery (commits on local master, not yet pushed): `git checkout -b feat/...` → `git checkout master && git reset --hard origin/master` → push feature branch and open PR from it.
+  - Recovery (commits on local master, not yet pushed): stash any uncommitted changes first (`git stash`), then `git checkout -b feat/...` → `git checkout master && git reset --soft origin/master && git restore --staged .` → push feature branch and open PR from it. Pop the stash on the feature branch if needed.
 - Run `cargo build` before committing so `Cargo.lock` is refreshed and included in the commit when it changes.
 - Plan first. Tests before prod code (TDD). Lint changed files.
 - Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - Max line: 100 (rustfmt default).
 - Strict clippy (enforced).
 - Prefer Rust idioms over literal C++ ports. When in doubt, ask.
+- Let chains (`if let A = x && let B = y { ... }`) are valid in this codebase (edition 2024). Do not avoid them. Always format via `cargo fmt`, never `rustfmt <file>` directly.
 
 ## Workflow
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -8,6 +8,30 @@
 
 **Escalated?** AGENTS.md
 
+### 2026-05-02 — process — do not touch IDE files unless explicitly asked
+
+**What happened:** `.idea/quartzite.iml` had an uncommitted modification. Without being asked, it was added to `.gitignore` and removed from tracking.
+
+**Rule:** Never add, remove, modify, or `.gitignore` IDE files (`.idea/`, `*.iml`, `.vscode/`, etc.) unless the user explicitly asks. Treat them as the user's domain.
+
+**Escalated?** no
+
+### 2026-05-02 — process — "submit to PR" means push to remote, not merge
+
+**What happened:** User said "submit to pr". Interpreted as merging the PR via `gh pr merge`. User meant pushing the local commits to the remote branch so they appear in the open PR.
+
+**Rule:** "Submit to PR" (and similar: "push to PR", "add to PR") means `git push` the branch to remote. It does not mean merging. Only merge when the user explicitly says "merge" or "merge the PR".
+
+**Escalated?** no
+
+### 2026-05-02 — process — "wtf" signals that the previous action was wrong
+
+**What happened:** User said "add ide files". Interpreted as adding IDE files to `.gitignore`. User meant commit and track them. User responded "wtf?" to signal the action was wrong.
+
+**Rule:** "wtf" (and similar expressions of surprise/frustration) means the last action was the opposite of what the user wanted. Stop immediately, ask what went wrong, and do not proceed until the intent is clarified.
+
+**Escalated?** no
+
 ### 2026-05-02 — process — always create a feature branch before committing; never commit directly to master
 
 **What happened:** When the user said "submit PR", commits were already on local master. Instead of creating a feature branch first, `git push` was run directly against master — pushing the commits to origin/master. `master` is branch-protected (no force push), so the commits could not be removed after the fact and a proper PR became impossible.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -32,6 +32,18 @@
 
 **Escalated?** no
 
+### 2026-05-02 — process — never use git reset --hard; use soft reset, stash, cherry-pick, or backup branch
+
+**What happened:** `git reset --hard origin/master` was used to move commits off local master to a feature branch. This discarded uncommitted changes to `ai-docs/learnings.md` that had not been staged.
+
+**Rule:** Never use `git reset --hard`. Use one of these instead:
+- `git reset --soft HEAD~N` — moves commits back to staged, preserves working tree
+- `git stash` — saves uncommitted changes before switching branches
+- `git cherry-pick` — moves specific commits to another branch
+- Backup branch — `git checkout -b backup/...` before any destructive operation
+
+**Escalated?** no
+
 ### 2026-05-02 — process — always create a feature branch before committing; never commit directly to master
 
 **What happened:** When the user said "submit PR", commits were already on local master. Instead of creating a feature branch first, `git push` was run directly against master — pushing the commits to origin/master. `master` is branch-protected (no force push), so the commits could not be removed after the fact and a proper PR became impossible.


### PR DESCRIPTION
## Summary

- Adds the let-chains rule to `AGENTS.md` Code Style section (escalated from `ai-docs/learnings.md`)
- Restores three learnings entries that were lost to `git reset --hard`

## Test plan

- [ ] No code changes — docs only