### PR TITLE
chore(security): enforce .env / secrets denies; clarify permission tiers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,19 @@
     "deny": [
       "Read(.idea/**)",
       "Edit(.idea/**)",
-      "Write(.idea/**)"
+      "Write(.idea/**)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Read(**/secrets*)",
+      "Read(**/.secrets*)",
+      "Edit(**/secrets*)",
+      "Edit(**/.secrets*)",
+      "Write(**/secrets*)",
+      "Write(**/.secrets*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,21 @@
 
 ## Permissions
 
-Enforced by `settings.json`. Intent:
+Enforced by `settings.json`:
 
-**ALLOW:** project files, `git`, `cargo`, `gh`, `~/.claude`
-**DENY:** `.env`, `secrets*`, `git push --force`, files outside project
-**ASK:** any tool not listed above; if access denied — suggest an alternative
+- **ALLOW:** Edit/Write under project root, `~/.claude`, `.claude`; `Bash(cargo *)`, `Bash(git *)`, `Bash(gh *)`
+- **DENY (machine-blocked):** `.idea/**`; `.env` and `.env.*` (any depth); `secrets*` and `.secrets*` (any depth) — read/edit/write all blocked
+
+Enforced server-side:
+
+- **DENY:** `git push --force` to `master` — branch protection on `origin`
+
+Honor-system (no machine check; rule still binding):
+
+- **DENY:** `git push --force` to feature branches — prefer `--force-with-lease` and only after explicit user approval
+- **DENY:** files outside project root
+
+**ASK:** any tool not listed above; if access denied — suggest an alternative.
 
 On session start: read `.gitignore`, treat matched paths as a read blacklist.
 


### PR DESCRIPTION
## Summary

R7 from the latest re-inspection. AGENTS.md listed \`.env\`, \`secrets*\`, and \`git push --force\` as **DENY** — but \`settings.json\` only enforced the \`.idea/\` deny. The other rules were honor-system without saying so. This PR plugs the two cheap holes and labels the rest honestly.

### \`settings.json\` — machine-blocked denies (new)

Reads/edits/writes blocked at the harness layer for any path matching:

- \`**/.env\` — the file itself, root or nested
- \`**/.env.*\` — \`.env.local\`, \`.env.production\`, etc.
- \`**/secrets*\` — \`secrets\`, \`secrets.json\`, \`secrets/\`, \`secrets-prod.json\`
- \`**/.secrets*\` — hidden variants

Why reads matter as much as writes: a leaked secret only has to enter the conversation once to land in API logs / cache for as long as the provider keeps them.

### \`AGENTS.md\` — three permission tiers

Old: one DENY list mixing enforced and honor-system rules.
New:
1. **Enforced by \`settings.json\`** (machine-blocked)
2. **Enforced server-side** (\`git push --force\` to master — branch protection at origin)
3. **Honor-system** (\`git push --force\` to feature branches; files outside project root)

### Why no client-side force-push hook?

\`master\` is already protected server-side. On feature branches \`--force-with-lease\` is sometimes the right tool (after user approval). A blanket PreToolUse hook would create false positives without giving real safety beyond branch protection.

## Test plan

- [x] \`python3 -m json.tool .claude/settings.json\` — JSON valid
- [x] \`git ls-files | grep -E '(^|/)(\\.env|\\.env\\.|secrets|\\.secrets)'\` — no tracked file accidentally matches the new denies
- [x] \`cargo build\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] Branch is not \`master\` before push
- [x] Diff stat: 2 files, +27/-5