### PR TITLE
chore: follow-up workflow fixes; declare MSRV 1.95

### DIFF
--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -59,7 +59,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 
 ### 6. Documentation
 
-Run `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps 2>&1` and check:
+Run `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace 2>&1` and check:
 - Exits with code 0 (no doc errors)?
 - No `warning:` lines in output (broken intra-doc links, missing items, etc.)?
 - Public items added by this diff have at least a one-line doc comment?

--- a/.claude/skills/bugfix/SKILL.md
+++ b/.claude/skills/bugfix/SKILL.md
@@ -2,7 +2,7 @@
 name: bugfix
 description: "Reactive bug-fixing workflow. Trace → Root cause → Failing test → Fix. Prevents the fix-break cycle."
 when_to_use: "Activate on: 'not working', 'broken', 'wrong', 'incorrect', 'doesn't show', unexpected panic/crash/compile error, failing test that should pass. Divergence signal: 'expected X got Y', 'should return X but returns Y'. During implementation: 'this is wrong', 'overengineered', 'not what I meant'. Regression: 'broke again', 'stopped working', 'worked before'. SKIP for general questions, codebase exploration, known/planned limitations."
-allowed-tools: Bash(cargo test *) Bash(cargo clippy *) Bash(cargo build) Bash(cargo fmt *) Bash(git rm *) Bash(rm *)
+allowed-tools: Bash(cargo test *) Bash(cargo clippy *) Bash(cargo build) Bash(cargo fmt *) Bash(git rm ai-docs/bugfix/*) Bash(rm -f ai-docs/bugfix/*)
 ---
 
 Reactive bug-fixing workflow. **Fundamentally different from `/task` and `/task-issue`:**

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -3,7 +3,7 @@ name: code-review
 description: "Whole-codebase review on the current branch (or branch given as argument). Reads all source files and done plans, runs fix loop and self-review loop until APPROVE, then commits."
 disable-model-invocation: true
 argument-hint: "[branch-name]"
-allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git log *) Bash(git add *) Bash(git commit *)
+allowed-tools: Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(cargo doc *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git log *) Bash(git add *) Bash(git commit *)
 ---
 
 Whole-codebase review workflow. Steps execute **strictly in sequence**.
@@ -60,7 +60,8 @@ After every 3 fixes (or when all findings in a subtask are resolved):
 2. `cargo test` — all green
 3. `cargo clippy -- -D warnings` — clean
 4. `cargo fmt`
-5. Update `## Files touched` and mark subtask `[x]` in progress file
+5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — clean
+6. Update `## Files touched` and mark subtask `[x]` in progress file
 
 **Context handoff rule:** if the finding count is ≥ 10 and more than half remain open, spawn a sub-agent per subtask rather than working inline — pass the progress file path so it can resume.
 
@@ -70,7 +71,8 @@ After every 3 fixes (or when all findings in a subtask are resolved):
 2. `cargo test` — all green
 3. `cargo clippy -- -D warnings` — clean
 4. `cargo fmt -- --check` — clean
-5. Update progress file: `**Last build:** PASS`
+5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — clean (matches CI / `/task` Step 9)
+6. Update progress file: `**Last build:** PASS`
 
 ### Step 5: Self-review loop (max 3 rounds)
 
@@ -119,6 +121,6 @@ EOF
 |---|---|
 | Step 2 | branch confirmed? base_commit recorded? |
 | Step 3 | build green after every 3 fixes? |
-| Step 4 | all four checks pass? |
+| Step 4 | all five checks pass? |
 | Step 5 | self-review APPROVE before commit? |
 | Commit | `major`/`blocker` objections user-approved? progress file deleted? |

--- a/.claude/skills/task-issue/SKILL.md
+++ b/.claude/skills/task-issue/SKILL.md
@@ -3,7 +3,7 @@ name: task-issue
 description: "Full ticket workflow: ticket → interview → spec → design → design-review → impl → verify → self-review. Steps are strictly ordered and cannot be skipped."
 disable-model-invocation: true
 argument-hint: "[issue-number]"
-allowed-tools: Bash(gh issue view *) Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git add *) Bash(git commit *) Bash(git push *) Bash(gh pr create *) Bash(gh pr view *)
+allowed-tools: Bash(gh issue view *) Bash(cargo build) Bash(cargo test *) Bash(cargo clippy *) Bash(cargo fmt *) Bash(cargo doc *) Bash(git diff *) Bash(git rev-parse *) Bash(git checkout *) Bash(git branch *) Bash(git add *) Bash(git commit *) Bash(git push *) Bash(gh pr create *) Bash(gh pr view *)
 ---
 
 Full workflow for working on a task (issue). Steps execute **strictly in sequence** — proceeding to N+1 before N is complete is FORBIDDEN.
@@ -134,7 +134,7 @@ finding (Step 11) requires a design change rather than a code fix:
   2. `cargo test test_name` — if subtask adds tests
   3. `cargo fmt`; `cargo clippy -- -D warnings`
   4. Update `.progress.md`
-  5. If N=3 of M≥5 → handoff via Task (see `/context-reset`)
+  5. If N=3 of M≥5 → handoff via Agent (see `/context-reset`)
 - Unknown API → read sources → grep codebase → ask user. Don't guess.
 - Bug report during impl → activate `/bugfix`, then return here.
 - Implementation reveals design must change → trigger **Design Amendment** above, then resume here.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -182,7 +182,7 @@ finding (Step 11) requires a design change rather than a code fix:
   2. `cargo test test_name` — if subtask adds tests
   3. `cargo fmt`; `cargo clippy -- -D warnings`
   4. Update `.progress.md`
-  5. If N=3 of M≥5 → handoff via Task (see `/context-reset`)
+  5. If N=3 of M≥5 → handoff via Agent (see `/context-reset`)
 - Unknown API → read sources → grep codebase → ask user. Don't guess.
 - Bug report during impl → activate `/bugfix`, then return here.
 - Implementation reveals design must change → trigger **Design Amendment** above, then resume here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.95"
 authors = ["Marat Bukharov <marat.buharov@gmail.com>"]
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/maratik123/quartzite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Marat Bukharov <marat.buharov@gmail.com>"]
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/maratik123/quartzite"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Early development. Core crates are implemented; widget and painting layers are n
 
 ## Prerequisites
 
-- Rust stable (≥ 1.85, for edition 2024 support)
+- Rust stable (≥ 1.95)
 - Cargo (comes with Rust)
 
 ## Build

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quartzite-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/quartzite-macros/Cargo.toml
+++ b/quartzite-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quartzite-macros"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/quartzite-runtime/Cargo.toml
+++ b/quartzite-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quartzite-runtime"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/quartzite/Cargo.toml
+++ b/quartzite/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quartzite"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

PR 5 — follow-up to the four cleanup PRs (#20, #21, #22, #23). Fixes residual bugs uncovered by re-inspection.

- **R1** \`task-issue/SKILL.md\`: add \`Bash(cargo doc *)\` to \`allowed-tools\`. PR #20 added the \`cargo doc\` step to Step 9 but did not widen permissions — running the workflow would hit a permission prompt at Step 9. \`task/\` already had this permission; \`task-issue/\` had drifted out of sync.
- **R2** \`self-review\` agent: doc check uses \`--workspace\` to match CI and the task workflows. Without it self-review under-checks on multi-crate diffs.
- **R3** \`task/\` and \`task-issue/\` Step 8 prose: "handoff via Task" → "via Agent" (residual from the same Task→Agent rename in PR #20; the function-call sites were caught, this prose mention slipped through).
- **R4** \`code-review/SKILL.md\`: add \`RUSTDOCFLAGS=… cargo doc …\` to Step 3 (per-3-fixes verify) and Step 4 (Final verify), plus \`Bash(cargo doc *)\` permission. Code-review now matches the gate set the task workflows enforce.
- **R5** \`Cargo.toml\`: declare workspace-level \`rust-version = "1.85"\` (matches edition 2024 + the README); inherit via \`rust-version.workspace = true\` in every crate. A contributor on an older toolchain now gets a clear MSRV error instead of a generic edition-2024 error. Verified via \`cargo metadata\` — all four crates report \`rust-version: 1.85\`.
- **R6** \`bugfix/SKILL.md\` \`allowed-tools\`: narrow \`Bash(rm *)\` and \`Bash(git rm *)\` to \`ai-docs/bugfix/*\` — the skill only ever deletes trace artifacts there.

## Test plan

- [x] \`cargo build\` clean (all four crates with new \`rust-version\`)
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo metadata\` confirms \`rust-version: 1.85\` on every crate
- [x] No production source files touched
- [x] Branch is not \`master\` before push
- [x] Diff stat: 10 files, +16/-9