### PR TITLE
refactor: deduplicate macros mod.rs and object_tree helper; drop unused dev-deps

### DIFF
--- a/.claude/agents/diff-review.md
+++ b/.claude/agents/diff-review.md
@@ -1,4 +1,4 @@
-# Code Review Agent
+# Diff Review Agent
 
 Reviews implemented code. Receives a diff, compares against the design doc and spec. Issues APPROVE or REJECT.
 

--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -1,4 +1,4 @@
-# Codebase Review Agent
+# Review Findings Agent
 
 Reviews the entire codebase on the current branch. No diff, no spec — reads source files directly. Produces a findings table and writes it into the progress file.
 
@@ -53,7 +53,9 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 
 ## What you do NOT check
 
-- Formatting — that's `cargo fmt`
+- `cargo fmt` / formatting drift — enforced by the fix loop in the calling skill
+- `cargo clippy` — same; enforced by the fix loop
+- `cargo build` / `cargo check` / `cargo test` — same; enforced by the fix loop's verify step
 - Anything explicitly documented as intentional in done plans
 - Subjective preferences — only objective violations
 

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -54,7 +54,6 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 
 ### 5. Style (AGENTS.md rules)
 - All new source files in Rust (`.rs`)?
-- `cargo fmt` applied (no formatting drift)?
 - No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
 
 ### 6. Objection quality (round > 1 only)
@@ -67,7 +66,9 @@ For each `⚠️ Objected` item in the progress file:
 
 ## What you do NOT check
 
