### PR TITLE
chore: remove explicit framework name references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - **All source files must be Rust (`.rs`).** No other languages in `src/`.
 - Max line: 100 (rustfmt default).
 - Strict clippy (enforced).
-- Prefer Rust idioms over literal C++ ports. When in doubt, ask.
+- Prefer Rust idioms over literal ports from other languages. When in doubt, ask.
 - Let chains (`if let A = x && let B = y { ... }`) are valid in this codebase (edition 2024). Do not avoid them. Always format via `cargo fmt`, never `rustfmt <file>` directly.
 - **Documentation:** Every crate must have `#![deny(missing_docs)]` in its `lib.rs`. Every public item must have at least a one-line `///` doc comment. Every new public item with only a single-line doc must include a `# Examples` block. Proc-macro examples use `no_run`; runtime items needing an event loop use `no_run`; pure library types use compiling doctests.
 - **`#[inline]`:** Add `#[inline]` to every simple, non-generic function: no branches or loops, at most one function call, no binary bloat. Typical targets: field getters (`self.field`), trivial wrappers (`.as_deref()`, single delegation call), `Default::default()` that calls `Self::new()`, `const fn` struct-literal constructors. **Exclude** generic functions and blanket-impl trait methods — the compiler already has their bodies via monomorphization. Apply the same rule in proc-macro codegen: emit `#[inline]` before each simple generated `fn`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # quartzite
 
-A GUI and object framework for Rust. Inspired by the design principles of Qt — signals/slots,
-a rich object model, and a declarative UI layer — but implemented as idiomatic Rust with no C++
-dependency, no foreign ABI, and no code generation outside of proc macros.
+A GUI and object framework for Rust built around signals/slots,
+a rich object model, and a declarative UI layer — implemented as idiomatic Rust with no native
+dependencies, no foreign ABI, and no code generation outside of proc macros.
 
 ## Status
 

--- a/ai-docs/context.md
+++ b/ai-docs/context.md
@@ -37,7 +37,7 @@ Python interop (`quartzite-python` via PyO3) is **deferred** — the reflection 
 ## Out of Scope
 
 - Binary/ABI compatibility with other frameworks
-- C++ single-inheritance model — replaced by traits + composition
+- Single-inheritance model — replaced by traits + composition
 - External code generation — replaced by proc macros
 - Declarative/scripting layer — not a goal for v1; deferred
 

--- a/ai-docs/plans/done/2026-05-01-auto-connection.spec.md
+++ b/ai-docs/plans/done/2026-05-01-auto-connection.spec.md
@@ -36,7 +36,7 @@ the receiver's `thread_id` (captured at connect time). If same thread → behave
 | API surface | `ConnectionType::Auto` variant, not a separate `connect_auto()` method |
 | Same-thread behavior | Direct — slot called synchronously with `&Args` |
 | Cross-thread behavior | Queued — `Args` cloned, posted to `QueuedDispatcher` |
-| No dispatcher | Silent drop — Qt-compatible, consistent with existing `Queued` behavior |
+| No dispatcher | Silent drop — consistent with existing `Queued` behavior |
 | `thread_id` timing | Captured at connect time from `receiver.object_base().thread_id` |
 | `no_std` policy | Compile error — `Auto` variant `#[cfg(feature = "std")]` only |
 


### PR DESCRIPTION
## Summary

- Remove Qt mentions from `README.md` and `ai-docs/plans/done/2026-05-01-auto-connection.spec.md`
- Remove C++ mentions from `README.md`, `AGENTS.md`, and `ai-docs/context.md`
- Rephrase descriptions to be language-neutral and concept-focused

## Test plan

- [ ] No Qt or C++ references remain in project files
- [ ] README intro clearly describes the framework concepts without naming other frameworks
- [ ] AGENTS.md code style guidance is still accurate and actionable