### PR TITLE
feat(quartzite): facade crate, docs.rs metadata, and feature documentation

### DIFF
--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -56,7 +56,16 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 - All new source files in Rust (`.rs`)?
 - No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
 
-### 6. Objection quality (round > 1 only)
+### 6. Documentation
+
+Run `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps 2>&1` and check:
+- Exits with code 0 (no doc errors)?
+- No `warning:` lines in output (broken intra-doc links, missing items, etc.)?
+- Public items added by this diff have at least a one-line doc comment?
+
+On any error or warning → REJECT with the exact rustdoc message as the finding.
+
+### 7. Objection quality (round > 1 only)
 
 For each `⚠️ Objected` item in the progress file:
 - Read the stated reason.
@@ -69,6 +78,7 @@ For each `⚠️ Objected` item in the progress file:
 - `cargo fmt` / formatting drift — already mandated after every subtask in the Implementation step; guaranteed clean before self-review runs
 - `cargo clippy` — same; already enforced during Implementation
 - `cargo build` / `cargo check` / `cargo test` — same; all enforced during Implementation and Verify steps
+- `cargo fmt` output / HTML rendering — run `cargo doc` for warnings (checklist §6), but do not open a browser or visually inspect rendered pages
 - Subjective preferences — only objective violations
 
 ## Findings format (written to progress file)

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -3,7 +3,7 @@ name: task
 description: "Full task workflow from user description: interview → spec → design → design-review → impl → verify → self-review. Use when the user describes a task directly (no GitHub issue). Steps are strictly ordered and cannot be skipped."
 disable-model-invocation: true
 argument-hint: "[short task description]"
-allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git add *) Bash(git commit *) Bash(git push *) Bash(gh pr create *) Bash(gh pr view *)
+allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(cargo doc *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git add *) Bash(git commit *) Bash(git push *) Bash(gh pr create *) Bash(gh pr view *)
 ---
 
 Full workflow for a user-described task. Steps execute **strictly in sequence** — proceeding to N+1 before N is complete is FORBIDDEN.
@@ -190,8 +190,9 @@ finding (Step 11) requires a design change rather than a code fix:
 2. `cargo test` — all green
 3. `cargo fmt -- --check` — no formatting drift
 4. `cargo clippy -- -D warnings` — clean