-- Formatting — that's `cargo fmt`; if CI is green, skip
+- `cargo fmt` / formatting drift — already mandated after every subtask in the Implementation step; guaranteed clean before self-review runs
+- `cargo clippy` — same; already enforced during Implementation
+- `cargo build` / `cargo check` / `cargo test` — same; all enforced during Implementation and Verify steps
 - Subjective preferences — only objective violations
 
 ## Findings format (written to progress file)

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -37,7 +37,7 @@ Create the progress file path: `ai-docs/plans/YYYY-MM-DD-code-review.progress.md
 
 ```
 Agent(subagent_type="general-purpose", prompt="
-  Read .claude/agents/codebase-review.md and follow it exactly.
+  Read .claude/agents/review-findings.md and follow it exactly.
   Branch: [branch name]
   base_commit: [base_commit]
   Write progress file to: ai-docs/plans/YYYY-MM-DD-code-review.progress.md

--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -138,10 +138,12 @@ finding (Step 11) requires a design change rather than a code fix:
 
 ### Step 9: Verify
 
-1. `cargo test` — all green
-2. `cargo clippy -- -D warnings` — clean
-3. For each AC — confirm covered by test or manual verification
-4. Show summary table:
+1. `cargo build` — compiles clean
+2. `cargo test` — all green
+3. `cargo fmt -- --check` — no formatting drift
+4. `cargo clippy -- -D warnings` — clean
+5. For each AC — confirm covered by test or manual verification
+6. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |
@@ -149,7 +151,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-5. On ALL PASS → proceed to Step 9.5
+7. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -237,7 +239,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo test` green? clippy clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? |

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -186,9 +186,11 @@ finding (Step 11) requires a design change rather than a code fix:
 
 ### Step 9: Verify
 
-1. `cargo test` — all green
-2. `cargo clippy -- -D warnings` — clean
-3. For each AC — confirm covered by test or manual verification
+1. `cargo build` — compiles clean
+2. `cargo test` — all green
+3. `cargo fmt -- --check` — no formatting drift
+4. `cargo clippy -- -D warnings` — clean
+5. For each AC — confirm covered by test or manual verification
 4. Show summary table:
 
 ```
@@ -197,7 +199,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-5. On ALL PASS → proceed to Step 9.5
+6. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -284,7 +286,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo test` green? clippy clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,16 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +127,6 @@ dependencies = [
 name = "quartzite-core"
 version = "0.1.0"
 dependencies = [
- "pretty_assertions",
  "rstest",
 ]
 
@@ -152,7 +135,6 @@ name = "quartzite-macros"
 version = "0.1.0"
 dependencies = [
  "heck",
- "pretty_assertions",
  "proc-macro2",
  "quartzite-core",
  "quote",
@@ -163,9 +145,7 @@ dependencies = [
 name = "quartzite-runtime"
 version = "0.1.0"
 dependencies = [
- "pretty_assertions",
  "quartzite-core",
- "rstest",
  "slotmap",
 ]
 
@@ -353,9 +333,3 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -78,6 +78,26 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Escalated?** AGENTS.md
 
+### 2026-05-02 — process — propagate skill/agent fixes to all related files in the same operation
+
+**What happened:** A fix to `self-review.md` was applied in isolation; `codebase-review.md` was only updated after the user pointed it out. Similarly, `/task` and `/task-issue` fixes were done together, but the code-review family was handled piecemeal.
+
+**Rule:** When fixing a skill or agent, immediately propagate the change to all files in the same sync group before reporting done. Two sync groups:
+- **Task group:** `skills/task/SKILL.md` ↔ `skills/task-issue/SKILL.md`
+- **Review group:** `skills/code-review/SKILL.md` (workflow orchestrator) ↔ `agents/review-findings.md` (findings producer) ↔ `agents/self-review.md` (fix validator)
+
+Note: `code-review` is a **skill** (user-facing workflow); `review-findings` and `self-review` are **agents** spawned by it. `diff-review` is an agent that exists but is not currently wired into any skill. Do not refer to any of these as "code-review agent" — that conflates the skill with an agent.
+
+**Escalated?** memory
+
+### 2026-05-02 — process — self-review must not re-run cargo fmt or cargo clippy
+
+**What happened:** The self-review agent checked `cargo fmt -- --check` and raised REJECT findings for formatting drift, even though both `cargo fmt` and `cargo clippy -- -D warnings` are already mandated after every subtask during Implementation (Step 8 of /task and /task-issue). This caused a spurious round-trip.
+
+**Rule:** Self-review must not run or re-check `cargo fmt`, `cargo clippy`, `cargo build`/`check`, or `cargo test`. These are all guaranteed by the Implementation and Verify steps before self-review runs. Self-review scope: spec conformance, design conformance, test coverage, safety/correctness, style (Rust file conventions, allow attributes) — not build tooling.
+
+**Escalated?** agent:self-review, agent:review-findings, skill:task, skill:task-issue, skill:code-review
+
 ### 2026-05-02 — process — check current branch before committing, not only before pushing
 
 **What happened:** For the `docs/learnings-and-skill-fix` branch, commits were made directly to local master without checking `git branch --show-current` first. The error was caught at push time (branch protection rejected the push), not at commit time. The rule in AGENTS.md mentions checking before `git push`, but the correct mental model is: verify branch before `git commit`.

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -11,6 +11,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [macros](done/2026-05-01-macros.spec.md) | `quartzite-macros` | ✅ implemented (47 tests) | — |
 | [runtime](done/2026-05-01-runtime.spec.md) | `quartzite-runtime` | ✅ implemented (176 tests) | — |
 | [auto-connection](done/2026-05-01-auto-connection.spec.md) | `quartzite-core` (extension) | ✅ implemented (6 tests) | — |
+| [code-quality-cleanup](done/2026-05-02-code-quality-cleanup.spec.md) | `quartzite-macros` `quartzite-runtime` `quartzite-core` | ✅ implemented (0 new tests) | — |
 
 ## Deferred plans
 

--- a/ai-docs/plans/done/2026-05-02-code-quality-cleanup.design.md
+++ b/ai-docs/plans/done/2026-05-02-code-quality-cleanup.design.md
@@ -1,0 +1,124 @@
+# Design: Code Quality Cleanup (RustRover findings)
+
+**Issue:** user description — RustRover static analysis
+**Date:** 2026-05-02
+
+## Approach
+
+Four independent, low-risk refactors. Each is self-contained and can be done in
+any order; the decomposition sequences them logically (runtime first, then
+macros, then dependency trimmings).
+
+### Task 1 — `detach_from_parent` helper in `object_tree.rs`
+
+Both `reparent` and `remove_node` contain an identical let-chain:
+
+```rust
+if let Some(old_parent) = self.parent_map.remove(&id)
+    && let Some(siblings) = self.children_map.get_mut(&old_parent)
+{
+    siblings.retain(|&c| c != id);
+}
+```
+
+Extract this into a private `fn detach_from_parent(&mut self, id: ObjectId)`
+method and call it from both sites. No behaviour change; the existing tests
+cover both paths.
+
+**Alternatives considered:** none — the duplication is literal and the fix is
+mechanical.
+
+### Task 2 — `make_expand!` macro in `quartzite-macros`
+
+All four `mod.rs` files (`extend`, `meta_enum`, `object`, `object_impl`) are
+byte-for-byte identical:
+
+```rust
+mod codegen;
+mod parse;
+
+pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    match parse::parse(input) {
+        Ok(ir) => codegen::codegen(ir),
+        Err(e) => e.to_compile_error(),
+    }
+}
+```
+
+Define a `macro_rules! make_expand` in `lib.rs` that emits this boilerplate.
+Each `mod.rs` keeps only `mod codegen; mod parse;` plus the macro invocation.
+
+Visibility: the macro only needs crate visibility. Use
+`pub(crate) use make_expand;` (re-export from root after `macro_rules!`
+definition) so the four inner modules can reference it via `crate::make_expand!`.
+
+**Alternatives considered:**
+- A free function taking function pointers — rejected, because it would change
+  the public-facing `expand` function from a `pub(crate) fn` to a wrapper,
+  adding indirection with no benefit.
+- Leaving duplication — rejected, contradicts spec.
+
+### Tasks 3 & 4 — Remove unused dev-dependencies
+
+Confirmed via `rg`: neither `pretty_assertions` nor `rstest` appear in any
+source or integration-test file of `quartzite-macros` or `quartzite-runtime`.
+`pretty_assertions` also has zero uses in `quartzite-core` source. `rstest` is
+used in `quartzite-core/src/value.rs` and must stay.
+
+Removal is a one-line deletion per `Cargo.toml`.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Extract `detach_from_parent` private method | `quartzite-runtime/src/object_tree.rs` | — |
+| 2 | Define `make_expand!` macro and update four `mod.rs` files | `quartzite-macros/src/lib.rs`, `quartzite-macros/src/extend/mod.rs`, `quartzite-macros/src/meta_enum/mod.rs`, `quartzite-macros/src/object/mod.rs`, `quartzite-macros/src/object_impl/mod.rs` | — |
+| 3 | Remove `pretty_assertions` from three `Cargo.toml` files | `quartzite-macros/Cargo.toml`, `quartzite-core/Cargo.toml`, `quartzite-runtime/Cargo.toml` | — |
+| 4 | Remove `rstest` from `quartzite-runtime/Cargo.toml` | `quartzite-runtime/Cargo.toml` | — |
+| 5 | Run `cargo build` + `cargo test` + `cargo clippy -- -D warnings` to verify | — | 1, 2, 3, 4 |
+
+All four change tasks are independent and can be executed in any order.
+
+## Risks
+
+- `make_expand!` macro hygiene: `macro_rules!` macros operate in the caller's
+  module namespace, so `parse::parse` and `codegen::codegen` must be
+  resolvable from the call site. Each `mod.rs` already declares `mod codegen`
+  and `mod parse`, so these identifiers will be in scope. Mitigation: compile
+  after each mod.rs change, not only at the end.
+- Removing `pretty_assertions` from `quartzite-core`: the crate has no
+  source-level uses, but if a future test file adds `use pretty_assertions`
+  the dependency will need to be re-added. Mitigation: spec is clear on scope;
+  proceed.
+- No API surface change (all edits are private/internal): zero backward
+  compatibility risk.
+
+## Test Design
+
+### Task 1 — `detach_from_parent`
+
+- Location: `quartzite-runtime/src/object_tree.rs` `#[cfg(test)]` module
+  (already exists)
+- Entry points: `reparent`, `remove_node` (via `destroy`)
+- Scenarios covered by existing tests:
+  - `reparent_updates_both_parent_and_children` — exercises `reparent` fully
+  - `destroy_removes_all_descendants` — exercises `remove_node` for parent
+    cleanup
+- No new tests needed; refactoring must not break any existing test.
+
+### Task 2 — `make_expand!` macro
+
+- Integration tests in `quartzite-macros/tests/` (`extend.rs`, `meta_enum.rs`,
+  `object.rs`, `object_impl.rs`) exercise the `expand` entry points end-to-end
+  through `proc_macro` invocation.
+- No new tests needed; all four derive/attribute macros must continue to compile
+  and produce correct output for the existing test inputs.
+
+### Tasks 3 & 4 — Dependency removal
+
+- No code logic changed; `cargo build` and `cargo test` passing is sufficient
+  evidence that no test relied on the removed crate.
+
+## Open questions
+
+- None.

