### PR TITLE
chore(agents): fix workflow correctness inconsistencies

### DIFF
--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -67,7 +67,7 @@ After applying changes — answer:
 - How to reproduce the original error?
 - What does the output look like if the fix worked?
 
-Run the scenario via Task subagent in a clean context.
+Run the scenario via an `Agent` subagent in a clean context.
 
 **PASS criterion:** the problematic pattern is gone.
 **FAIL criterion:** same error → rule not strong enough → go back to Step 3, strengthen it.

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -2,7 +2,7 @@
 
 Reviews implementation code for a task. Reads the diff since implementation started, checks against the spec and design, writes structured findings into the progress file, and issues APPROVE or REJECT.
 
-Used in the automated self-review loop inside `/task` and `/task-workflow` — runs after Verify, before the task is declared done.
+Used in the automated self-review loop inside `/task` and `/task-issue` — runs after Verify, before the task is declared done. Also reused by `/code-review` to approve the post-fix state.
 
 ## Mindset: maximally skeptical, but justified
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,8 +31,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f && [[ \"$f\" == *.rs ]] && rustfmt \"$f\"; } || true",
-            "timeout": 30,
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f && [[ \"$f\" == *.rs ]] && cargo fmt --quiet --manifest-path \"$CLAUDE_PROJECT_DIR/Cargo.toml\"; } || true",
+            "timeout": 60,
             "statusMessage": "Formatting Rust..."
           }
         ]

--- a/.claude/skills/bugfix/SKILL.md
+++ b/.claude/skills/bugfix/SKILL.md
@@ -2,10 +2,10 @@
 name: bugfix
 description: "Reactive bug-fixing workflow. Trace → Root cause → Failing test → Fix. Prevents the fix-break cycle."
 when_to_use: "Activate on: 'not working', 'broken', 'wrong', 'incorrect', 'doesn't show', unexpected panic/crash/compile error, failing test that should pass. Divergence signal: 'expected X got Y', 'should return X but returns Y'. During implementation: 'this is wrong', 'overengineered', 'not what I meant'. Regression: 'broke again', 'stopped working', 'worked before'. SKIP for general questions, codebase exploration, known/planned limitations."
-allowed-tools: Bash(cargo test *) Bash(cargo clippy *) Bash(cargo build) Bash(git rm *)
+allowed-tools: Bash(cargo test *) Bash(cargo clippy *) Bash(cargo build) Bash(cargo fmt *) Bash(git rm *) Bash(rm *)
 ---
 
-Reactive bug-fixing workflow. **Fundamentally different from task-workflow:**
+Reactive bug-fixing workflow. **Fundamentally different from `/task` and `/task-issue`:**
 - First step is analysis, NOT code
 - Failing test is written BEFORE the fix, not after
 
@@ -135,8 +135,8 @@ Now open Edit.
 1. Run the failing test from Step 3: `cargo test test_name` — must turn green
 2. Run the full suite: `cargo test` — confirm nothing else broke
 3. Run `cargo clippy -- -D warnings` for changed files
-4. Run `rustfmt` on changed `.rs` files
-5. **Delete the trace artifact:** `git rm ai-docs/bugfix/trace-*.md`
+4. Run `cargo fmt`
+5. **Delete the trace artifact:** `git rm ai-docs/bugfix/trace-*.md 2>/dev/null || rm -f ai-docs/bugfix/trace-*.md` (handles both tracked and untracked traces)
 
 ---
 

--- a/.claude/skills/context-reset/SKILL.md
+++ b/.claude/skills/context-reset/SKILL.md
@@ -11,15 +11,15 @@ When triggered (N=3, M>=5 OR compaction detected):
 
 1. `cargo build` — ensure code compiles
 2. Update `ai-docs/plans/YYYY-MM-DD-name.progress.md` (format below)
-3. Launch: `Task(prompt="Read ai-docs/plans/YYYY-MM-DD-name.progress.md and continue")`
-4. Remaining subtasks — one per Task call, not batched
+3. Launch: `Agent(subagent_type="general-purpose", prompt="Read ai-docs/plans/YYYY-MM-DD-name.progress.md and continue")`
+4. Remaining subtasks — one per Agent call, not batched
 5. Do NOT continue in current context
 
-## Checkpoint handoff: 1 Task = 1 subtask
+## Checkpoint handoff: 1 Agent = 1 subtask
 
 - Do NOT ask "continue?" between subtasks — just proceed
-- Each Task = 1 subtask, ending with `cargo build`
-- Update progress.md after each Task
+- Each Agent = 1 subtask, ending with `cargo build`
+- Update progress.md after each Agent
 
 ## `.progress.md` format
 
@@ -62,6 +62,6 @@ _Updated: YYYY-MM-DD HH:MM_
 ## Rules
 
 1. Progress file = `ai-docs/plans/*.progress.md`. Updated at each checkpoint.
-2. On context reset: pass file path in Task prompt: `"Read ai-docs/plans/YYYY-MM-DD-name.progress.md and continue"`
+2. On context reset: pass file path in Agent prompt: `"Read ai-docs/plans/YYYY-MM-DD-name.progress.md and continue"`
 3. `cargo build` BEFORE handoff — don't pass broken code
-4. Maximum 3 handoffs per task. If more needed — task is too large, decompose.
+4. Maximum 3 handoffs per task. If more needed — the task is too large, decompose.

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -10,7 +10,7 @@ Requirements interview with the product owner.
 Output: refined task spec saved as `ai-docs/plans/YYYY-MM-DD-name.spec.md`.
 
 > **MUST run before:** code investigation, design agent, or writing code.
-> For the full workflow use `/task-workflow` — it includes interview as steps 2-4.
+> For the full workflow use `/task` (or `/task-issue` for an existing GitHub issue) — it includes interview as steps 2-4.
 
 ## Rules
 

--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -62,7 +62,7 @@ One business requirement = ONE AC. Show to user for confirmation.
 > First action: confirm `ai-docs/plans/YYYY-MM-DD-name.spec.md` exists.
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/design.md and follow it.
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
   Research codebase, produce Design Document.
@@ -74,14 +74,17 @@ Result: `ai-docs/plans/YYYY-MM-DD-name.design.md`
 ### Step 7: Design review
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/design-review.md and follow it.
   Design: ai-docs/plans/YYYY-MM-DD-name.design.md
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
 ")
 ```
 
-Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
+Verdict: GO / ITERATE / STOP.
+- **GO** → proceed to Step 8.
+- **ITERATE** → back to Step 6 (max 3 rounds total).
+- **STOP** → fundamental flaw with the approach. Surface the verdict and `Issues` table to the user, do not start Step 8. Wait for direction (e.g., narrow scope, change approach, abandon).
 
 ### Design Amendment (re-entrant — triggered from Step 8 or Step 11)
 
@@ -93,7 +96,7 @@ finding (Step 11) requires a design change rather than a code fix:
 3. Update `ai-docs/plans/YYYY-MM-DD-name.design.md` to reflect the new approach.
 4. Re-run design review — same as Step 7 (max 3 rounds total across all design-review runs):
    ```
-   Task(subagent_type="general-purpose", prompt="
+   Agent(subagent_type="general-purpose", prompt="
      Read .claude/agents/design-review.md and follow it.
      Design: ai-docs/plans/YYYY-MM-DD-name.design.md
      Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
@@ -142,8 +145,9 @@ finding (Step 11) requires a design change rather than a code fix:
 2. `cargo test` — all green
 3. `cargo fmt -- --check` — no formatting drift
 4. `cargo clippy -- -D warnings` — clean
-5. For each AC — confirm covered by test or manual verification
-6. Show summary table:
+5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — no doc errors or warnings (matches CI)
+6. For each AC — confirm covered by test or manual verification
+7. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |
@@ -151,7 +155,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-7. On ALL PASS → proceed to Step 9.5
+8. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -171,7 +175,7 @@ Then proceed to Step 10.
 Spawn the self-review agent:
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/self-review.md and follow it.
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
   Design: ai-docs/plans/YYYY-MM-DD-name.design.md
@@ -239,7 +243,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps --workspace` clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? |

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -110,7 +110,7 @@ One business requirement = ONE AC. Show to user for confirmation.
 > First action: confirm `ai-docs/plans/YYYY-MM-DD-name.spec.md` exists.
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/design.md and follow it.
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
   Research codebase, produce Design Document.
@@ -122,14 +122,17 @@ Result: `ai-docs/plans/YYYY-MM-DD-name.design.md`
 ### Step 7: Design review
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/design-review.md and follow it.
   Design: ai-docs/plans/YYYY-MM-DD-name.design.md
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
 ")
 ```
 
-Verdict: GO / ITERATE / STOP. On ITERATE → back to Step 6 (max 3 rounds).
+Verdict: GO / ITERATE / STOP.
+- **GO** → proceed to Step 8.
+- **ITERATE** → back to Step 6 (max 3 rounds total).
+- **STOP** → fundamental flaw with the approach. Surface the verdict and `Issues` table to the user, do not start Step 8. Wait for direction (e.g., narrow scope, change approach, abandon).
 
 ### Design Amendment (re-entrant — triggered from Step 8 or Step 11)
 
@@ -141,7 +144,7 @@ finding (Step 11) requires a design change rather than a code fix:
 3. Update `ai-docs/plans/YYYY-MM-DD-name.design.md` to reflect the new approach.
 4. Re-run design review — same as Step 7 (max 3 rounds total across all design-review runs):
    ```
-   Task(subagent_type="general-purpose", prompt="
+   Agent(subagent_type="general-purpose", prompt="
      Read .claude/agents/design-review.md and follow it.
      Design: ai-docs/plans/YYYY-MM-DD-name.design.md
      Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
@@ -190,9 +193,9 @@ finding (Step 11) requires a design change rather than a code fix:
 2. `cargo test` — all green
 3. `cargo fmt -- --check` — no formatting drift
 4. `cargo clippy -- -D warnings` — clean
-5. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — no doc errors or warnings
+5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — no doc errors or warnings (matches CI)
 6. For each AC — confirm covered by test or manual verification
-5. Show summary table:
+7. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |
@@ -200,7 +203,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-6. On ALL PASS → proceed to Step 9.5
+8. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -220,7 +223,7 @@ Then proceed to Step 10.
 Spawn the self-review agent:
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Read .claude/agents/self-review.md and follow it.
   Spec: ai-docs/plans/YYYY-MM-DD-name.spec.md
   Design: ai-docs/plans/YYYY-MM-DD-name.design.md
@@ -287,7 +290,7 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps` clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps --workspace` clean? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? |

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -50,11 +50,12 @@
 
 **Rule:** When work is intended for a PR, create a feature branch (`git checkout -b feat/...`) *before* making any commits. Never commit to local master with the intention of later turning it into a PR.
 
-Recovery — if commits were accidentally made on local master and not yet pushed:
-1. `git checkout -b feat/...` — branch off from current HEAD (carries the commits)
-2. `git checkout master && git reset --hard origin/master` — reset local master to remote state
-3. Push the feature branch and open the PR from it
-4. **Never push master** — not even as an intermediate step.
+Recovery — if commits were accidentally made on local master and not yet pushed (full procedure in `AGENTS.md`):
+1. `git stash` — save any uncommitted changes
+2. `git checkout -b feat/...` — branch off from current HEAD (carries the commits)
+3. `git checkout master && git reset --soft origin/master && git restore --staged .` — soft-rewind local master to remote state without discarding work
+4. Push the feature branch and open the PR from it; pop the stash on the feature branch if needed
+5. **Never push master** — not even as an intermediate step. **Never use `git reset --hard`** — see the dedicated rule above.
 
 Before any `git push`: run `git branch --show-current` and confirm it is **not** `master`. If it is master — stop, do not push, apply the recovery procedure above.
 
@@ -68,7 +69,7 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 **Rule:** At the start of Step 8 (Implementation), immediately create a feature branch (`git checkout -b feat/...`) before writing any code. Record the branch name in the progress file. Do not wait until after self-review to create the branch.
 
-**Escalated?** skill:task, skill:task-issue
+**Escalated?** skill:task, skill:task-issue, hook (PreToolUse on `git commit` blocks master)
 
 ### 2026-05-02 — testing — any sufficiently large file requires unit tests
 


### PR DESCRIPTION
## Summary

PR 1 of a planned cleanup pass on agent/skill instruction files. Fixes self-contradictions, missing handlers, and stale references — no code changes, no test changes.

- **A1** Stale `/task-workflow` → `/task` (or `/task-issue`) in `interview`, `bugfix`, `self-review`
- **A2** `task/SKILL.md` Step 9 numbering (1..6, then duplicate 5/6 → fixed to 1..8)
- **A3** `task-issue/SKILL.md` Step 9: add missing `cargo doc` (sync with `task/`)
- **A4** Align `RUSTDOCFLAGS` value with CI: `-D warnings -D missing-docs --workspace`
- **A5** `learnings.md` "always create a feature branch" Recovery used `git reset --hard`, contradicting the later escalated rule "never use `git reset --hard`". Rewritten to use `git reset --soft` per AGENTS.md
- **A6** PostToolUse hook called `rustfmt "$f"` directly — violated the escalated AGENTS.md rule "always format via `cargo fmt`, never `rustfmt <file>` directly". Now invokes `cargo fmt --manifest-path "\$CLAUDE_PROJECT_DIR/Cargo.toml"`
- **A7** `bugfix` Step 6: `git rm` failed when trace was never committed. Now falls back to `rm -f`. Also replaced a stray `rustfmt` call with `cargo fmt` (same rule as A6)
- **A9** `task`/`task-issue` Step 7: STOP verdict was listed but had no handler — added one (surface to user, don't enter Step 8)
- **A10** `Task(subagent_type=...)` → `Agent(subagent_type=...)` in `task`, `task-issue`, `context-reset`, `self-improve`. `Task*` now refers to task-tracking tools; agents spawn via `Agent`
- **B5** Marked the Step-8 branch-creation entry in `learnings.md` as also escalated to the PreToolUse hook (was only `skill:task, skill:task-issue`)

## Test plan

- [x] \`cargo build\` clean (no code changed; sanity check)
- [x] No production source files touched
- [x] Branch is not \`master\` before push
- [x] Diff stat: 9 files, +48/-40 — instruction text only