### PR TITLE
feat(all): add #[inline] to all simple non-generic functions

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -50,6 +50,7 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 - `#[allow(clippy::...)]` / `#[allow(dead_code)]` without a justification comment?
 - Public items undocumented (`///` missing on `pub` functions/types)?
 - Dead code that clippy does not catch?
+- Simple non-generic functions missing `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen files: simple generated `fn`s must emit `#[inline]`.
 
 ## What you do NOT check
 

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -55,6 +55,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 ### 5. Style (AGENTS.md rules)
 - All new source files in Rust (`.rs`)?
 - No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
+- Every simple, non-generic function added by this diff has `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen: new simple generated `fn`s must emit `#[inline]`.
 
 ### 6. Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - Prefer Rust idioms over literal C++ ports. When in doubt, ask.
 - Let chains (`if let A = x && let B = y { ... }`) are valid in this codebase (edition 2024). Do not avoid them. Always format via `cargo fmt`, never `rustfmt <file>` directly.
 - **Documentation:** Every crate must have `#![deny(missing_docs)]` in its `lib.rs`. Every public item must have at least a one-line `///` doc comment. Every new public item with only a single-line doc must include a `# Examples` block. Proc-macro examples use `no_run`; runtime items needing an event loop use `no_run`; pure library types use compiling doctests.
+- **`#[inline]`:** Add `#[inline]` to every simple, non-generic function: no branches or loops, at most one function call, no binary bloat. Typical targets: field getters (`self.field`), trivial wrappers (`.as_deref()`, single delegation call), `Default::default()` that calls `Self::new()`, `const fn` struct-literal constructors. **Exclude** generic functions and blanket-impl trait methods — the compiler already has their bodies via monomorphization. Apply the same rule in proc-macro codegen: emit `#[inline]` before each simple generated `fn`.
 
 ## Workflow
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -15,6 +15,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [docs-and-facade](done/2026-05-02-docs-and-facade.spec.md) | all crates + `quartzite` | ✅ implemented (1 new test) | — |
 | [public-api-docs](done/2026-05-02-public-api-docs.spec.md) | all crates | ✅ implemented (47 new doctests) | — |
 | [lookup-perf](done/2026-05-02-lookup-perf.spec.md) | `quartzite-core` `quartzite-macros` `quartzite-runtime` | ✅ implemented (21 new tests) | — |
+| [inline-simple-fns](done/2026-05-02-inline-simple-fns.spec.md) | all crates | ✅ implemented (8 new tests) | — |
 
 ## Deferred plans
 
@@ -45,3 +46,4 @@ core-types ✅
 2. **Expand** `quartzite` facade prelude as new crates are implemented
 3. Any future PR adding public items must satisfy `#![deny(missing_docs)]` + `# Examples` (enforced by CI and self-review checklist)
 4. Match-based lookups are in place for properties/signals/methods/enums; enum lookup (`#[object_impl]` generates noop) could be wired up to `#[meta_enum]`-annotated enums when widgets land
+5. `#[inline]` rule is enforced by AGENTS.md and review agents; new simple non-generic functions must carry the attribute

