### PR TITLE
chore(docs): polish — README sections, commit safety, hook recovery

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -q 'git commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"master\" ]; then echo 'BLOCKED: git commit on master is forbidden. Create a feature branch first (git checkout -b feat/...) and apply the AGENTS.md recovery procedure.'; exit 1; fi; fi",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -q 'git commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"master\" ]; then printf 'BLOCKED: git commit on master is forbidden.\\n\\nRecovery (no commits yet on master):\\n  git checkout -b feat/YYYY-MM-DD-name\\n\\nRecovery (commits already on master, not yet pushed):\\n  git stash                                           # save uncommitted work\\n  git checkout -b feat/YYYY-MM-DD-name                 # branch carries the commits\\n  git checkout master                                  # back to master\\n  git reset --soft origin/master && git restore --staged .   # rewind without losing work\\n  git checkout feat/YYYY-MM-DD-name && git stash pop   # resume on feature branch\\n\\nNever use git reset --hard. Full procedure: AGENTS.md > Workflow > Recovery.\\n'; exit 1; fi; fi",
             "timeout": 10,
             "statusMessage": "Checking branch before commit..."
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - **Never commit to local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any commits. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
   - Recovery (commits on local master, not yet pushed): stash any uncommitted changes first (`git stash`), then `git checkout -b feat/...` → `git checkout master && git reset --soft origin/master && git restore --staged .` → push feature branch and open PR from it. Pop the stash on the feature branch if needed.
 - Run `cargo build` before committing so `Cargo.lock` is refreshed and included in the commit when it changes.
+- Stage files explicitly by name. **Never** use `git add -A` or `git add .` — they pull in unintended files (IDE state, accidental scratch files). The diff stat in PR 1–3 was cleanly scoped because every file was named.
+- **Never** use `git commit --no-verify` (or any other hook-skipping flag). If a hook fails, fix the underlying issue.
 - Plan first. Tests before prod code (TDD). Lint changed files.
 - Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files.
 - `.gitignore` (not `.arcignore`).
@@ -80,7 +82,7 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 > `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (AGENTS.md / skill / agent / hook / settings). `settings.local` does NOT count as project-level.
 ```
 
-Categories: `code-style` | `process` | `architecture` | `testing` | `search` | `other`
+Categories: `code-style` | `process` | `architecture` | `testing` | `documentation` | `tooling` | `search` | `other`
 
 Run `/improve` when ≥3 unescalated entries accumulate.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ cargo test
 cargo clippy -- -D warnings
 ```
 
+## Format
+
+```bash
+cargo fmt              # apply
+cargo fmt -- --check   # verify (CI gate)
+```
+
+## Docs
+
+```bash
+RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace
+```
+
 ## License
 
 Licensed under the GNU Lesser General Public License v3.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

PR 4 (final) of the agent-docs cleanup pass — quality-of-life polish.

- **C3** README: add **Format** (\`cargo fmt\` / \`cargo fmt -- --check\`) and **Docs** (\`RUSTDOCFLAGS=… cargo doc …\`) sections. README now lists every gate CI enforces. Skipped the inline framework code example — too easy to write something that looks right but doesn't compile.
- **C4** AGENTS.md: explicit commit-safety bullets. Never \`git add -A\` / \`git add .\` (pulls in unintended files like IDE state), never \`git commit --no-verify\` (skips hooks). Both were implicit in the system prompt but missing from project rules — the recent PRs already followed both, just uncodified.
- **C6** AGENTS.md: extend \`learnings.md\` category list with \`documentation\` and \`tooling\`. Earlier corrections about doc tooling and CI sat ambiguously under \`code-style\` / \`process\`.
- **D1** PreToolUse branch-block hook: print the full recovery procedure inline (stash → branch → soft reset on master → pop stash on feature branch) rather than only pointing at AGENTS.md. Faster recovery, fewer round-trips when an agent hits the block.

Skipped from the original plan: **D3** (split AGENTS.md "Code Style" into subsections) — bikeshedding without strong impact.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`python3 -m json.tool .claude/settings.json\` validates after the hook update
- [x] No production source files touched
- [x] Branch is not \`master\` before push
- [x] Diff stat: 3 files, +17/-2

## Wrap-up

After this merges, the agent-docs cleanup pass (PRs #20, #21, #22, this) is complete. Remaining items from the original audit (B5 partial — done; D2 — code-review reuses self-review awkwardly; D5 — done/ growth; D6 — Cargo.toml metadata) are either already addressed or premature.