--- a/ai-docs/plans/done/2026-05-02-code-quality-cleanup.spec.md
+++ b/ai-docs/plans/done/2026-05-02-code-quality-cleanup.spec.md
@@ -1,0 +1,48 @@
+# Code Quality Cleanup (RustRover findings)
+
+**Source:** user description — RustRover static analysis
+**Date:** 2026-05-02
+
+## Scope
+
+1. `quartzite-runtime/src/object_tree.rs` — extract `detach_from_parent` private helper to eliminate the duplicated 5-line let-chain shared between `reparent` and `remove_node`.
+2. Introduce `make_expand!()` declarative macro in `quartzite-macros/src/lib.rs`; replace the duplicated `expand` function body in each of the 4 `mod.rs` files (`extend`, `meta_enum`, `object_impl`, `object`).
+3. Remove unused `pretty_assertions` dev-dependency from `quartzite-macros`, `quartzite-core`, `quartzite-runtime`.
+4. Remove unused `rstest` dev-dependency from `quartzite-runtime` only.
+
+## Out of scope
+
+- Removing `rstest` from `quartzite-core` — it is genuinely used in `quartzite-core/src/value.rs`.
+- Any other code-quality changes not listed above.
+
+## Deferred
+
+- None.
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| How to deduplicate 4 identical mod.rs files? | Declarative `make_expand!()` macro in lib.rs; each mod.rs keeps `mod codegen; mod parse;` and calls `crate::make_expand!()` |
+| Where to define the macro? | `quartzite-macros/src/lib.rs` using `macro_rules!` + `#[macro_export]`... actually `pub(crate) use make_expand;` since it only needs crate visibility |
+| rstest in quartzite-core? | Keep — 4 `#[rstest]` uses in `value.rs` |
+
+## Technical constraints
+
+- Rust edition 2024; let-chains valid.
+- `cargo clippy -- -D warnings` must stay clean.
+- Macro must be `macro_rules!` (declarative); no proc-macro changes.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `object_tree.rs` contains a private `detach_from_parent` method; `reparent` and `remove_node` each call it instead of repeating the let-chain |
+| AC2 | A `make_expand!` macro is defined in `quartzite-macros`; each of the 4 `mod.rs` files invokes it rather than repeating the `expand` function body |
+| AC3 | `pretty_assertions` does not appear in `quartzite-macros/Cargo.toml`, `quartzite-core/Cargo.toml`, or `quartzite-runtime/Cargo.toml` |
+| AC4 | `rstest` does not appear in `quartzite-runtime/Cargo.toml`; it remains in `quartzite-core/Cargo.toml` |
+| AC5 | `cargo build` succeeds and all existing tests pass after all changes |
+
+## Open questions
+
+- None.

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -11,4 +11,3 @@ std = []
 
 [dev-dependencies]
 rstest = "0.26.1"
