### PR TITLE
chore(ci): add cargo fmt --check; document cargo doc gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -31,6 +31,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Format
+        run: cargo fmt -- --check
 
       - name: Build
         run: cargo build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ cargo test -- --nocapture             # show stdout
 cargo clippy -- -D warnings           # lint (strict)
 cargo fmt                             # fix formatting
 cargo fmt -- --check                  # check only
+RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace   # doc gate (matches CI)
 ```
 
 Search: `rg <pattern> --type rust [-l | -C 3]`


### PR DESCRIPTION
## Summary

PR 2 of the agent-docs cleanup pass — closes the gap between local Step 9 gates and CI.

- **A8/C2** Add \`cargo fmt -- --check\` to CI as the **first** job step. Before this, a PR could land with formatting drift that Step 9 of \`/task\` would have rejected locally. The toolchain action now also installs the \`rustfmt\` component.
- **C1** Add the \`cargo doc\` invocation (with the same \`RUSTDOCFLAGS\` as CI) to AGENTS.md Build & Test commands so agents following AGENTS.md alone see the full local gate set.

(C5 \"align \`--workspace\` flag\" was already absorbed into PR #20 when Step 9 was rewritten.)

## Test plan

- [x] \`cargo fmt -- --check\` passes locally (would have caught any drift before pushing)
- [x] \`RUSTDOCFLAGS=\"-D warnings -D missing-docs\" cargo doc --no-deps --workspace\` passes locally
- [x] \`cargo build\` clean
- [x] Branch is not \`master\` before push
- [ ] CI run on this PR shows the new Format step pass