### PR TITLE
chore(agents): add Communication rules; escalate memory-only entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files.
 - `.gitignore` (not `.arcignore`).
 
+## Communication
+
+Interpret user phrasing literally and conservatively. When uncertain — ask, don't guess.
+
+- **"Submit / push to PR"** = `git push` the branch to remote so commits appear in the open PR. **NOT** `gh pr merge`. Only merge when the user explicitly says "merge" or "merge the PR".
+- **"wtf?" / "what?" / "huh?"** (or similar surprise/frustration) = the previous action was the opposite of what the user wanted. **Stop immediately**, do not retry, ask what was wrong before doing anything else.
+- **IDE files** (`.idea/`, `*.iml`, `.vscode/`, `*.swp`, etc.) — never add, remove, modify, stage, or `.gitignore` them unless the user explicitly asks. They are the user's domain. "add ide files" most likely means **commit and track them**, not gitignore them — confirm before acting.
+
 ## Agent Docs
 
 | Path | Purpose |

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -14,7 +14,7 @@
 
 **Rule:** Never add, remove, modify, or `.gitignore` IDE files (`.idea/`, `*.iml`, `.vscode/`, etc.) unless the user explicitly asks. Treat them as the user's domain.
 
-**Escalated?** memory
+**Escalated?** AGENTS.md, memory
 
 ### 2026-05-02 — process — "submit to PR" means push to remote, not merge
 
@@ -22,7 +22,7 @@
 
 **Rule:** "Submit to PR" (and similar: "push to PR", "add to PR") means `git push` the branch to remote. It does not mean merging. Only merge when the user explicitly says "merge" or "merge the PR".
 
-**Escalated?** memory
+**Escalated?** AGENTS.md, memory
 
 ### 2026-05-02 — process — "wtf" signals that the previous action was wrong
 
@@ -30,7 +30,7 @@
 
 **Rule:** "wtf" (and similar expressions of surprise/frustration) means the last action was the opposite of what the user wanted. Stop immediately, ask what went wrong, and do not proceed until the intent is clarified.
 
-**Escalated?** memory
+**Escalated?** AGENTS.md, memory
 
 ### 2026-05-02 — process — never use git reset --hard; use soft reset, stash, cherry-pick, or backup branch
 


### PR DESCRIPTION
## Summary
- Adds a new `## Communication` section to `AGENTS.md` covering three user-phrasing rules previously held only in personal/global memory
- Marks the corresponding entries in `ai-docs/learnings.md` (L2/L3/L4) as `AGENTS.md, memory` to record the project-level escalation
- Result of `/improve` run on 2026-05-02 — three memory-only entries crossed the ≥2-occurrence threshold and were not visible to subagents that don't load global memory

## Rules added
- **"Submit / push to PR"** = `git push`, not `gh pr merge`
- **"wtf?" / "what?" / "huh?"** = stop, do not retry, ask what was wrong
- **IDE files** (`.idea/`, `*.iml`, `.vscode/`, `*.swp`, …) — never modify or `.gitignore` them unless explicitly asked

## Test plan
- [x] Eval: a fresh general-purpose agent in a clean context loaded `AGENTS.md` and answered three reproduction scenarios correctly (push, stop+ask, confirm-before-act)
- [x] No source code touched; docs/markdown only — no `cargo` gates apply