### PR TITLE
chore(workflow): harden branch guard against master commits

### DIFF
--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -18,14 +18,14 @@ Read:
 Go through `ai-docs/learnings.md` and group entries:
 - By category (`code-style`, `process`, `architecture`, `testing`, `search`, `other`)
 - By recurrence (how many times the same mistake)
-- By escalation status (none / AGENTS.md / skill / hook)
+- By escalation status: treat `no` and `memory` as **unescalated** (memory is global, not project-level); treat `AGENTS.md`, `skill`, `hook`, `settings`, `agent` as escalated
 
 ### Step 2: Determine actions
 
 | Occurrences | Current status | Action |
 |---|---|---|
-| 1 | none | Nothing — wait for recurrence |
-| ≥2 | none | Update `AGENTS.md` or skill/agent file — add/strengthen rule |
+| 1 | no / memory | Nothing — wait for recurrence |
+| ≥2 | no / memory | Update `AGENTS.md` or skill/agent file — add/strengthen rule |
 | ≥2 | AGENTS.md/skill | Rule exists but isn't working → move closer to the point of execution |
 | ≥3 | rule in place | Propose a hook in `.claude/settings.json` |
 

--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -18,15 +18,17 @@ Read:
 Go through `ai-docs/learnings.md` and group entries:
 - By category (`code-style`, `process`, `architecture`, `testing`, `search`, `other`)
 - By recurrence (how many times the same mistake)
-- By escalation status: treat `no` and `memory` as **unescalated** (memory is global, not project-level); treat `AGENTS.md`, `skill`, `hook`, `settings`, `agent` as escalated
+- By escalation status:
+  - **Unescalated** (`no`, `memory`): `memory` is global cross-project only — not a project-level fix
+  - **Escalated** (`AGENTS.md`, `skill:[name]`, `hook`, `settings`, `agent:[name]`): rule is in project instructions; `settings.local` does NOT count (user-local, not project)
 
 ### Step 2: Determine actions
 
 | Occurrences | Current status | Action |
 |---|---|---|
 | 1 | no / memory | Nothing — wait for recurrence |
-| ≥2 | no / memory | Update `AGENTS.md` or skill/agent file — add/strengthen rule |
-| ≥2 | AGENTS.md/skill | Rule exists but isn't working → move closer to the point of execution |
+| ≥2 | no / memory | Update `AGENTS.md` or skill/agent/settings file — add/strengthen rule |
+| ≥2 | AGENTS.md / skill / agent / settings | Rule exists but isn't working → move closer to the point of execution |
 | ≥3 | rule in place | Propose a hook in `.claude/settings.json` |
 
 **Routing — which file to update:**

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,19 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -q 'git commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"master\" ]; then echo 'BLOCKED: git commit on master is forbidden. Create a feature branch first (git checkout -b feat/...) and apply the AGENTS.md recovery procedure.'; exit 1; fi; fi",
+            "timeout": 10,
+            "statusMessage": "Checking branch before commit..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -119,6 +119,7 @@ finding (Step 11) requires a design change rather than a code fix:
   git checkout -b feat/YYYY-MM-DD-name
   ```
   Use the same date-name as the spec file. Record the branch name in the progress file.
+- **Before every `git commit` in this step:** run `git branch --show-current` and confirm it is NOT `master`. If it is — stop immediately, do not commit, apply the recovery procedure in AGENTS.md.
 - Create `ai-docs/plans/YYYY-MM-DD-name.progress.md` at start (see `/context-reset` for format)
 - **Record base commit** in the progress file immediately:
   ```
@@ -234,7 +235,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 5 | All decisions confirmed? Every AC verifiable? |
 | Step 6 | Spec saved? ACs confirmed? |
 | Step 8 | Design doc with GO? Test Design section present? |
-| Step 8 start | Feature branch created (`git branch --show-current` ≠ master)? `base_commit` + `branch` recorded in progress file? |
+| Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
 | Step 9 | `cargo test` green? clippy clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -167,6 +167,7 @@ finding (Step 11) requires a design change rather than a code fix:
   git checkout -b feat/YYYY-MM-DD-name
   ```
   Use the same date-name as the spec file. Record the branch name in the progress file.
+- **Before every `git commit` in this step:** run `git branch --show-current` and confirm it is NOT `master`. If it is — stop immediately, do not commit, apply the recovery procedure in AGENTS.md.
 - Create `ai-docs/plans/YYYY-MM-DD-name.progress.md` at start (see `/context-reset` for format)
 - **Record base commit** in the progress file immediately:
   ```
@@ -281,7 +282,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 5 | All decisions confirmed? Every AC verifiable? |
 | Step 6 | Spec saved? ACs confirmed? |
 | Step 8 | Design doc with GO? Test Design section present? |
-| Step 8 start | Feature branch created (`git branch --show-current` ≠ master)? `base_commit` + `branch` recorded in progress file? |
+| Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
 | Step 9 | `cargo test` green? clippy clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 **Rule:** [what to do instead, or what to keep doing]
 **Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory (comma-separate multiple)
 
-> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (skill/hook/AGENTS.md).
+> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (AGENTS.md / skill / agent / hook / settings). `settings.local` does NOT count as project-level.
 ```
 
 Categories: `code-style` | `process` | `architecture` | `testing` | `search` | `other`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 ### YYYY-MM-DD — [category] — [short description]
 **What happened:** [quote or paraphrase]
 **Rule:** [what to do instead, or what to keep doing]
-**Escalated?** no | AGENTS.md | skill:[name] | hook
+**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory
 ```
 
 Categories: `code-style` | `process` | `architecture` | `testing` | `search` | `other`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 ### YYYY-MM-DD — [category] — [short description]
 **What happened:** [quote or paraphrase]
 **Rule:** [what to do instead, or what to keep doing]
-**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory
+**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory (comma-separate multiple)
 ```
 
 Categories: `code-style` | `process` | `architecture` | `testing` | `search` | `other`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 **What happened:** [quote or paraphrase]
 **Rule:** [what to do instead, or what to keep doing]
 **Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory (comma-separate multiple)
+
+> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (skill/hook/AGENTS.md).
 ```
 
 Categories: `code-style` | `process` | `architecture` | `testing` | `search` | `other`

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -68,7 +68,7 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Rule:** At the start of Step 8 (Implementation), immediately create a feature branch (`git checkout -b feat/...`) before writing any code. Record the branch name in the progress file. Do not wait until after self-review to create the branch.
 
-**Escalated?** skill:task
+**Escalated?** skill:task, skill:task-issue
 
 ### 2026-05-02 — testing — any sufficiently large file requires unit tests
 
@@ -84,4 +84,4 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Rule:** Run `git branch --show-current` and confirm it is **not** `master` before any `git commit` that is intended for a PR. A pre-push check is a last resort, not the primary safeguard. The commit should never happen on master — the push check only exists as a final gate.
 
-**Escalated?** hook
+**Escalated?** hook, skill:task, skill:task-issue

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -14,7 +14,7 @@
 
 **Rule:** Never add, remove, modify, or `.gitignore` IDE files (`.idea/`, `*.iml`, `.vscode/`, etc.) unless the user explicitly asks. Treat them as the user's domain.
 
-**Escalated?** no
+**Escalated?** memory
 
 ### 2026-05-02 — process — "submit to PR" means push to remote, not merge
 
@@ -22,7 +22,7 @@
 
 **Rule:** "Submit to PR" (and similar: "push to PR", "add to PR") means `git push` the branch to remote. It does not mean merging. Only merge when the user explicitly says "merge" or "merge the PR".
 
-**Escalated?** no
+**Escalated?** memory
 
 ### 2026-05-02 — process — "wtf" signals that the previous action was wrong
 
@@ -30,7 +30,7 @@
 
 **Rule:** "wtf" (and similar expressions of surprise/frustration) means the last action was the opposite of what the user wanted. Stop immediately, ask what went wrong, and do not proceed until the intent is clarified.
 
-**Escalated?** no
+**Escalated?** memory
 
 ### 2026-05-02 — process — never use git reset --hard; use soft reset, stash, cherry-pick, or backup branch
 
@@ -42,7 +42,7 @@
 - `git cherry-pick` — moves specific commits to another branch
 - Backup branch — `git checkout -b backup/...` before any destructive operation
 
-**Escalated?** no
+**Escalated?** memory
 
 ### 2026-05-02 — process — always create a feature branch before committing; never commit directly to master
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -68,7 +68,7 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Rule:** At the start of Step 8 (Implementation), immediately create a feature branch (`git checkout -b feat/...`) before writing any code. Record the branch name in the progress file. Do not wait until after self-review to create the branch.
 
-**Escalated?** no
+**Escalated?** skill:task
 
 ### 2026-05-02 — testing — any sufficiently large file requires unit tests
 
@@ -77,3 +77,11 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 **Rule:** Any file with ~50+ lines of non-trivial code must have a `#[cfg(test)] mod tests` block. This applies equally to codegen, parse, util, and any other module — not just files named `codegen.rs`.
 
 **Escalated?** AGENTS.md
+
+### 2026-05-02 — process — check current branch before committing, not only before pushing
+
+**What happened:** For the `docs/learnings-and-skill-fix` branch, commits were made directly to local master without checking `git branch --show-current` first. The error was caught at push time (branch protection rejected the push), not at commit time. The rule in AGENTS.md mentions checking before `git push`, but the correct mental model is: verify branch before `git commit`.
+
+**Rule:** Run `git branch --show-current` and confirm it is **not** `master` before any `git commit` that is intended for a PR. A pre-push check is a last resort, not the primary safeguard. The commit should never happen on master — the push check only exists as a final gate.
+
+**Escalated?** hook


### PR DESCRIPTION
## Summary

- Add `PreToolUse` Bash hook in `settings.json`: blocks any `git commit` when `git branch --show-current` returns `master`, exits 1 with a recovery message
- Update `task/SKILL.md` and `task-issue/SKILL.md` Step 8: add explicit "before every `git commit`" branch check bullet; strengthen Gate checklist row for Step 8 start
- Expand `AGENTS.md` `Escalated?` options: add `settings | agent:[name] | memory`
- Mark two `ai-docs/learnings.md` entries as escalated (`skill:task` and `hook`)

## Test plan

- [ ] Hook fires and blocks `git commit` when on master
- [ ] Hook does not interfere with commits on a feature branch
- [ ] `task/SKILL.md` Step 8 pre-commit warning is present
- [ ] `task-issue/SKILL.md` Step 8 pre-commit warning is present (kept in sync)
- [ ] `AGENTS.md` `Escalated?` line includes all new options
- [ ] `ai-docs/learnings.md` two entries show correct escalation targets