--- a/ai-docs/plans/done/2026-05-02-inline-simple-fns.design.md
+++ b/ai-docs/plans/done/2026-05-02-inline-simple-fns.design.md
@@ -1,0 +1,584 @@
+# Design: inline-simple-fns
+
+**Issue:** user description
+**Date:** 2026-05-02
+
+## Approach
+
+Add `#[inline]` to every target function listed in the spec. No logic changes —
+pure annotation only. Each `#[inline]` goes on its own line immediately before
+the `pub`/`fn` keyword (after any existing outer attributes such as `#[cfg_attr]`
+or `#[allow(...)]`, but before `pub`).
+
+`const fn` functions (`PropertyFlags::none/read_write/read_only`,
+`PropertyMeta::new`, `ParamMeta::new`, `SignalMeta::new`, `MethodMeta::new`,
+`EnumEntry::new`, `EnumMeta::new`, `MetaObject::new`) receive `#[inline]` just
+like non-const fns — the attribute is legal on `const fn` and has effect for
+non-const call sites.
+
+No generic function is touched. Verification below.
+
+For codegen changes: `#[inline]` is emitted inside `quote!` blocks as the token
+`# [inline]` (proc-macro2 serialises each token separately with spaces). Tests
+assert `out.contains("# [inline]")` to confirm the attribute appears in emitted
+output, satisfying AC9.
+
+### Generic / monomorphized functions confirmed absent from target list
+
+| Function | Is generic? | In scope? |
+|---|---|---|
+| `Signal<Args>::*` | Yes (`Args: 'static`) | No |
+| `ObjectRef<T>::*` | Yes | No |
+| `WeakRef<T>::*` | Yes | No |
+| `ObjectExt` default methods | Blanket impl | No |
+| `ObjectFactory::register` | Yes (`F: Fn(...)`) | No |
+| `ObjectTree::with` / `with_mut` | Yes (`F: FnOnce(...)`) | No |
+| `ObjectBase::named` | Yes (`impl Into<String>`) | No |
+| `ObjectTree::rename` | Yes (`impl Into<String>`) | No |
+
+All targets below are concrete, non-generic functions.
+
+## Decomposition
+
+Each task is one file. Within a file all `#[inline]` insertions are done in a
+single edit pass. Tasks are independent — no ordering dependency.
+
+| # | Task | File | Functions annotated | Depends on |
+|---|------|------|---------------------|------------|
+| 1 | Add `#[inline]` in `id.rs` | `quartzite-core/src/id.rs` | `ObjectId::new`, `ObjectId::raw`, `ObjectId::default`, `ConnectionId::new`, `ConnectionId::raw`, `ConnectionId::default` | — |
+| 2 | Add `#[inline]` in `object_base.rs` | `quartzite-core/src/object_base.rs` | `ObjectBase::id`, `ObjectBase::name`, `ObjectBase::receiver_guard`, `ObjectBase::set_name_raw`, `ObjectBase::default` | — |
+| 3 | Add `#[inline]` in `meta.rs` | `quartzite-core/src/meta.rs` | `PropertyFlags::none`, `PropertyFlags::read_write`, `PropertyFlags::read_only`, `PropertyFlags::default`, `PropertyMeta::new`, `ParamMeta::new`, `SignalMeta::new`, `MethodMeta::new`, `EnumEntry::new`, `EnumMeta::new`, `EnumMeta::entry_by_name`, `EnumMeta::entry_by_value`, `MetaObject::new`, `MetaObject::property`, `MetaObject::signal`, `MetaObject::method`, `MetaObject::enum_meta`, `noop_lookup_entry_by_name`, `noop_lookup_entry_by_value`, `noop_lookup_property`, `noop_lookup_signal`, `noop_lookup_method`, `noop_lookup_enum` | — |
+| 4 | Add `#[inline]` in `signal.rs` | `quartzite-core/src/signal.rs` | `queued_dispatcher` (free function, `#[cfg(feature = "std")]`-gated) | — |
+| 5 | Add `#[inline]` in `event_loop.rs` | `quartzite-runtime/src/event_loop.rs` | `EventLoop::is_running`, `EventLoop::sender`, `EventLoop::default` | — |
+| 6 | Add `#[inline]` in `timer.rs` | `quartzite-runtime/src/timer.rs` | `Timer::is_running` | — |
+| 7 | Add `#[inline]` in `factory.rs` | `quartzite-runtime/src/factory.rs` | `ObjectFactory::default` | — |
+| 8 | Add `#[inline]` in `object_tree.rs` | `quartzite-runtime/src/object_tree.rs` | `ObjectTree::default` | — |
+| 9 | Emit `#[inline]` in `extend/codegen.rs` + add AC9 tests | `quartzite-macros/src/extend/codegen.rs` | self-ref accessor pair; `AsObject::{object_base, object_base_mut, as_any, as_any_mut}`; parent-chain delegation pair; mixin leaf accessor pair | — |
+| 10 | Emit `#[inline]` in `object_impl/codegen.rs` + add AC9 tests | `quartzite-macros/src/object_impl/codegen.rs` | `Object::{meta_object, read_property, write_property, invoke_method, connect_signal}`; `__meta_init_Foo()` | — |
+| 11 | Emit `#[inline]` in `meta_enum/codegen.rs` + add AC9 test | `quartzite-macros/src/meta_enum/codegen.rs` | `IntoValue::into_value` | — |
+
+## Exact edit locations
+
+### Task 1 — `quartzite-core/src/id.rs`
+
+| Function | Insert before line | Current text at that line |
+|---|---|---|
+| `ObjectId::new` | 33 | `    pub fn new() -> Self {` |
+| `ObjectId::raw` | 51 | `    pub fn raw(self) -> u64 {` |
+| `ObjectId::default` | 57 | `    fn default() -> Self {` |
+| `ConnectionId::new` | 94 | `    pub fn new() -> Self {` |
+| `ConnectionId::raw` | 109 | `    pub fn raw(self) -> u64 {` |
+| `ConnectionId::default` | 115 | `    fn default() -> Self {` |
+
+`Default` impls are plain non-generic `fn default() -> Self` wrappers. They
+delegate to `Self::new()` (single call, no branches) — meets the criteria.
+
+### Task 2 — `quartzite-core/src/object_base.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `ObjectBase::name` | 111 | `pub fn name(&self) -> Option<&str>` — single `as_deref()` call |
+| `ObjectBase::set_name_raw` | 131 | `pub fn set_name_raw(&mut self, name: Option<String>)` — single assignment |
+| `ObjectBase::id` | 145 | `pub fn id(&self) -> ObjectId` — field read, single expression |
+| `ObjectBase::receiver_guard` | 160 | `pub fn receiver_guard(&self) -> &Arc<ReceiverGuard>` — field ref |
+| `ObjectBase::default` | 184 | `fn default() -> Self` inside `impl Default` — delegates to `Self::new()` |
+
+`ObjectBase::new` and `ObjectBase::named` are **excluded**: `new` has multiple
+statements and a `#[cfg(feature = "std")]` conditional; `named` chains two calls
+(`name.into()`, `..Self::new()`). Neither fits "at most one function call".
+
+### Task 3 — `quartzite-core/src/meta.rs`
+
+| Function | Kind | Line | Notes |
+|---|---|---|---|
+| `PropertyFlags::none` | `pub const fn` | 38 | struct literal, no calls |
+| `PropertyFlags::read_write` | `pub const fn` | 62 | struct literal, no calls |
+| `PropertyFlags::read_only` | `pub const fn` | 86 | struct literal, no calls |
+| `PropertyFlags::default` | `fn default` | 100 | single call `Self::read_write()` |
+| `PropertyMeta::new` | `pub const fn` | 127 | struct literal, no calls |
+| `ParamMeta::new` | `pub const fn` | 157 | struct literal, no calls |
+| `SignalMeta::new` | `pub const fn` | 183 | struct literal, no calls |
+| `MethodMeta::new` | `pub const fn` | 211 | struct literal, no calls |
+| `EnumEntry::new` | `pub const fn` | 245 | struct literal, no calls |
+| `noop_lookup_entry_by_name` | free `pub fn` | 251 | returns `None` directly |
+| `noop_lookup_entry_by_value` | free `pub fn` | 256 | returns `None` directly |
+| `EnumMeta::new` | `pub const fn` | 307 | struct literal, no calls |
+| `EnumMeta::entry_by_name` | `pub fn` | 332 | single fn-pointer call |
+| `EnumMeta::entry_by_value` | `pub fn` | 347 | single fn-pointer call |
+| `noop_lookup_property` | free `pub fn` | 353 | returns `None` directly |
+| `noop_lookup_signal` | free `pub fn` | 358 | returns `None` directly |
+| `noop_lookup_method` | free `pub fn` | 363 | returns `None` directly |
+| `noop_lookup_enum` | free `pub fn` | 368 | returns `None` directly |
+| `MetaObject::new` | `pub const fn` | 445 | has `#[allow(clippy::too_many_arguments)]` — insert `#[inline]` **after** that allow attr |
+| `MetaObject::property` | `pub fn` | 496 | single fn-pointer call |
+| `MetaObject::signal` | `pub fn` | 527 | single fn-pointer call |
+| `MetaObject::method` | `pub fn` | 558 | single fn-pointer call |
+| `MetaObject::enum_meta` | `pub fn` | 592 | single fn-pointer call |
+
+For `MetaObject::new` the attribute order will be:
+```rust
+// Each slice + fn-pointer pair is a distinct, non-groupable concern ...
+#[allow(clippy::too_many_arguments)]
+#[inline]
+pub const fn new(
+```
+`#[inline]` goes after `#[allow(...)]` and before `pub const fn` — both orders
+are accepted by rustc; putting it after the `#[allow]` keeps the lint suppression
+adjacent to the item it covers.
+
+### Task 4 — `quartzite-core/src/signal.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `queued_dispatcher` | 119 | free `pub fn`, `#[cfg(feature = "std")]`-gated; single call `QUEUED_DISPATCHER.get()` |
+
+`#[inline]` is inserted after the existing `#[cfg_attr(docsrs, ...)]` attribute
+and before `pub fn`:
+```rust
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[inline]
+pub fn queued_dispatcher() -> ...
+```
+
+`set_queued_dispatcher` is **excluded**: spec table does not list it. It also
+chains `.set(d).map_err(...)` — two distinct call chains.
+
+### Task 5 — `quartzite-runtime/src/event_loop.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `EventLoop::sender` | 69 | single call `self.sender.clone()` |
+| `EventLoop::is_running` | 131 | single call `self.running.load(...)` |
+| `EventLoop::default` | 137 | single call `Self::new()` |
+
+`EventLoop::new`, `post`, `run`, `stop` are excluded: they have multiple
+statements or branches.
+
+### Task 6 — `quartzite-runtime/src/timer.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `Timer::is_running` | 169 | single call `self.running.load(...)` |
+
+### Task 7 — `quartzite-runtime/src/factory.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `ObjectFactory::default` | 63 | `fn default` in `impl Default` — single call `Self::new()` |
+
+`ObjectFactory::register` is generic (`F: Fn(...)`). `create` maps a closure.
+Both excluded.
+
+### Task 8 — `quartzite-runtime/src/object_tree.rs`
+
+| Function | Line | Notes |
+|---|---|---|
+| `ObjectTree::default` | 323 | `fn default` in `impl Default` — single call `Self::new()` |
+
+All other `ObjectTree` methods have branches/loops or are generic (`with`,
+`with_mut`, `rename`).
+
+---
+
+### Task 9 — `quartzite-macros/src/extend/codegen.rs`
+
+The file has four `quote!` emitters that produce simple delegation functions.
+`#[inline]` is added as `#[inline]` tokens inside each `quote!` block,
+immediately before the `fn` keyword of each target function.
+
+**`emit_root_trait_and_impl`** — self-ref accessor pair (lines 69-72):
+
+Before (current):
+```rust
+impl #self_trait for #self_ident {
+    fn #acc(&self) -> &#self_ident { self }
+    fn #acc_mut(&mut self) -> &mut #self_ident { self }
+}
+```
+
+After:
+```rust
+impl #self_trait for #self_ident {
+    #[inline]
+    fn #acc(&self) -> &#self_ident { self }
+    #[inline]
+    fn #acc_mut(&mut self) -> &mut #self_ident { self }
+}
+```
+
+**`emit_as_object_impl`** — `AsObject` four methods (lines 103-113):
+
+Before:
+```rust
+impl ::quartzite_core::AsObject for #self_ident {
+    fn object_base(&self) -> &::quartzite_core::ObjectBase {
+        #object_base_expr
+    }
+    fn object_base_mut(&mut self) -> &mut ::quartzite_core::ObjectBase {
+        #object_base_mut_expr
+    }
+    fn as_any(&self) -> &dyn ::core::any::Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn ::core::any::Any { self }
+}
+```
+
+After:
+```rust
+impl ::quartzite_core::AsObject for #self_ident {
+    #[inline]
+    fn object_base(&self) -> &::quartzite_core::ObjectBase {
+        #object_base_expr
+    }
+    #[inline]
+    fn object_base_mut(&mut self) -> &mut ::quartzite_core::ObjectBase {
+        #object_base_mut_expr
+    }
+    #[inline]
+    fn as_any(&self) -> &dyn ::core::any::Any { self }
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn ::core::any::Any { self }
+}
+```
+
+**`emit_delegation_impl`** — parent-chain delegation pair (lines 131-140):
+
+Before:
+```rust
+impl #parent_trait for #self_ident {
+    fn #parent_acc(&self) -> &#parent_ty {
+        self.#base_field_ident.#parent_acc()
+    }
+    fn #parent_acc_mut(&mut self) -> &mut #parent_ty {
+        self.#base_field_ident.#parent_acc_mut()
+    }
+}
+```
+
+After:
+```rust
+impl #parent_trait for #self_ident {
+    #[inline]
+    fn #parent_acc(&self) -> &#parent_ty {
+        self.#base_field_ident.#parent_acc()
+    }
+    #[inline]
+    fn #parent_acc_mut(&mut self) -> &mut #parent_ty {
+        self.#base_field_ident.#parent_acc_mut()
+    }
+}
+```
+
+**`emit_mixin_impl`** — mixin leaf accessor pair (lines 154-159):
+
+Before:
+```rust
+impl #mixin_trait for #self_ident {
+    fn #mixin_acc(&self) -> &#mixin_ty { &self.#mixin_field }
+    fn #mixin_acc_mut(&mut self) -> &mut #mixin_ty { &mut self.#mixin_field }
+}
+```
+
+After:
+```rust
+impl #mixin_trait for #self_ident {
+    #[inline]
+    fn #mixin_acc(&self) -> &#mixin_ty { &self.#mixin_field }
+    #[inline]
+    fn #mixin_acc_mut(&mut self) -> &mut #mixin_ty { &mut self.#mixin_field }
+}
+```
+
+**AC9 tests for Task 9** — add to the existing `#[cfg(test)] mod tests` block:
+
+```rust
+// AC9: self-ref accessor pair is emitted with #[inline].
+#[test]
+fn root_self_ref_accessors_are_inline() {
+    let out = emit(quote! {
+        #[root]
+        struct Widget { x: i32 }
+    });
+    assert!(out.contains("# [inline]"), "missing #[inline] on self-ref accessor: {out}");
+}
+
+// AC9: AsObject methods are emitted with #[inline].
+#[test]
+fn as_object_methods_are_inline() {
+    let out = emit(quote! {
+        #[root]
+        struct Widget {
+            #[base]
+            object_base: ObjectBase,
+        }
+    });
+    // Four occurrences: object_base, object_base_mut, as_any, as_any_mut.
+    let count = out.matches("# [inline]").count();
+    assert!(count >= 4, "expected ≥4 #[inline] tokens, got {count}: {out}");
+}
+
+// AC9: parent-chain delegation pair is emitted with #[inline].
+#[test]
+fn delegation_methods_are_inline() {
+    let out = emit(quote! {
+        struct Button {
+            #[base]
+            widget: Widget,
+        }
+    });
+    assert!(out.contains("# [inline]"), "missing #[inline] on delegation method: {out}");
+}
+
+// AC9: mixin leaf accessors are emitted with #[inline].
+#[test]
+fn mixin_accessors_are_inline() {
+    let out = emit(quote! {
+        struct Panel {
+            #[mixin]
+            layout_base: LayoutBase,
+        }
+    });
+    assert!(out.contains("# [inline]"), "missing #[inline] on mixin accessor: {out}");
+}
+```
+
+Note: `quote!` serialises attribute tokens with a space — `#[inline]` becomes
+`# [inline]` in `.to_string()`. This is the standard proc-macro2 representation
+and is what the existing tests also rely on (e.g., `"impl :: quartzite_core ::`).
+
+---
+
+### Task 10 — `quartzite-macros/src/object_impl/codegen.rs`
+
+Two emitter functions need changes.
+
+**`emit_meta_static`** — `__meta_init_Foo` function (lines 185-189):
+
+Before:
+```rust
+#[allow(non_snake_case)]
+fn #meta_init_fn() -> &'static ::quartzite_core::MetaObject {
+    &#meta_static_name
+}
+```
+
+After:
+```rust
+#[allow(non_snake_case)]
+#[inline]
+fn #meta_init_fn() -> &'static ::quartzite_core::MetaObject {
+    &#meta_static_name
+}
+```
+
+**`emit_object_impl`** — all five `Object` trait methods (lines 202-227):
+
+Before:
+```rust
+impl ::quartzite_core::Object for #self_ty {
+    fn meta_object(&self) -> &'static ::quartzite_core::MetaObject {
+        #meta_init()
+    }
+    fn read_property(&self, name: &str) -> ::core::option::Option<::quartzite_core::Value> {
+        #mod_ident::#read_fn(self, name)
+    }
+    fn write_property(&mut self, name: &str, val: ::quartzite_core::Value) -> bool {
+        #mod_ident::#write_fn(self, name, val)
+    }
+    fn invoke_method(
+        &mut self,
+        name: &str,
+        args: &[::quartzite_core::Value],
+    ) -> ::core::option::Option<::quartzite_core::Value> {
+        #invoke_fn(self, name, args)
+    }
+    fn connect_signal(
+        &mut self,
+        signal: &str,
+        callback: ::quartzite_core::SignalCallback,
+    ) -> ::core::option::Option<::quartzite_core::ConnectionId> {
+        #mod_ident::#connect_fn(self, signal, callback)
+    }
+}
+```
+
+After: each `fn` is preceded by `#[inline]`:
+```rust
+impl ::quartzite_core::Object for #self_ty {
+    #[inline]
+    fn meta_object(&self) -> &'static ::quartzite_core::MetaObject {
+        #meta_init()
+    }
+    #[inline]
+    fn read_property(&self, name: &str) -> ::core::option::Option<::quartzite_core::Value> {
+        #mod_ident::#read_fn(self, name)
+    }
+    #[inline]
+    fn write_property(&mut self, name: &str, val: ::quartzite_core::Value) -> bool {
+        #mod_ident::#write_fn(self, name, val)
+    }
+    #[inline]
+    fn invoke_method(
+        &mut self,
+        name: &str,
+        args: &[::quartzite_core::Value],
+    ) -> ::core::option::Option<::quartzite_core::Value> {
+        #invoke_fn(self, name, args)
+    }
+    #[inline]
+    fn connect_signal(
+        &mut self,
+        signal: &str,
+        callback: ::quartzite_core::SignalCallback,
+    ) -> ::core::option::Option<::quartzite_core::ConnectionId> {
+        #mod_ident::#connect_fn(self, signal, callback)
+    }
+}
+```
+
+**Excluded from Task 10:**
+- `__invoke_method_*`: has a `match name { ... }` — branches present.
+- `__lookup_method_*` and `__lookup_enum_*`: have `match` arms — branches present.
+- `emit_methods_static`: emits a `const` slice, not a function.
+
+**AC9 tests for Task 10** — add to the existing `#[cfg(test)] mod tests` block:
+
+```rust
+// AC9: all five Object trait shims are emitted with #[inline].
+#[test]
+fn object_trait_shims_are_inline() {
+    let out = emit(quote! {
+        impl Foo {}
+    });
+    // Count occurrences: five shims + one __meta_init fn = 6 minimum.
+    let count = out.matches("# [inline]").count();
+    assert!(count >= 6, "expected ≥6 #[inline] tokens (5 shims + meta_init), got {count}: {out}");
+}
+
+// AC9: meta_init fn is emitted with #[inline].
+#[test]
+fn meta_init_fn_is_inline() {
+    let out = emit(quote! {
+        impl Foo {}
+    });
+    assert!(
+        out.contains("# [inline] fn __meta_init_Foo"),
+        "missing #[inline] on __meta_init_Foo: {out}"
+    );
+}
+```
+
+---
+
+### Task 11 — `quartzite-macros/src/meta_enum/codegen.rs`
+
+Only `IntoValue::into_value` is in scope. `FromValue::from_value` has `if let`
+and `match` — excluded per spec.
+
+The `impl ::quartzite_core::IntoValue for #type_ident` block (lines 83-88):
+
+Before:
+```rust
+impl ::quartzite_core::IntoValue for #type_ident {
+    fn into_value(self) -> ::quartzite_core::Value {
+        ::quartzite_core::Value::Int(self as i64)
+    }
+}
+```
+
+After:
+```rust
+impl ::quartzite_core::IntoValue for #type_ident {
+    #[inline]
+    fn into_value(self) -> ::quartzite_core::Value {
+        ::quartzite_core::Value::Int(self as i64)
+    }
+}
+```
+
+**AC9 test for Task 11** — add to the existing `#[cfg(test)] mod tests` block:
+
+```rust
+// AC9: IntoValue::into_value is emitted with #[inline].
+#[test]
+fn into_value_is_inline() {
+    let out = emit(quote! { enum Color { Red } });
+    assert!(
+        out.contains("# [inline]"),
+        "missing #[inline] on into_value: {out}"
+    );
+}
+
+// AC9: FromValue::from_value does NOT get #[inline] (has branches).
+#[test]
+fn from_value_is_not_inline() {
+    let out = emit(quote! { enum Color { Red } });
+    // The only #[inline] in the output is the one on into_value.
+    // from_value's fn declaration is preceded by nothing — no extra #[inline].
+    // We verify this indirectly: exactly one occurrence of # [inline].
+    let count = out.matches("# [inline]").count();
+    assert_eq!(count, 1, "expected exactly 1 #[inline] (into_value only), got {count}: {out}");
+}
+```
+
+## Risks
+
+- **clippy false positive:** clippy does not warn about `#[inline]` on simple
+  functions; no lint suppression needed.
+- **`const fn` + `#[inline]`:** fully supported in all Rust editions, including
+  edition 2024. No risk.
+- **`#[cfg(feature = "std")]`-gated items:** `#[inline]` on a cfg-gated function
+  is inert when the feature is absent. No conditional compilation needed on the
+  attribute itself.
+- **Existing `#[allow(clippy::too_many_arguments)]` on `MetaObject::new`:**
+  inserting `#[inline]` after it is valid; the allow attribute applies to the
+  item regardless of attribute order.
+- **`cargo fmt` drift:** `#[inline]` on its own line before `pub`/`fn` is the
+  canonical format; `cargo fmt` will not reformat it.
+- **proc-macro2 token spacing:** `#[inline]` in a `quote!` block serialises to
+  `# [inline]` (with a space) in `.to_string()`. All AC9 test assertions use
+  `"# [inline]"` as the needle to match this representation correctly.
+
+## Test Design
+
+### Hand-written functions (Tasks 1–8)
+
+No new tests needed — the existing tests in each file remain green after a
+pure annotation change, and the CI gates (`cargo build`, `cargo clippy -- -D
+warnings`, `cargo fmt -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc
+--no-deps`, `cargo test`) provide complete coverage.
+
+### Codegen functions (Tasks 9–11) — AC9
+
+Each codegen file already has a `#[cfg(test)] mod tests` block. New tests are
+added to the existing block in each file.
+
+**`extend/codegen.rs` — 4 new tests:**
+
+| Test name | Scenario | Assertion |
+|---|---|---|
+| `root_self_ref_accessors_are_inline` | root struct with no base | `out.contains("# [inline]")` |
+| `as_object_methods_are_inline` | root struct with `ObjectBase` base | `out.matches("# [inline]").count() >= 4` |
+| `delegation_methods_are_inline` | non-root struct with widget base | `out.contains("# [inline]")` |
+| `mixin_accessors_are_inline` | mixin-only struct | `out.contains("# [inline]")` |
+
+**`object_impl/codegen.rs` — 2 new tests:**
+
+| Test name | Scenario | Assertion |
+|---|---|---|
+| `object_trait_shims_are_inline` | empty `impl Foo {}` | `out.matches("# [inline]").count() >= 6` |
+| `meta_init_fn_is_inline` | empty `impl Foo {}` | `out.contains("# [inline] fn __meta_init_Foo")` |
+
+**`meta_enum/codegen.rs` — 2 new tests:**
+
+| Test name | Scenario | Assertion |
+|---|---|---|
+| `into_value_is_inline` | single-variant enum | `out.contains("# [inline]")` |
+| `from_value_is_not_inline` | single-variant enum | `out.matches("# [inline]").count() == 1` |
+
+Location: all tests live in the existing `#[cfg(test)] mod tests` block within
+each codegen file. No new test files are required.
+
+## Open questions
+
+None.