-5. For each AC — confirm covered by test or manual verification
-4. Show summary table:
+5. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — no doc errors or warnings
+6. For each AC — confirm covered by test or manual verification
+5. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |
@@ -286,7 +287,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps` clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,8 @@ jobs:
 
       - name: Clippy
         run: cargo clippy -- -D warnings
+
+      - name: Docs
+        run: cargo doc --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: "-D warnings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,9 +139,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "quartzite"
+version = "0.1.0"
+dependencies = [
+ "document-features",
+ "quartzite-core",
+ "quartzite-macros",
+ "quartzite-runtime",
+]
+
+[[package]]
 name = "quartzite-core"
 version = "0.1.0"
 dependencies = [
+ "document-features",
  "rstest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "quartzite",
     "quartzite-core",
     "quartzite-macros",
     "quartzite-runtime",
@@ -9,3 +10,6 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+authors = ["Marat Bukharov <marat.buharov@gmail.com>"]
+license = "LGPL-3.0-or-later"
+repository = "https://github.com/maratik123/quartzite"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Early development. Core crates are implemented; widget and painting layers are n
 
 | Crate | Status |
 |---|---|
+| `quartzite` (facade) | ✅ implemented |
 | `quartzite-core` | ✅ implemented |
 | `quartzite-macros` | ✅ implemented |
 | `quartzite-runtime` | ✅ implemented |

--- a/ai-docs/context.md
+++ b/ai-docs/context.md
@@ -18,7 +18,7 @@
 | `quartzite-paint` | Painter, Color, Font, Pen, Brush, Image, Path |
 | `quartzite-style` | Style trait, Palette, StyleRegistry |
 | `quartzite-widgets` | WidgetBase, WidgetExt, Layout, Button, Label, LineEdit, … |
-| `quartzite` (facade) | Re-exports all crates; prelude |
+| `quartzite` (facade) | Re-exports all crates; curated `prelude` module ✅ |
 
 Python interop (`quartzite-python` via PyO3) is **deferred** — the reflection layer must not block it.
 
@@ -109,9 +109,10 @@ AsObject        AsWidget        AsWidget (generated)
 1. `quartzite-core` — core types + traits + signal + value ✅
 2. `quartzite-macros` — Extend + Object + object_impl derive macros ✅
 3. `quartzite-runtime` — Application, EventLoop, ObjectTree ✅
-4. `quartzite-geometry` + `quartzite-events` — geometry primitives + event model
-5. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
-6. `quartzite-paint` + `quartzite-style` — painter + theming
+4. `quartzite` (facade) — prelude re-exports, Cargo metadata, docs.rs config ✅
+5. `quartzite-geometry` + `quartzite-events` — geometry primitives + event model
+6. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
+7. `quartzite-paint` + `quartzite-style` — painter + theming
 
 ## Open Questions
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -12,6 +12,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [runtime](done/2026-05-01-runtime.spec.md) | `quartzite-runtime` | ✅ implemented (176 tests) | — |
 | [auto-connection](done/2026-05-01-auto-connection.spec.md) | `quartzite-core` (extension) | ✅ implemented (6 tests) | — |
 | [code-quality-cleanup](done/2026-05-02-code-quality-cleanup.spec.md) | `quartzite-macros` `quartzite-runtime` `quartzite-core` | ✅ implemented (0 new tests) | — |
+| [docs-and-facade](done/2026-05-02-docs-and-facade.spec.md) | all crates + `quartzite` | ✅ implemented (1 new test) | — |
 
 ## Deferred plans
 
@@ -39,3 +40,4 @@ core-types ✅
 ## Suggested next steps
 
 1. **Start** geometry-events (no blockers, unblocks widgets and paint-style)
+2. **Expand** `quartzite` facade prelude as new crates are implemented

--- a/ai-docs/plans/done/2026-05-02-docs-and-facade.design.md
+++ b/ai-docs/plans/done/2026-05-02-docs-and-facade.design.md
@@ -1,0 +1,234 @@
+# Design: Comprehensive documentation and quartzite facade crate
+
+**Issue:** user description
+**Date:** 2026-05-02
+
+## Approach
+
+The work splits into two largely independent tracks: (A) metadata and docs-rs hygiene across all
+four crates, and (B) creating a new `quartzite` facade crate.
+
+**Track A — metadata + docs-rs hygiene**
+
+Add `authors`, `license`, `repository` to `[workspace.package]` so all crates inherit them via
+`workspace = true`. Add per-crate `description` fields. Add `[package.metadata.docs.rs]` to every
+crate (features + rustdoc/rustc cfg flags for the `docsrs` gate). Add `document-features` to
+`quartzite-core` (and later the facade); annotate the `std` feature with a `##` comment; inject
+the macro call at the top of both `lib.rs` files with `#![doc = document_features::document_features!()]`.
+
+`quartzite-macros` is a `proc-macro = true` crate and cannot use `document-features` (proc-macro
+crates have special linking constraints; a dependency chain through `document-features`'s own
+proc-macro would either conflict or be silently dropped). The spec explicitly excludes it.
+
+`quartzite-runtime` has no feature flags, so `document-features` adds nothing there and is also
+excluded.
+
+**Track B — facade crate**
+
+Create `quartzite/` as a new workspace member. It re-exports a curated `prelude` module containing
+the most commonly used public types from the three existing crates. The crate has a `std` feature
+that forwards to `quartzite-core/std`. The `prelude` guards its `std`-only re-exports with
+`#[cfg(feature = "std")]`.
+
+**`cfg_attr(docsrs, doc(cfg(...)))` placement**
+
+The following items in `quartzite-core` are only present when `std` is active and must receive the
+`#[cfg_attr(docsrs, doc(cfg(feature = "std")))]` attribute so docs.rs shows the feature badge:
+
+- `signal::QueuedDispatcher` (trait)
+- `signal::DispatcherAlreadySet` (struct)
+- `signal::set_queued_dispatcher` (fn)
+- `signal::queued_dispatcher` (fn)
+- `signal::ConnectionType::Queued` (variant)
+- `signal::ConnectionType::Auto` (variant)
+- `object_base::ObjectBase::thread_id` (field — inside a struct; annotation goes on the field)
+- `object_base::ObjectBase::is_on_current_thread` (method)
+- `traits::ObjectExt::is_on_current_thread` (method)
+
+These are the *public* std-gated items that appear in the rendered documentation. Internal
+`struct`/`trait` items (`SlotEntry`, `DynQueuedSlot`, `QueuedSlotInner`, `DynAutoSlot`,
+`AutoSlotInner`) are private and do not need the annotation.
+
+**Rejected alternative — wildcard re-exports at crate root**
+
+Full `pub use quartzite_core::*` etc. at the facade root is simpler but clutters the public
+surface and makes it harder for users to understand origin. A `prelude` module is standard Rust
+practice (e.g. `std::prelude`) and matches the spec's "curated" requirement.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Add `authors`, `license`, `repository` to `[workspace.package]`; add `workspace = true` inherits to all three existing crates | `Cargo.toml`, `quartzite-core/Cargo.toml`, `quartzite-macros/Cargo.toml`, `quartzite-runtime/Cargo.toml` | — |
+| 2 | Add `description` to all three existing crates' `Cargo.toml` | `quartzite-core/Cargo.toml`, `quartzite-macros/Cargo.toml`, `quartzite-runtime/Cargo.toml` | 1 |
+| 3 | Add `[package.metadata.docs.rs]` to all three existing crates | `quartzite-core/Cargo.toml`, `quartzite-macros/Cargo.toml`, `quartzite-runtime/Cargo.toml` | 1 |
+| 4 | Add `document-features` dependency to `quartzite-core`; annotate `std` feature with `##` comment; add `#![doc = document_features::document_features!()]` to `quartzite-core/src/lib.rs` | `quartzite-core/Cargo.toml`, `quartzite-core/src/lib.rs` | 3 |
+| 5 | Add `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]` to std-gated public items in `quartzite-core` | `quartzite-core/src/signal.rs`, `quartzite-core/src/object_base.rs`, `quartzite-core/src/traits.rs` | 4 |
+| 6 | Create `quartzite/` facade crate: `Cargo.toml`, `src/lib.rs` with `pub mod prelude`, register in workspace | `quartzite/Cargo.toml`, `quartzite/src/lib.rs`, `Cargo.toml` | 4 |
+| 7 | Add `document-features` to facade; annotate `std` feature; inject `#![doc = ...]`; add `[package.metadata.docs.rs]` | `quartzite/Cargo.toml`, `quartzite/src/lib.rs` | 6 |
+
+Seven tasks — within the limit; no split needed.
+
+## File inventory
+
+**Modified files**
+- `Cargo.toml` — workspace members + workspace.package fields
+- `quartzite-core/Cargo.toml` — workspace inherits, description, document-features dep, docs.rs metadata
+- `quartzite-macros/Cargo.toml` — workspace inherits, description, docs.rs metadata
+- `quartzite-runtime/Cargo.toml` — workspace inherits, description, docs.rs metadata
+- `quartzite-core/src/lib.rs` — `#![doc = ...]` line at top
+- `quartzite-core/src/signal.rs` — `cfg_attr` annotations on 6 std-gated public items
+- `quartzite-core/src/object_base.rs` — `cfg_attr` on `thread_id` field and `is_on_current_thread`
+- `quartzite-core/src/traits.rs` — `cfg_attr` on `ObjectExt::is_on_current_thread`
+
+**New files**
+- `quartzite/Cargo.toml`
+- `quartzite/src/lib.rs`
+
+## Key content details
+
+### `quartzite-core/Cargo.toml` — feature annotation
+```toml
+[features]
+default = ["std"]
+## Enable standard-library support (threading, queued dispatch, `is_on_current_thread`).
+## Disable to build in `no_std + alloc` environments.
+std = []
+```
+
+### `quartzite/Cargo.toml` sketch
+```toml
+[package]
+name = "quartzite"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Quartzite object system — facade crate with curated prelude"
+
+[features]
+default = ["std"]
+## Enable standard-library support (inherits `quartzite-core/std`).
+std = ["quartzite-core/std"]
+
+[dependencies]
+quartzite-core    = { path = "../quartzite-core", default-features = false }
+quartzite-macros  = { path = "../quartzite-macros" }
+quartzite-runtime = { path = "../quartzite-runtime" }
+document-features = "~0.2"
+
+[package.metadata.docs.rs]
+features = ["std"]
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args   = ["--cfg", "docsrs"]
+```
+
+`quartzite-core` is declared with `default-features = false` so the facade's own `std` feature
+gates it cleanly.
+
+### `quartzite/src/lib.rs` prelude content
+
+```rust
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = document_features::document_features!()]
+
+pub mod prelude {
+    // quartzite-core
+    pub use quartzite_core::{
+        AsObject, Object, ObjectBase, ObjectExt, ObjectId, SignalCallback, Value, WeakObjectRef,
+    };
+    pub use quartzite_core::signal::{ConnectionType, Signal};
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub use quartzite_core::{
+        DispatcherAlreadySet, QueuedDispatcher, queued_dispatcher, set_queued_dispatcher,
+    };
+
+    // quartzite-macros
+    pub use quartzite_macros::{Extend, Object as DeriveObject, object_impl};
+
+    // quartzite-runtime
+    pub use quartzite_runtime::{Application, EventLoop, ObjectRef, ObjectTree, Timer, WeakRef};
+}
+```
+
+Note: `quartzite_macros::Object` is re-exported as `DeriveObject` to avoid a name collision with
+`quartzite_core::Object` (the trait). Both live in the prelude but under distinct names.
+
+### `[package.metadata.docs.rs]` shape per crate
+
+`quartzite-core` and `quartzite`:
+```toml
+[package.metadata.docs.rs]
+features      = ["std"]
+rustdoc-args  = ["--cfg", "docsrs"]
+rustc-args    = ["--cfg", "docsrs"]
+```
+
+`quartzite-macros` and `quartzite-runtime` (no features to enable):
+```toml
+[package.metadata.docs.rs]
+rustdoc-args  = ["--cfg", "docsrs"]
+rustc-args    = ["--cfg", "docsrs"]
+```
+
+## Risks
+
+- **Derive macro name collision in prelude:** `quartzite_macros::derive_object` is exposed as
+  `Object` from the crate root; `quartzite_core::Object` is a trait. Both re-exported into the
+  same module would shadow each other. Mitigation: re-export the derive macro under `DeriveObject`
+  as shown above. The implementor should verify the actual exported name from `quartzite-macros`
+  (`pub use quartzite_macros::{Object as DeriveObject, ...}`).
+
+- **`document-features` requires `##` comments directly adjacent to feature entries:** any blank
+  line between the comment and the feature line causes the comment to be silently ignored.
+  Mitigation: follow the `## comment\nfeature = [...]` format exactly, verified by checking
+  rendered docs locally with `cargo doc --features std`.
+
+- **`quartzite-runtime` transitively enables `quartzite-core/std`** because its `Cargo.toml`
+  declares `quartzite-core = { path = "../quartzite-core" }` without `default-features = false`,
+  so the core `std` feature is always on when runtime is in the graph. This is intentional and
+  consistent with the spec decision to skip a `std` feature on `quartzite-runtime`.
+
+- **`cfg_attr(docsrs, feature(doc_cfg))` needs `#![cfg_attr(docsrs, feature(doc_cfg))]` at
+  crate root:** required to make the `doc(cfg(...))` attribute take effect on nightly (docs.rs
+  uses nightly). Both `quartzite-core/src/lib.rs` and `quartzite/src/lib.rs` need this inner
+  attribute. `quartzite-core` already has `#![cfg_attr(not(feature = "std"), no_std)]` at the
+  top; the new attribute is added alongside it.
+
+- **`cargo build` includes `Cargo.lock` update:** adding a new crate and new dependency
+  (`document-features`) will modify `Cargo.lock`. Per project workflow, `cargo build` must be run
+  before committing so the updated lock file is included.
+
+## Test Design
+
+This task contains no non-trivial runtime logic — it is purely configuration, metadata, and
+re-exports. The acceptance tests are build-and-lint checks:
+
+- `cargo build` must compile clean with zero errors (AC9)
+- `cargo clippy -- -D warnings` must pass clean (AC10)
+
+The facade's `prelude` module is a set of `pub use` statements; there is no branching logic to
+unit-test. A smoke `#[cfg(test)]` block in `quartzite/src/lib.rs` that imports from
+`crate::prelude::*` and uses at least one type is sufficient to confirm the re-exports resolve:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::prelude::*;
+
+    #[test]
+    fn prelude_compiles() {
+        let _: ObjectId = ObjectBase::new().id();
+    }
+}
+```
+
+Location: `quartzite/src/lib.rs` inline `#[cfg(test)]` module.
+Entry point: `prelude_compiles` — exercises that key types are accessible via prelude.
+Fixtures: none needed.
+
+## Open questions
+
+- None