-pretty_assertions = "1"

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -309,8 +309,8 @@ mod tests {
     use super::*;
     #[cfg(feature = "std")]
     use std::sync::{
-        atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
         Arc, Mutex, OnceLock,
+        atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
     };
 
     // ---------------------------------------------------------------------------

--- a/quartzite-macros/Cargo.toml
+++ b/quartzite-macros/Cargo.toml
@@ -14,4 +14,3 @@ heck = "0.5"
 
 [dev-dependencies]
 quartzite-core = { path = "../quartzite-core" }
-pretty_assertions = "1"

--- a/quartzite-macros/src/extend/mod.rs
+++ b/quartzite-macros/src/extend/mod.rs
@@ -1,9 +1,4 @@
 mod codegen;
 mod parse;
 
-pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    match parse::parse(input) {
-        Ok(ir) => codegen::codegen(ir),
-        Err(e) => e.to_compile_error(),
-    }
-}
+crate::make_expand!();

--- a/quartzite-macros/src/lib.rs
+++ b/quartzite-macros/src/lib.rs
@@ -9,6 +9,18 @@
 
 use proc_macro::TokenStream;
 
+macro_rules! make_expand {
+    () => {
+        pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+            match parse::parse(input) {
+                Ok(ir) => codegen::codegen(ir),
+                Err(e) => e.to_compile_error(),
+            }
+        }
+    };
+}
+pub(crate) use make_expand;
+
 mod util;
 
 mod extend;