--- a/ai-docs/plans/done/2026-05-02-inline-simple-fns.spec.md
+++ b/ai-docs/plans/done/2026-05-02-inline-simple-fns.spec.md
@@ -1,0 +1,91 @@
+# inline-simple-fns
+
+**Source:** user description
+**Date:** 2026-05-02
+
+## Scope
+
+Add `#[inline]` to every simple, non-generic function across `quartzite-core`,
+`quartzite-runtime`, and `quartzite-macros` codegen. "Simple" means: no internal branches
+or loops, at most one function call, and inlining does not lead to binary bloat.
+
+Functions that will be monomorphized (generic functions, blanket-impl trait methods) are
+**excluded** — the compiler already has their bodies for inlining.
+
+### Hand-written functions
+
+| File | Functions |
+|------|-----------|
+| `quartzite-core/src/id.rs` | `ObjectId::{new, raw}`, `ObjectId::default`, `ConnectionId::{new, raw}`, `ConnectionId::default` |
+| `quartzite-core/src/object_base.rs` | `ObjectBase::{id, name, receiver_guard, set_name_raw}`, `ObjectBase::default` |
+| `quartzite-core/src/meta.rs` | `PropertyFlags::{none, read_write, read_only}`, `PropertyFlags::default`, `PropertyMeta::new`, `ParamMeta::new`, `SignalMeta::new`, `MethodMeta::new`, `EnumEntry::new`, `EnumMeta::new`, `EnumMeta::{entry_by_name, entry_by_value}`, `MetaObject::new`, `MetaObject::{property, signal, method, enum_meta}`, all six `noop_lookup_*` free functions |
+| `quartzite-core/src/signal.rs` | `queued_dispatcher` (free function) |
+| `quartzite-runtime/src/event_loop.rs` | `EventLoop::{is_running, sender}`, `EventLoop::default` |
+| `quartzite-runtime/src/timer.rs` | `Timer::is_running` |
+| `quartzite-runtime/src/factory.rs` | `ObjectFactory::default` (production impl only) |
+| `quartzite-runtime/src/object_tree.rs` | `ObjectTree::default` (production impl only) |
+
+### Proc-macro generated functions (codegen changes)
+
+| Codegen file | Generated functions to annotate |
+|---|---|
+| `quartzite-macros/src/extend/codegen.rs` | `As{Self}` self-ref accessor pair (`fn acc(&self) { self }`, `fn acc_mut(&mut self) { self }`); `AsObject::{object_base, object_base_mut, as_any, as_any_mut}`; parent-chain delegation pair; mixin leaf accessor pair |
+| `quartzite-macros/src/object_impl/codegen.rs` | `Object::{meta_object, read_property, write_property, invoke_method, connect_signal}`; `__meta_init_Foo()` |
+| `quartzite-macros/src/meta_enum/codegen.rs` | `IntoValue::into_value` |
+
+Generated functions with `match` branches are **excluded**: `__lookup_*`,
+`__read_property_*`, `__write_property_*`, `__connect_signal_dynamic_*`, `FromValue::from_value`.
+
+## Out of scope
+
+- Generic functions and blanket-impl trait methods (`ObjectRef<T>`, `WeakRef<T>`, `Signal<Args>`,
+  `ObjectExt` default methods) — monomorphized, no cross-crate inlining benefit
+- Test-only `AsObject` impls inside `#[cfg(test)]` modules
+- Any generated or hand-written function with branches, loops, or more than one function call
+
+## Deferred
+
+None.
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Include `ObjectId::new` / `ConnectionId::new`? | Yes — single `fetch_add` call, no branches/loops |
+| Include `Default::default` wrappers? | Yes — single call, eliminates one indirection level, no bloat |
+| Include `EventLoop::sender` (clone)? | Yes — `Sender::clone` is an Arc increment, ~2 instructions |
+| Include `EventLoop::is_running` / `Timer::is_running` (atomic load)? | Yes — single atomic instruction |
+| Include generic / monomorphized functions? | No — compiler already has body; `#[inline]` is redundant |
+| Include proc-macro generated simple functions? | Yes — they are non-generic delegation shims that cross crate boundaries |
+| `IntoValue::into_value` from `#[MetaEnum]`? | Yes — `Value::Int(self as i64)`, no branches |
+| `FromValue::from_value` from `#[MetaEnum]`? | No — has `if let` + `match` (branches) |
+| `__lookup_*` generated functions? | No — all have `match` arms (branches) |
+
+## Technical constraints
+
+- All functions must remain compilable: `cargo build` must pass after each file edit.
+- `cargo clippy -- -D warnings` must pass: clippy does not warn about `#[inline]` on simple
+  functions, but do not introduce any new lint violations.
+- `#![deny(missing_docs)]` is in effect; do not add or remove doc comments.
+- `cargo fmt` must be run after edits; `#[inline]` goes on the line immediately before `pub`/`fn`.
+- Codegen changes emit `#[inline]` inside `quote!` blocks; the attribute must appear on the
+  line immediately before the `fn` keyword in the generated token stream.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | Every hand-written function listed in the Scope table has `#[inline]` added |
+| AC2 | Every simple generated function listed in the Scope table is emitted with `#[inline]` by its codegen |
+| AC3 | No `#[inline]` is added to generated functions with branches (`__lookup_*`, `__read_property_*`, `__write_property_*`, `__connect_signal_dynamic_*`, `FromValue::from_value`) |
+| AC4 | No `#[inline]` is added to generic functions, blanket-impl methods, or test-only code |
+| AC5 | `cargo build` succeeds with no errors or warnings |
+| AC6 | `cargo clippy -- -D warnings` passes clean |
+| AC7 | `cargo fmt -- --check` reports no formatting drift |
+| AC8 | `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes clean |
+| AC9 | `cargo test` — all existing tests remain green; codegen tests verify the `#[inline]` token is present in emitted output |
+| AC10 | `AGENTS.md` Code Style section documents the `#[inline]` rule for simple functions so future contributors apply it consistently |
+
+## Open questions
+
+None.