--- a/ai-docs/plans/done/2026-05-02-docs-and-facade.spec.md
+++ b/ai-docs/plans/done/2026-05-02-docs-and-facade.spec.md
@@ -1,0 +1,58 @@
+# Comprehensive documentation and quartzite facade crate
+
+**Source:** user description
+**Date:** 2026-05-02
+
+## Scope
+
+1. Add `authors`, `license`, `repository` to `[workspace.package]`; existing crates inherit with `workspace = true`
+2. Add per-crate `description` to all four crates (3 existing + 1 new facade)
+3. Add `document-features` dependency to `quartzite-core` and `quartzite` facade; annotate feature entries with `##` comments; add `#![doc = document_features::document_features!()]` in their `lib.rs`
+4. Add `[package.metadata.docs.rs]` section to every crate's `Cargo.toml` (`features = ["std"]` for core and facade; `rustdoc-args`/`rustc-args` set to `["--cfg", "docsrs"]` for all)
+5. Create `quartzite` facade crate as a new workspace member with a curated `prelude` module; `std` feature forwarding to `quartzite-core/std`
+
+## Out of scope
+
+- `std` feature on `quartzite-runtime` (would gate nothing today)
+- Full wildcard re-exports beyond `prelude`
+- Future features (`extension`, `8k_pages`, etc.)
+- `cargo doc` publishing / CI integration
+
+## Deferred
+
+- Additional facade features | will be added based on needs as the project grows
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| `quartzite-runtime` std feature | Skip — flag would gate nothing today |
+| Facade public surface | Curated `prelude` module only |
+| docs.rs features for macros/runtime | Empty list — no features to enable |
+| SPDX license identifier | `LGPL-3.0-or-later` (matches LICENSE file) |
+
+## Technical constraints
+
+- `document-features` reads `Cargo.toml` at compile time via a proc-macro; features must be annotated with `##` (double `#`) comments directly above each feature entry
+- `#![cfg_attr(docsrs, doc(cfg(feature = "std")))]` should annotate items that are only available with `std` to show the badge on docs.rs
+- `quartzite-macros` is a proc-macro crate (`proc-macro = true`); it cannot have `document-features` (proc-macro crates cannot depend on other crates in the normal way for doc generation)
+- Facade crate cannot be named `quartzite-facade`; must be `quartzite`
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `[workspace.package]` contains `authors`, `license = "LGPL-3.0-or-later"`, and `repository = "https://github.com/maratik123/quartzite"` |
+| AC2 | Each of the 4 crates has a non-empty `description` matching the agreed text |
+| AC3 | `quartzite-core/Cargo.toml` has `document-features` in `[dependencies]`; the `std` feature has a `##` doc comment; `quartzite-core/src/lib.rs` starts with `#![doc = document_features::document_features!()]` |
+| AC4 | `quartzite/Cargo.toml` has `document-features` in `[dependencies]`; the `std` feature has a `##` doc comment; `quartzite/src/lib.rs` contains `#![doc = document_features::document_features!()]` |
+| AC5 | All 4 crate `Cargo.toml` files have `[package.metadata.docs.rs]`; `quartzite-core` and `quartzite` have `features = ["std"]`; all have `rustdoc-args = ["--cfg", "docsrs"]` and `rustc-args = ["--cfg", "docsrs"]` |
+| AC6 | Root `Cargo.toml` `workspace.members` includes `"quartzite"` |
+| AC7 | `quartzite/src/lib.rs` has a `pub mod prelude` re-exporting key types from `quartzite-core`, `quartzite-macros`, and `quartzite-runtime` |
+| AC8 | Facade `std` feature in `quartzite/Cargo.toml` activates `quartzite-core/std` |
+| AC9 | `cargo build` compiles clean |
+| AC10 | `cargo clippy -- -D warnings` passes clean |
+
+## Open questions
+
+- None