--- a/quartzite-macros/src/meta_enum/mod.rs
+++ b/quartzite-macros/src/meta_enum/mod.rs
@@ -1,9 +1,4 @@
 mod codegen;
 mod parse;
 
-pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    match parse::parse(input) {
-        Ok(ir) => codegen::codegen(ir),
-        Err(e) => e.to_compile_error(),
-    }
-}
+crate::make_expand!();

--- a/quartzite-macros/src/object/mod.rs
+++ b/quartzite-macros/src/object/mod.rs
@@ -1,9 +1,4 @@
 mod codegen;
 mod parse;
 
-pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    match parse::parse(input) {
-        Ok(ir) => codegen::codegen(ir),
-        Err(e) => e.to_compile_error(),
-    }
-}
+crate::make_expand!();

--- a/quartzite-macros/src/object_impl/mod.rs
+++ b/quartzite-macros/src/object_impl/mod.rs
@@ -1,9 +1,4 @@
 mod codegen;
 mod parse;
 
-pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    match parse::parse(input) {
-        Ok(ir) => codegen::codegen(ir),
-        Err(e) => e.to_compile_error(),
-    }
-}
+crate::make_expand!();

--- a/quartzite-runtime/Cargo.toml
+++ b/quartzite-runtime/Cargo.toml
@@ -8,5 +8,3 @@ quartzite-core = { path = "../quartzite-core" }
 slotmap = "1"
 
 [dev-dependencies]
-rstest = "0.26.1"
-pretty_assertions = "1"

--- a/quartzite-runtime/src/object_tree.rs
+++ b/quartzite-runtime/src/object_tree.rs
@@ -91,14 +91,18 @@ impl ObjectTree {
 
     /// Move `id` to a new parent. If `new_parent` is `None`, `id` becomes a root.
     pub fn reparent(&mut self, id: ObjectId, new_parent: Option<ObjectId>) {
+        self.detach_from_parent(id);
+        if let Some(pid) = new_parent {
+            self.parent_map.insert(id, pid);
+            self.children_map.entry(pid).or_default().push(id);
+        }
+    }
+
+    fn detach_from_parent(&mut self, id: ObjectId) {
         if let Some(old_parent) = self.parent_map.remove(&id)
             && let Some(siblings) = self.children_map.get_mut(&old_parent)
         {
             siblings.retain(|&c| c != id);
-        }
-        if let Some(pid) = new_parent {
-            self.parent_map.insert(id, pid);
-            self.children_map.entry(pid).or_default().push(id);
         }
     }
 
@@ -139,11 +143,7 @@ impl ObjectTree {
             self.store.remove(slot.0);
             self.reverse.remove(&slot);
         }
-        if let Some(parent_id) = self.parent_map.remove(&id)
-            && let Some(siblings) = self.children_map.get_mut(&parent_id)
-        {
-            siblings.retain(|&c| c != id);
-        }
+        self.detach_from_parent(id);
         self.children_map.remove(&id);
     }
 }


### PR DESCRIPTION
## Summary

- **`object_tree.rs`**: extract private `detach_from_parent` helper — eliminates the duplicated 5-line let-chain that appeared identically in both `reparent` and `remove_node`
- **`quartzite-macros`**: introduce `make_expand!()` declarative macro in `lib.rs`; all 4 module `mod.rs` files now call `crate::make_expand!()` instead of repeating the expand function body
- **Cargo.toml**: remove unused `pretty_assertions` from quartzite-macros, quartzite-core, quartzite-runtime; remove unused `rstest` from quartzite-runtime (`rstest` retained in quartzite-core where it is actively used in `value.rs`)

## Test plan

- [ ] AC1: `detach_from_parent` exists; `reparent` and `remove_node` call it — verified by `reparent_updates_both_parent_and_children` and `destroy_removes_all_descendants`
- [ ] AC2: `make_expand!` macro defined; 4 mod.rs files use it — `cargo build -p quartzite-macros` clean
- [ ] AC3: `pretty_assertions` absent from all 3 Cargo.toml files
- [ ] AC4: `rstest` absent from quartzite-runtime/Cargo.toml; present in quartzite-core/Cargo.toml
- [ ] AC5: `cargo test` — 268 tests, 0 failures
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt -- --check` — clean