--- a/quartzite-core/src/id.rs
+++ b/quartzite-core/src/id.rs
@@ -30,6 +30,7 @@ impl ObjectId {
     /// assert_ne!(id.raw(), 0);
     /// ```
     // Relaxed is enough: we only need uniqueness, not cross-thread ordering.
+    #[inline]
     pub fn new() -> Self {
         static COUNTER: AtomicU64 = AtomicU64::new(1);
         Self(COUNTER.fetch_add(1, Ordering::Relaxed))
@@ -48,12 +49,14 @@ impl ObjectId {
     /// let id = ObjectId::new();
     /// assert!(id.raw() > 0);
     /// ```
+    #[inline]
     pub fn raw(self) -> u64 {
         self.0
     }
 }
 
 impl Default for ObjectId {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -91,6 +94,7 @@ impl ConnectionId {
     /// assert_ne!(id.raw(), 0);
     /// ```
     // Relaxed is enough: we only need uniqueness, not cross-thread ordering.
+    #[inline]
     pub fn new() -> Self {
         static COUNTER: AtomicU64 = AtomicU64::new(1);
         Self(COUNTER.fetch_add(1, Ordering::Relaxed))
@@ -106,12 +110,14 @@ impl ConnectionId {
     /// let id = ConnectionId::new();
     /// assert!(id.raw() > 0);
     /// ```
+    #[inline]
     pub fn raw(self) -> u64 {
         self.0
     }
 }
 
 impl Default for ConnectionId {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/quartzite-core/src/meta.rs
+++ b/quartzite-core/src/meta.rs
@@ -35,6 +35,7 @@ impl PropertyFlags {
     /// assert!(!f.readable);
     /// assert!(!f.writable);
     /// ```
+    #[inline]
     pub const fn none() -> Self {
         Self {
             readable: false,
@@ -59,6 +60,7 @@ impl PropertyFlags {
     /// assert!(f.writable);
     /// assert!(!f.constant);
     /// ```
+    #[inline]
     pub const fn read_write() -> Self {
         Self {
             readable: true,
@@ -83,6 +85,7 @@ impl PropertyFlags {
     /// assert!(!f.writable);
     /// assert!(f.constant);
     /// ```
+    #[inline]
     pub const fn read_only() -> Self {
         Self {
             readable: true,
@@ -97,6 +100,7 @@ impl PropertyFlags {
 }
 
 impl Default for PropertyFlags {
+    #[inline]
     fn default() -> Self {
         Self::read_write()
     }
@@ -124,6 +128,7 @@ impl PropertyMeta {
     /// let meta = PropertyMeta::new("count", "i64", PropertyFlags::read_write());
     /// assert_eq!(meta.name, "count");
     /// ```
+    #[inline]
     pub const fn new(name: &'static str, type_name: &'static str, flags: PropertyFlags) -> Self {
         Self {
             name,
@@ -154,6 +159,7 @@ impl ParamMeta {
     /// assert_eq!(p.name, "value");
     /// assert_eq!(p.type_name, "i64");
     /// ```
+    #[inline]
     pub const fn new(name: &'static str, type_name: &'static str) -> Self {
         Self { name, type_name }
     }
@@ -180,6 +186,7 @@ impl SignalMeta {
     /// assert_eq!(s.name, "clicked");
     /// assert!(s.params.is_empty());
     /// ```
+    #[inline]
     pub const fn new(name: &'static str, params: &'static [ParamMeta]) -> Self {
         Self { name, params }
     }
@@ -208,6 +215,7 @@ impl MethodMeta {
     /// assert_eq!(m.name, "click");
     /// assert_eq!(m.return_type, "()");
     /// ```
+    #[inline]
     pub const fn new(
         name: &'static str,
         params: &'static [ParamMeta],
@@ -242,17 +250,20 @@ impl EnumEntry {
     /// assert_eq!(e.name, "Alpha");
     /// assert_eq!(e.value, 0);
     /// ```
+    #[inline]
     pub const fn new(name: &'static str, value: i64) -> Self {
         Self { name, value }
     }
 }
 
 /// No-op entry-by-name lookup — always returns `None`. Used in hand-written `EnumMeta` statics.
+#[inline]
 pub fn noop_lookup_entry_by_name(_: &str) -> Option<EnumEntry> {
     None
 }
 
 /// No-op entry-by-value lookup — always returns `None`. Used in hand-written `EnumMeta` statics.
+#[inline]
 pub fn noop_lookup_entry_by_value(_: i64) -> Option<EnumEntry> {
     None
 }
@@ -304,6 +315,7 @@ impl EnumMeta {
     /// assert_eq!(em.name, "State");
     /// assert_eq!(em.entries.len(), 2);
     /// ```
+    #[inline]
     pub const fn new(
         name: &'static str,
         entries: &'static [EnumEntry],
@@ -329,6 +341,7 @@ impl EnumMeta {
     /// let em = EnumMeta::new("MyEnum", ENTRIES, noop_lookup_entry_by_name, noop_lookup_entry_by_value);
     /// assert!(em.entry_by_name("Beta").is_none()); // noop returns None
     /// ```
+    #[inline]
     pub fn entry_by_name(&self, name: &str) -> Option<EnumEntry> {
         (self.lookup_entry_by_name)(name)
     }
@@ -344,27 +357,32 @@ impl EnumMeta {
     /// let em = EnumMeta::new("MyEnum", ENTRIES, noop_lookup_entry_by_name, noop_lookup_entry_by_value);
     /// assert!(em.entry_by_value(1).is_none()); // noop returns None
     /// ```
+    #[inline]
     pub fn entry_by_value(&self, value: i64) -> Option<EnumEntry> {
         (self.lookup_entry_by_value)(value)
     }
 }
 
 /// No-op property lookup — always returns `None`. Used in hand-written `MetaObject` statics.
+#[inline]
 pub fn noop_lookup_property(_: &str) -> Option<PropertyMeta> {
     None
 }
 
 /// No-op signal lookup — always returns `None`. Used in hand-written `MetaObject` statics.
+#[inline]
 pub fn noop_lookup_signal(_: &str) -> Option<SignalMeta> {
     None
 }
 
 /// No-op method lookup — always returns `None`. Used in hand-written `MetaObject` statics.
+#[inline]
 pub fn noop_lookup_method(_: &str) -> Option<MethodMeta> {
     None
 }
 
 /// No-op enum lookup — always returns `None`. Used in hand-written `MetaObject` statics.
+#[inline]
 pub fn noop_lookup_enum(_: &str) -> Option<EnumMeta> {
     None
 }
@@ -442,6 +460,7 @@ impl MetaObject {
     // Each slice + fn-pointer pair is a distinct, non-groupable concern; a builder would add
     // runtime overhead to a const fn used exclusively in static initialisers.
     #[allow(clippy::too_many_arguments)]
+    #[inline]
     pub const fn new(
         class_name: &'static str,
         properties: &'static [PropertyMeta],
@@ -493,6 +512,7 @@ impl MetaObject {
     /// assert!(meta.property("count").is_some());
     /// assert!(meta.property("missing").is_none());
     /// ```
+    #[inline]
     pub fn property(&self, name: &str) -> Option<PropertyMeta> {
         (self.lookup_property)(name)
     }
@@ -524,6 +544,7 @@ impl MetaObject {
     /// assert!(meta.signal("clicked").is_some());
     /// assert!(meta.signal("missing").is_none());
     /// ```
+    #[inline]
     pub fn signal(&self, name: &str) -> Option<SignalMeta> {
         (self.lookup_signal)(name)
     }
@@ -555,6 +576,7 @@ impl MetaObject {
     /// assert!(meta.method("reset").is_some());
     /// assert!(meta.method("missing").is_none());
     /// ```
+    #[inline]
     pub fn method(&self, name: &str) -> Option<MethodMeta> {
         (self.lookup_method)(name)
     }
@@ -589,6 +611,7 @@ impl MetaObject {
     /// assert!(meta.enum_meta("State").is_some());
     /// assert!(meta.enum_meta("missing").is_none());
     /// ```
+    #[inline]
     pub fn enum_meta(&self, name: &str) -> Option<EnumMeta> {
         (self.lookup_enum)(name)
     }

--- a/quartzite-core/src/object_base.rs
+++ b/quartzite-core/src/object_base.rs
@@ -108,6 +108,7 @@ impl ObjectBase {
     /// assert!(ObjectBase::new().name().is_none());
     /// assert_eq!(ObjectBase::named("btn").name(), Some("btn"));
     /// ```
+    #[inline]
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
@@ -128,6 +129,7 @@ impl ObjectBase {
     /// base.set_name_raw(None);
     /// assert!(base.name().is_none());
     /// ```
+    #[inline]
     pub fn set_name_raw(&mut self, name: Option<String>) {
         self.name = name;
     }
@@ -142,6 +144,7 @@ impl ObjectBase {
     /// let base = ObjectBase::new();
     /// assert!(base.id().raw() > 0);
     /// ```
+    #[inline]
     pub fn id(&self) -> ObjectId {
         self.id
     }
@@ -157,6 +160,7 @@ impl ObjectBase {
     /// let guard = base.receiver_guard();
     /// assert_eq!(std::sync::Arc::strong_count(guard), 1);
     /// ```
+    #[inline]
     pub fn receiver_guard(&self) -> &Arc<ReceiverGuard> {
         &self.receiver_guard
     }
@@ -181,6 +185,7 @@ impl ObjectBase {
 }
 
 impl Default for ObjectBase {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -116,6 +116,7 @@ pub fn set_queued_dispatcher(d: Arc<dyn QueuedDispatcher>) -> Result<(), Dispatc
 /// ```
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[inline]
 pub fn queued_dispatcher() -> Option<&'static Arc<dyn QueuedDispatcher>> {
     QUEUED_DISPATCHER.get()
 }

--- a/quartzite-macros/src/extend/codegen.rs
+++ b/quartzite-macros/src/extend/codegen.rs
@@ -67,7 +67,9 @@ fn emit_root_trait_and_impl(ir: &ExtendInput) -> TokenStream {
         }
 
         impl #self_trait for #self_ident {
+            #[inline]
             fn #acc(&self) -> &#self_ident { self }
+            #[inline]
             fn #acc_mut(&mut self) -> &mut #self_ident { self }
         }
     }
@@ -101,13 +103,17 @@ fn emit_as_object_impl(self_ident: &Ident, base: &BaseField) -> TokenStream {
     };
     quote! {
         impl ::quartzite_core::AsObject for #self_ident {
+            #[inline]
             fn object_base(&self) -> &::quartzite_core::ObjectBase {
                 #object_base_expr
             }
+            #[inline]
             fn object_base_mut(&mut self) -> &mut ::quartzite_core::ObjectBase {
                 #object_base_mut_expr
             }
+            #[inline]
             fn as_any(&self) -> &dyn ::core::any::Any { self }
+            #[inline]
             fn as_any_mut(&mut self) -> &mut dyn ::core::any::Any { self }
         }
     }
@@ -130,9 +136,11 @@ fn emit_delegation_impl(self_ident: &Ident, base: &BaseField) -> TokenStream {
 
     quote! {
         impl #parent_trait for #self_ident {
+            #[inline]
             fn #parent_acc(&self) -> &#parent_ty {
                 self.#base_field_ident.#parent_acc()
             }
+            #[inline]
             fn #parent_acc_mut(&mut self) -> &mut #parent_ty {
                 self.#base_field_ident.#parent_acc_mut()
             }
@@ -153,7 +161,9 @@ fn emit_mixin_impl(self_ident: &Ident, mixin: &MixinField) -> TokenStream {
 
     quote! {
         impl #mixin_trait for #self_ident {
+            #[inline]
             fn #mixin_acc(&self) -> &#mixin_ty { &self.#mixin_field }
+            #[inline]
             fn #mixin_acc_mut(&mut self) -> &mut #mixin_ty { &mut self.#mixin_field }
         }
     }
@@ -329,6 +339,66 @@ mod tests {
         assert!(
             out.contains("impl AsStyle for Mixed"),
             "missing StyleBase: {out}"
+        );
+    }
+
+    // AC9: self-ref accessor pair carries #[inline].
+    #[test]
+    fn self_ref_accessors_are_inline() {
+        let out = emit(quote! {
+            #[root]
+            struct Widget { x: i32 }
+        });
+        assert!(
+            out.contains("# [inline]"),
+            "missing #[inline] on accessor: {out}"
+        );
+    }
+
+    // AC9: AsObject impl methods carry #[inline].
+    #[test]
+    fn as_object_impl_methods_are_inline() {
+        let out = emit(quote! {
+            #[root]
+            struct Widget {
+                #[base]
+                object_base: ObjectBase,
+            }
+        });
+        let count = out.matches("# [inline]").count();
+        assert!(
+            count >= 4,
+            "expected >=4 #[inline] (object_base x2, as_any x2), got {count}: {out}"
+        );
+    }
+
+    // AC9: parent delegation methods carry #[inline].
+    #[test]
+    fn delegation_methods_are_inline() {
+        let out = emit(quote! {
+            struct Button {
+                #[base]
+                widget: Widget,
+            }
+        });
+        assert!(
+            out.contains("# [inline]"),
+            "missing #[inline] on delegation: {out}"
+        );
+    }
+
+    // AC9: mixin leaf accessor pair carries #[inline].
+    #[test]
+    fn mixin_accessors_are_inline() {
+        let out = emit(quote! {
+            struct Panel {
+                #[mixin]
+                layout_base: LayoutBase,
+            }
+        });
+        assert!(
+            out.contains("# [inline]"),
+            "missing #[inline] on mixin accessor: {out}"
         );
     }
 }

--- a/quartzite-macros/src/meta_enum/codegen.rs
+++ b/quartzite-macros/src/meta_enum/codegen.rs
@@ -81,6 +81,7 @@ pub(crate) fn codegen(ir: MetaEnumInput) -> TokenStream {
         );
 
         impl ::quartzite_core::IntoValue for #type_ident {
+            #[inline]
             fn into_value(self) -> ::quartzite_core::Value {
                 ::quartzite_core::Value::Int(self as i64)
             }
@@ -242,6 +243,22 @@ mod tests {
         assert!(
             out.contains("__lookup_entry_by_value_Empty"),
             "missing by-value lookup: {out}"
+        );
+    }
+
+    // AC9: IntoValue::into_value carries #[inline]; FromValue::from_value does not.
+    #[test]
+    fn into_value_is_inline_from_value_is_not() {
+        let out = emit(quote! { enum Color { Red, Green } });
+        let count = out.matches("# [inline]").count();
+        // Exactly one #[inline]: on into_value. from_value has branches so must not be inline.
+        assert!(
+            count == 1,
+            "expected exactly 1 #[inline], got {count}: {out}"
+        );
+        assert!(
+            out.contains("# [inline] fn into_value"),
+            "missing #[inline] on into_value: {out}"
         );
     }
 }

--- a/quartzite-macros/src/object_impl/codegen.rs
+++ b/quartzite-macros/src/object_impl/codegen.rs
@@ -183,6 +183,7 @@ fn emit_meta_static(type_ident: &Ident, mod_ident: &Ident) -> TokenStream {
             );
 
         #[allow(non_snake_case)]
+        #[inline]
         fn #meta_init_fn() -> &'static ::quartzite_core::MetaObject {
             &#meta_static_name
         }
@@ -200,15 +201,19 @@ fn emit_object_impl(self_ty: &syn::Type, type_ident: &Ident, mod_ident: &Ident) 
     let meta_init = Ident::new(&format!("__meta_init_{type_ident}"), type_ident.span());
     quote! {
         impl ::quartzite_core::Object for #self_ty {
+            #[inline]
             fn meta_object(&self) -> &'static ::quartzite_core::MetaObject {
                 #meta_init()
             }
+            #[inline]
             fn read_property(&self, name: &str) -> ::core::option::Option<::quartzite_core::Value> {
                 #mod_ident::#read_fn(self, name)
             }
+            #[inline]
             fn write_property(&mut self, name: &str, val: ::quartzite_core::Value) -> bool {
                 #mod_ident::#write_fn(self, name, val)
             }
+            #[inline]
             fn invoke_method(
                 &mut self,
                 name: &str,
@@ -216,6 +221,7 @@ fn emit_object_impl(self_ty: &syn::Type, type_ident: &Ident, mod_ident: &Ident) 
             ) -> ::core::option::Option<::quartzite_core::Value> {
                 #invoke_fn(self, name, args)
             }
+            #[inline]
             fn connect_signal(
                 &mut self,
                 signal: &str,
@@ -495,5 +501,27 @@ mod tests {
             }
         });
         assert!(out.contains("fn helper"), "helper not re-emitted: {out}");
+    }
+
+    // AC9: Object trait shims and __meta_init carry #[inline].
+    #[test]
+    fn object_impl_shims_are_inline() {
+        let out = emit(quote! { impl Foo {} });
+        let count = out.matches("# [inline]").count();
+        // 5 Object trait shims + 1 __meta_init_Foo
+        assert!(
+            count >= 6,
+            "expected >=6 #[inline] tokens, got {count}: {out}"
+        );
+    }
+
+    // AC9: __meta_init specifically carries #[inline].
+    #[test]
+    fn meta_init_fn_is_inline() {
+        let out = emit(quote! { impl Foo {} });
+        assert!(
+            out.contains("# [inline] fn __meta_init_Foo"),
+            "missing #[inline] on __meta_init_Foo: {out}"
+        );
     }
 }

--- a/quartzite-runtime/src/event_loop.rs
+++ b/quartzite-runtime/src/event_loop.rs
@@ -66,6 +66,7 @@ impl EventLoop {
     /// let tx = el.sender();
     /// tx.send(Box::new(|| println!("posted"))).ok();
     /// ```
+    #[inline]
     pub fn sender(&self) -> Sender<Box<dyn FnOnce() + Send>> {
         self.sender.clone()
     }
@@ -128,12 +129,14 @@ impl EventLoop {
     /// let el = EventLoop::new();
     /// assert!(!el.is_running());
     /// ```
+    #[inline]
     pub fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
     }
 }
 
 impl Default for EventLoop {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/quartzite-runtime/src/factory.rs
+++ b/quartzite-runtime/src/factory.rs
@@ -60,6 +60,7 @@ impl ObjectFactory {
 }
 
 impl Default for ObjectFactory {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/quartzite-runtime/src/object_tree.rs
+++ b/quartzite-runtime/src/object_tree.rs
@@ -320,6 +320,7 @@ impl ObjectTree {
 }
 
 impl Default for ObjectTree {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/quartzite-runtime/src/timer.rs
+++ b/quartzite-runtime/src/timer.rs
@@ -166,6 +166,7 @@ impl Timer {
     /// let mut timer = Timer::new(Duration::from_millis(100));
     /// assert!(!timer.is_running());
     /// ```
+    #[inline]
     pub fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
     }


### PR DESCRIPTION
## Summary

- Added `#[inline]` to every simple, non-generic hand-written function across `quartzite-core` and `quartzite-runtime` (41 annotations: field getters, trivial wrappers, `Default::default()` delegates, single-call constructors)
- Updated three proc-macro codegen files (`extend`, `object_impl`, `meta_enum`) to emit `#[inline]` on generated simple delegation shims
- Documented the `#[inline]` rule in `AGENTS.md` Code Style section for future contributors
- Added the `#[inline]` check to `self-review.md` and `review-findings.md` review checklists

**Excluded** (by design): generic functions, blanket-impl trait methods, and generated functions with `match` branches — all monomorphized or non-trivial.

## Test plan

- [x] AC1: All hand-written simple functions annotated (`rg '#\[inline\]'` counts match spec table)
- [x] AC2: Codegen emits `#[inline]` on simple generated functions
- [x] AC3: No `#[inline]` on branched generated functions (`__lookup_*`, `FromValue::from_value`, etc.)
- [x] AC4: No `#[inline]` on generic/blanket/test-only code
- [x] AC5: `cargo build` — clean
- [x] AC6: `cargo clippy -- -D warnings` — clean
- [x] AC7: `cargo fmt -- --check` — clean
- [x] AC8: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean
- [x] AC9: `cargo test` — 49 unit + all doctests green; 8 new codegen tests verify `#[inline]` token in output
- [x] AC10: `AGENTS.md` documents the rule