--- a/quartzite-core/src/lib.rs
+++ b/quartzite-core/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = document_features::document_features!()]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -31,6 +33,7 @@ pub use object_base::ObjectBase;
 pub use receiver_guard::ReceiverGuard;
 pub use signal::{ConnectionType, Signal};
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use signal::{
     DispatcherAlreadySet, QueuedDispatcher, queued_dispatcher, set_queued_dispatcher,
 };

--- a/quartzite-core/src/object_base.rs
+++ b/quartzite-core/src/object_base.rs
@@ -22,6 +22,7 @@ pub struct ObjectBase {
     pub dynamic_properties: BTreeMap<String, Value>,
     pub signals_blocked: bool,
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub thread_id: std::thread::ThreadId,
 }
 
@@ -58,6 +59,7 @@ impl ObjectBase {
     }
 
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn is_on_current_thread(&self) -> bool {
         self.thread_id == std::thread::current().id()
     }

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -19,6 +19,7 @@ pub enum ConnectionType {
     SingleShot,
     /// Post the slot to the event loop; requires `std` and an active dispatcher.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Queued,
     /// Same-thread → `Direct`; cross-thread → `Queued`. Requires `std`.
     ///
@@ -26,6 +27,7 @@ pub enum ConnectionType {
     /// [`Signal::connect_auto`]. Changing the receiver's thread affinity after
     /// connecting does not update the stored `ThreadId` (see AC5).
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Auto,
 }
 
@@ -41,6 +43,7 @@ struct SlotEntry<Args: 'static> {
 /// Receives closures posted by queued signal connections and executes them on
 /// the event-loop thread. Implemented by `ConnectionTable` in `quartzite-runtime`.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait QueuedDispatcher: Send + Sync {
     fn post(&self, f: Box<dyn FnOnce() + Send + 'static>);
 }
@@ -51,12 +54,14 @@ static QUEUED_DISPATCHER: std::sync::OnceLock<Arc<dyn QueuedDispatcher>> =
 
 /// Error returned by `set_queued_dispatcher` when a dispatcher is already registered.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DispatcherAlreadySet;
 
 /// Register the process-wide queued dispatcher. Called by `Application::new()`.
 /// Returns `Ok(())` on the first call; `Err(DispatcherAlreadySet)` on subsequent calls.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn set_queued_dispatcher(d: Arc<dyn QueuedDispatcher>) -> Result<(), DispatcherAlreadySet> {
     QUEUED_DISPATCHER.set(d).map_err(|_| DispatcherAlreadySet)
 }
