### PR TITLE
docs: add missed learnings entry and fix Step 12 staging list

### DIFF
--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -208,7 +208,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
    - Move spec/design files to `ai-docs/plans/done/`
    - Update dependency tree and **Suggested next steps**
 3. `cargo build` — ensures `Cargo.lock` is refreshed and included if changed.
-4. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, updated `INDEX.md`, and spec/design now in `done/`.
+4. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, `ai-docs/learnings.md` (if modified), updated `INDEX.md`, and spec/design now in `done/`.
 5. Commit:
    ```
    feat(<crate>): <short imperative description>

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -256,7 +256,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
    - Move spec/design files to `ai-docs/plans/done/`
    - Update dependency tree and **Suggested next steps**
 3. `cargo build` — ensures `Cargo.lock` is refreshed and included if changed.
-4. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, updated `INDEX.md`, and spec/design now in `done/`.
+4. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, `ai-docs/learnings.md` (if modified), updated `INDEX.md`, and spec/design now in `done/`.
 5. Commit:
    ```
    feat(<crate>): <short imperative description>

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -62,6 +62,14 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Escalated?** AGENTS.md
 
+### 2026-05-02 — process — create feature branch before committing at the start of Step 8
+
+**What happened:** The auto-connection task completed all implementation steps on the working tree without ever committing. Only after the user asked "why didn't you create a PR?" was the branch created. The changes had to be recovered by checking out a feature branch from the unstaged state.
+
+**Rule:** At the start of Step 8 (Implementation), immediately create a feature branch (`git checkout -b feat/...`) before writing any code. Record the branch name in the progress file. Do not wait until after self-review to create the branch.
+
+**Escalated?** no
+
 ### 2026-05-02 — testing — any sufficiently large file requires unit tests
 
 **What happened:** Three codegen files (`object/codegen.rs`, `object_impl/codegen.rs`, `meta_enum/codegen.rs`) were written without `#[cfg(test)]` modules. Gaps were caught in review and by the user. The original rule was codegen-specific, but the user generalised it: any file with substantial logic needs tests.


### PR DESCRIPTION
## Summary

- Adds the missed `learnings.md` entry from the auto-connection session (feature branch should be created at Step 8 start, not after the fact)
- Explicitly includes `ai-docs/learnings.md` in the Step 12 staging list in both `/task` and `/task-issue` skills so it is never left out of future PRs

## Test plan

- [ ] No code changes — docs and skill files only