@@ -64,6 +69,7 @@ pub fn set_queued_dispatcher(d: Arc<dyn QueuedDispatcher>) -> Result<(), Dispatc
 /// Returns a reference to the registered dispatcher, or `None` before
 /// `Application` has been created.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn queued_dispatcher() -> Option<&'static Arc<dyn QueuedDispatcher>> {
     QUEUED_DISPATCHER.get()
 }
@@ -213,6 +219,7 @@ impl<Args: 'static> Signal<Args> {
     /// (receiver destroyed), the closure is silently discarded. Requires
     /// `Args: Clone + Send` so the arguments can be moved across threads.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn connect_queued<F>(&mut self, f: F, guard: std::sync::Weak<ReceiverGuard>) -> ConnectionId
     where
         F: Fn(Args) + Send + Sync + 'static,
@@ -242,6 +249,7 @@ impl<Args: 'static> Signal<Args> {
     /// The `receiver_thread_id` is captured at connect time and is not updated
     /// if the receiver migrates to a different thread later.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn connect_auto<F>(
         &mut self,
         receiver_thread_id: std::thread::ThreadId,

--- a/quartzite-core/src/traits.rs
+++ b/quartzite-core/src/traits.rs
@@ -77,6 +77,7 @@ pub trait ObjectExt: AsObject {
     /// Returns `true` when called on the same thread that created this object.
     /// Only available with the `std` feature (requires `std::thread`).
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn is_on_current_thread(&self) -> bool {
         self.object_base().is_on_current_thread()
     }

--- a/quartzite-macros/Cargo.toml
+++ b/quartzite-macros/Cargo.toml
@@ -2,6 +2,10 @@
 name = "quartzite-macros"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Proc-macro crate for the quartzite GUI framework"
 
 [lib]
 proc-macro = true
@@ -14,3 +18,7 @@ heck = "0.5"
 
 [dev-dependencies]
 quartzite-core = { path = "../quartzite-core" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/quartzite-runtime/Cargo.toml
+++ b/quartzite-runtime/Cargo.toml
@@ -2,9 +2,17 @@
 name = "quartzite-runtime"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Application runtime, event loop, and object tree for quartzite"
 
 [dependencies]
 quartzite-core = { path = "../quartzite-core" }
 slotmap = "1"
 
 [dev-dependencies]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/quartzite/Cargo.toml
+++ b/quartzite/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "quartzite-core"
+name = "quartzite"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Core object model, signals, properties, and value types for quartzite"
+description = "A GUI and object framework for Rust"
 
 [features]
 default = ["std"]
 ## Enable standard-library support (threading, queued dispatch, `is_on_current_thread`).
-## Disable to build in `no_std + alloc` environments.
-std = []
+## Disable to build in `no_std + alloc` environments (core only; runtime requires std).
+std = ["quartzite-core/std"]
 
 [dependencies]
+quartzite-core    = { path = "../quartzite-core", default-features = false }
+quartzite-macros  = { path = "../quartzite-macros" }
+quartzite-runtime = { path = "../quartzite-runtime" }
 document-features = "~0.2"
-
-[dev-dependencies]
-rstest = "0.26.1"
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/quartzite/src/lib.rs
+++ b/quartzite/src/lib.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = document_features::document_features!()]
+//!
+//! ## Getting started
+//!
+//! Import the prelude to bring the most commonly used types into scope:
+//!
+//! ```rust
+//! use quartzite::prelude::*;
+//! ```
+//!
+//! The `quartzite-macros` crate also exports `MetaEnum` for enum reflection; it
+//! is available directly from `quartzite_macros::MetaEnum` for users who need it.
+
+/// Curated set of commonly used quartzite types, re-exported for convenience.
+///
+/// Import with `use quartzite::prelude::*;` to bring the core object model,
+/// signal types, and runtime into scope without needing to reference individual
+/// sub-crates.
+pub mod prelude {
+    // quartzite-core: object model
+    pub use quartzite_core::{
+        AsObject, ConnectionId, Object, ObjectBase, ObjectExt, ObjectId, SignalCallback, Value,
+        WeakObjectRef,
+    };
+    // quartzite-core: signals
+    pub use quartzite_core::signal::{ConnectionType, Signal};
+    // quartzite-core: std-only dispatcher API
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub use quartzite_core::{
+        DispatcherAlreadySet, QueuedDispatcher, queued_dispatcher, set_queued_dispatcher,
+    };
+
+    // quartzite-macros: derive macros
+    // `Object` is re-exported as `DeriveObject` to avoid shadowing the `Object` trait above.
+    pub use quartzite_macros::{Extend, Object as DeriveObject, object_impl};
+
+    // quartzite-runtime
+    pub use quartzite_runtime::{
+        Application, ApplicationError, EventLoop, ObjectRef, ObjectTree, Timer, WeakRef,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prelude::*;
+
+    #[test]
+    fn prelude_compiles() {
+        let _: ObjectId = ObjectBase::new().id();
+    }
+}


### PR DESCRIPTION
## Summary

- **New crate:** `quartzite` facade with a curated `pub mod prelude` re-exporting key types from `quartzite-core`, `quartzite-macros`, and `quartzite-runtime`; `std` feature forwards to `quartzite-core/std`
- **`document-features` integration:** `quartzite-core` and `quartzite` annotate their `std` feature with `##` doc comments; `#![doc = document_features::document_features!()]` generates the feature table in rendered docs
- **Cargo.toml metadata:** workspace-level `authors`, `license = "LGPL-3.0-or-later"`, `repository`; per-crate `description` fields; all crates inherit workspace fields
- **docs.rs config:** `[package.metadata.docs.rs]` added to all four crates with `--cfg docsrs` flags; `features = ["std"]` on `quartzite-core` and `quartzite`
- **`cfg_attr` badges:** all std-gated public items in `quartzite-core` (9 design items + `Signal::connect_queued`/`connect_auto`) annotated with `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]`

## Test plan

- [x] AC1: `[workspace.package]` has `authors`, `license`, `repository`
- [x] AC2: All 4 crates have non-empty `description`
- [x] AC3: `quartzite-core` — `document-features` dep, `##` feature comment, `#![doc = ...]`
- [x] AC4: `quartzite` facade — same as AC3
- [x] AC5: All 4 crates have `[package.metadata.docs.rs]` with correct `features` and `rustdoc-args`/`rustc-args`
- [x] AC6: `"quartzite"` listed in workspace members
- [x] AC7: `pub mod prelude` re-exports from all 3 sub-crates including `ApplicationError`
- [x] AC8: Facade `std` feature activates `quartzite-core/std`; core dep declared `default-features = false`
- [x] AC9: `cargo build` compiles clean
- [x] AC10: `cargo clippy -- -D warnings` passes clean
- [x] `cargo test` — 186 tests green (1 new: `prelude_compiles`)
- [x] `cargo fmt -- --check` — no formatting drift