### PR TITLE
feat(examples): add quartzite-examples crate with four runnable examples

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -37,7 +37,7 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 - Lifetime / ownership: surprising footguns for callers?
 
 ### 3. Test coverage
-- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block?
+- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exception: files under `quartzite-examples/examples/` are runnable demos — no test block required)
 - Tests cover edge cases and error paths, not just the happy path?
 - Any test that would pass even if the production code were deleted (cosmetic test)?
 - Integration tests for public-facing macro output?

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -39,7 +39,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 
 ### 3. Test coverage
 - Every non-trivial function / branch has a test?
-- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block?
+- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exception: files under `quartzite-examples/examples/` are runnable demos — no test block required)
 - Tests verify invariants, not cosmetics?
   - Mental test: comment out the production fix → does the test fail? If not → cosmetic → **REJECT**
 - No `unwrap()` in tests without justification?
@@ -63,7 +63,7 @@ Run `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace 
 - Exits with code 0 (no doc errors)?
 - No `warning:` lines in output (broken intra-doc links, missing items, etc.)?
 - Public items added by this diff have at least a one-line doc comment?
-- Every crate that has new public items also has `#![deny(missing_docs)]` in its `lib.rs`?
+- Every crate that has new public items also has `#![deny(missing_docs)]` in its `lib.rs`? (Exception: `quartzite-examples` — examples-only crate with no public library items)
 - Every new public item with only a single-line doc has a `# Examples` block?
 
 On any error or warning → REJECT with the exact rustdoc message as the finding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - Strict clippy (enforced).
 - Prefer Rust idioms over literal ports from other languages. When in doubt, ask.
 - Let chains (`if let A = x && let B = y { ... }`) are valid in this codebase (edition 2024). Do not avoid them. Always format via `cargo fmt`, never `rustfmt <file>` directly.
-- **Documentation:** Every crate must have `#![deny(missing_docs)]` in its `lib.rs`. Every public item must have at least a one-line `///` doc comment. Every new public item with only a single-line doc must include a `# Examples` block. Proc-macro examples use `no_run`; runtime items needing an event loop use `no_run`; pure library types use compiling doctests.
+- **Documentation:** Every crate must have `#![deny(missing_docs)]` in its `lib.rs`. Every public item must have at least a one-line `///` doc comment. Every new public item with only a single-line doc must include a `# Examples` block. Proc-macro examples use `no_run`; runtime items needing an event loop use `no_run`; pure library types use compiling doctests. **Exception:** `quartzite-examples` is exempt from `#![deny(missing_docs)]` — it is an examples-only crate with no public library items.
 - **`#[inline]`:** Add `#[inline]` to every simple, non-generic function: no branches or loops, at most one function call, no binary bloat. Typical targets: field getters (`self.field`), trivial wrappers (`.as_deref()`, single delegation call), `Default::default()` that calls `Self::new()`, `const fn` struct-literal constructors. **Exclude** generic functions and blanket-impl trait methods — the compiler already has their bodies via monomorphization. Apply the same rule in proc-macro codegen: emit `#[inline]` before each simple generated `fn`.
 
 ## Workflow
@@ -62,7 +62,7 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - Stage files explicitly by name. **Never** use `git add -A` or `git add .` — they pull in unintended files (IDE state, accidental scratch files). The diff stat in PR 1–3 was cleanly scoped because every file was named.
 - **Never** use `git commit --no-verify` (or any other hook-skipping flag). If a hook fails, fix the underlying issue.
 - Plan first. Tests before prod code (TDD). Lint changed files.
-- Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files.
+- Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files. **Exception:** files under `quartzite-examples/examples/` are runnable demos, not library code — no `#[cfg(test)]` block required.
 - `.gitignore` (not `.arcignore`).
 
 ## Communication

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "quartzite-examples"
+version = "0.1.0"
+dependencies = [
+ "quartzite",
+ "quartzite-core",
+]
+
+[[package]]
 name = "quartzite-macros"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "quartzite",
     "quartzite-core",
+    "quartzite-examples",
     "quartzite-macros",
     "quartzite-runtime",
 ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Early development. Core crates are implemented; widget and painting layers are n
 | `quartzite-core` | ✅ implemented |
 | `quartzite-macros` | ✅ implemented |
 | `quartzite-runtime` | ✅ implemented |
+| `quartzite-examples` | ✅ runnable examples: `hello_object`, `signals_slots`, `object_tree`, `timer` |
 | `quartzite-geometry` / `quartzite-events` | planned |
 | `quartzite-widgets` | planned |
 | `quartzite-paint` / `quartzite-style` | planned |

--- a/ai-docs/context.md
+++ b/ai-docs/context.md
@@ -115,15 +115,17 @@ Crate-level plans:
 1. `quartzite-core` — core types + traits + signal + value ✅
 2. `quartzite-macros` — Extend + Object + object_impl derive macros ✅
 3. `quartzite-runtime` — Application, EventLoop, ObjectTree ✅
-4. `quartzite` (facade) — prelude re-exports, Cargo metadata, docs.rs config ✅
-5. `quartzite-geometry` + `quartzite-events` — geometry primitives + event model
-6. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
-7. `quartzite-paint` + `quartzite-style` — painter + theming
+4. `quartzite` (facade) — prelude re-exports, sub-crate re-exports, Cargo metadata, docs.rs config ✅
+5. `quartzite-examples` — runnable API examples (hello_object, signals_slots, object_tree, timer) ✅
+6. `quartzite-geometry` + `quartzite-events` — geometry primitives + event model
+7. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
+8. `quartzite-paint` + `quartzite-style` — painter + theming
 
-Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns).
+Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns), examples-crate (runnable API examples).
 
 ## Open Questions
 
 - Async/await integration strategy
 - Accessibility (a11y) support
 - No-std support scope (core only, or further?)
+- **`proc_macro_crate` ergonomics:** `quartzite-macros` codegen emits `::quartzite_core::` absolute paths, requiring `quartzite-core` as a direct dep in any crate that uses the macros — even if the user already depends on the `quartzite` facade. Using `proc_macro_crate` at expansion time to detect whether the user has `quartzite` or `quartzite_core` (or both) would allow true single-dep usage. Deferred; non-trivial to implement.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -99,6 +99,14 @@ Note: `code-review` is a **skill** (user-facing workflow); `review-findings` and
 
 **Escalated?** agent:self-review, agent:review-findings, skill:task, skill:task-issue, skill:code-review
 
+### 2026-05-02 — process — propagate rule exemptions to agent/skill files in same task
+
+**What happened:** When adding `quartzite-examples` exemptions to `AGENTS.md` (no `#![deny(missing_docs)]`, no `#[cfg(test)]`), the corresponding checks in `.claude/agents/self-review.md` and `.claude/agents/review-findings.md` were not updated. Future reviews would have incorrectly flagged the examples crate.
+
+**Rule:** When a rule exemption is added to `AGENTS.md`, immediately propagate it to every agent/skill/settings file that enforces that rule. Check with `grep` across `.claude/agents/` and `.claude/skills/` before closing the task.
+
+**Escalated?** no
+
 ### 2026-05-02 — process — check current branch before committing, not only before pushing
 
 **What happened:** For the `docs/learnings-and-skill-fix` branch, commits were made directly to local master without checking `git branch --show-current` first. The error was caught at push time (branch protection rejected the push), not at commit time. The rule in AGENTS.md mentions checking before `git push`, but the correct mental model is: verify branch before `git commit`.

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -16,6 +16,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [public-api-docs](done/2026-05-02-public-api-docs.spec.md) | all crates | ✅ implemented (47 new doctests) | — |
 | [lookup-perf](done/2026-05-02-lookup-perf.spec.md) | `quartzite-core` `quartzite-macros` `quartzite-runtime` | ✅ implemented (21 new tests) | — |
 | [inline-simple-fns](done/2026-05-02-inline-simple-fns.spec.md) | all crates | ✅ implemented (8 new tests) | — |
+| [examples-crate](done/2026-05-02-examples-crate.spec.md) | `quartzite-examples` `quartzite` | ✅ implemented (0 new tests; 4 runnable examples) | — |
 
 ## Deferred plans
 
@@ -49,3 +50,4 @@ Maintenance plans (cross-cutting, all ✅): code-quality-cleanup, docs-and-facad
 3. Any future PR adding public items must satisfy `#![deny(missing_docs)]` + `# Examples` (enforced by CI and self-review checklist)
 4. Match-based lookups are in place for properties/signals/methods/enums; enum lookup (`#[object_impl]` generates noop) could be wired up to `#[meta_enum]`-annotated enums when widgets land
 5. `#[inline]` rule is enforced by AGENTS.md and review agents; new simple non-generic functions must carry the attribute
+6. `proc_macro_crate` ergonomics: macro users currently need both `quartzite` and `quartzite-core` as direct deps; using `proc_macro_crate` in `quartzite-macros` would enable true single-dep usage

--- a/ai-docs/plans/done/2026-05-02-examples-crate.design.md
+++ b/ai-docs/plans/done/2026-05-02-examples-crate.design.md
@@ -1,0 +1,258 @@
+# Design: Examples Crate
+
+**Issue:** user description
+**Date:** 2026-05-02
+
+## Approach
+
+Create a new workspace member `quartzite-examples` with four binary examples under an
+`examples/` directory. Each example is a self-contained runnable program demonstrating a
+distinct part of the public API.
+
+**Macro dep requirement:** `quartzite-macros` codegen emits `::quartzite_core::` absolute
+paths in all generated `impl` blocks. These resolve against the *user's* extern prelude —
+so `quartzite-core` must be a direct dependency of any crate that uses the macros. This is
+not a bug; it is the standard Rust proc-macro pattern. Future work with `proc_macro_crate`
+could detect the right path at expansion time and lift this requirement, but that is deferred.
+
+**Facade re-exports:** `quartzite/src/lib.rs` adds `pub use quartzite_core;` and
+`pub use quartzite_runtime;`. Rationale:
+- Users can reference types as `quartzite::quartzite_core::X` without an extra dep.
+- Type identity is guaranteed when mixing facade and direct sub-crate deps in the same
+  program — `quartzite::quartzite_core::ObjectBase` is the same type as `quartzite_core::ObjectBase`.
+- Migration from facade to direct sub-crate requires only a `Cargo.toml` change.
+
+## Facade public re-export (`quartzite/src/lib.rs`)
+
+Add immediately after the `pub mod prelude` block. `#![deny(missing_docs)]` is active,
+so both re-exports must carry a `///` doc comment:
+
+```rust
+/// Re-export of [`quartzite_core`]. Provides direct access to core types and ensures
+/// type identity when mixing facade and direct sub-crate dependencies. Use
+/// `quartzite_core` directly in your `Cargo.toml` when you need the full sub-crate API.
+pub use quartzite_core;
+
+/// Re-export of [`quartzite_runtime`]. Provides direct access to runtime types and
+/// ensures type identity when mixing facade and direct sub-crate dependencies.
+pub use quartzite_runtime;
+```
+
+## `quartzite-examples` Cargo.toml
+
+```toml
+[package]
+name = "quartzite-examples"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runnable examples for the quartzite object framework"
+publish = false
+
+[dependencies]
+quartzite = { path = "../quartzite" }
+quartzite-core = { path = "../quartzite-core" }
+```
+
+- `quartzite` — prelude, runtime access (`ObjectTree`, `Application`, `Timer`, …), derive macros
+- `quartzite-core` — required for `::quartzite_core::` paths in macro-generated code
+- `quartzite-runtime` NOT needed as a direct dep — no `::quartzite_runtime::` paths appear in macro output
+- `publish = false` — not intended for crates.io
+
+Root `Cargo.toml` workspace `members` gains `"quartzite-examples"`.
+
+A minimal `src/lib.rs` satisfies Cargo's "at least one target" requirement:
+
+```rust
+//! Runnable examples for the quartzite object framework.
+//! Run with: cargo run --example <name> -p quartzite-examples
+```
+
+No public items → `missing_docs` gate satisfied.
+
+## Concrete API calls per example
+
+### `hello_object.rs`
+
+Shows `#[derive(Extend, DeriveObject)]` + `#[object_impl]`, property read/write, and
+slot invocation. Also demonstrates using `quartzite_core::ObjectBase` directly (the
+explicit import shows users they need the sub-crate dep).
+
+```rust
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Counter {
+    #[base]
+    object_base: ObjectBase,
+    #[prop(notify = count_changed)]
+    pub count: i32,
+    #[signal]
+    pub count_changed: Signal<(i32,)>,
+}
+
+#[object_impl]
+impl Counter {
+    #[slot]
+    fn reset(&mut self) { self.count = 0; }
+}
+
+fn main() {
+    let mut c = Counter { object_base: ObjectBase::new(), count: 0, count_changed: Signal::new() };
+    println!("initial count: {:?}", c.read_property("count")); // Some(Int(0))
+    c.write_property("count", Value::Int(42));
+    println!("after write:   {:?}", c.read_property("count")); // Some(Int(42))
+    c.invoke_method("reset", &[]);
+    println!("after reset:   {:?}", c.read_property("count")); // Some(Int(0))
+}
+```
+
+AC2 evidence: three `println!` lines with `Int(0)`, `Int(42)`, `Int(0)`.
+
+### `signals_slots.rs`
+
+Shows typed `Signal::connect` / `Signal::emit` and dynamic `Object::connect_signal`.
+`SignalCallback = Box<dyn Fn(&[Value]) + Send + Sync>` — bare capturing-nothing closure
+satisfies both bounds.
+
+```rust
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Greeter {
+    #[base]
+    object_base: ObjectBase,
+    #[signal]
+    pub greeted: Signal<(String,)>,
+}
+
+#[object_impl]
+impl Greeter {}
+
+fn main() {
+    let mut g = Greeter { object_base: ObjectBase::new(), greeted: Signal::new() };
+    g.greeted.connect(|args| println!("typed slot: hello, {}", args.0));
+    g.connect_signal("greeted", Box::new(|vals| {
+        println!("dynamic slot received {} value(s)", vals.len());
+    }));
+    g.greeted.emit(&(String::from("world"),));
+}
+```
+
+AC3 evidence: both `println!` lines fire on the single `emit`.
+
+### `object_tree.rs`
+
+Shows `ObjectTree::insert` with parent, `parent_of`, `children_of`, `find_by_name`, `with`.
+Uses a minimal `Node` type with no properties or signals.
+
+```rust
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Node {
+    #[base]
+    object_base: ObjectBase,
+}
+
+#[object_impl]
+impl Node {}
+
+impl Node {
+    fn named(name: &str) -> Self { Self { object_base: ObjectBase::named(name) } }
+}
+
+fn main() {
+    let mut tree = ObjectTree::new();
+    let root_id  = tree.insert(Box::new(Node::named("root")),       None);
+    let child_id = tree.insert(Box::new(Node::named("child")),      Some(root_id));
+    let _gid     = tree.insert(Box::new(Node::named("grandchild")), Some(child_id));
+    println!("parent of child:   {:?}", tree.parent_of(child_id));
+    println!("children of root:  {:?}", tree.children_of(root_id));
+    println!("find 'grandchild': {:?}", tree.find_by_name("grandchild"));
+    tree.with(root_id, |obj| println!("root name: {:?}", obj.object_base().name()));
+}
+```
+
+AC4 evidence: four `println!` lines showing parent ID, children slice, found-by-name, name.
+
+### `timer.rs`
+
+Shows `Application::new`, `Timer::new`, `Timer::connect_timeout`, `Timer::start`,
+`Application::exec`, `Application::quit`. Stops after 3 ticks (~150 ms) — CI safe.
+Does not use `quartzite_core` types in user code directly (no `use quartzite_core::` needed
+in this file); only the crate-level dep is required for macro codegen in the other files.
+
+```rust
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+use std::time::Duration;
+use quartzite::prelude::*;
+
+fn main() {
+    let app = Application::new().expect("only one Application per process");
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter2 = Arc::clone(&counter);
+    let mut timer = Timer::new(Duration::from_millis(50));
+    timer.connect_timeout(move |_| {
+        let n = counter2.fetch_add(1, Ordering::SeqCst) + 1;
+        println!("tick {n}");
+        if n >= 3 { Application::global().expect("app").quit(); }
+    });
+    timer.start(app.event_loop().sender());
+    app.exec();
+    println!("done after {} ticks", counter.load(Ordering::SeqCst));
+}
+```
+
+AC5 evidence: "tick 1"–"tick 3", then "done after 3 ticks".
+
+## Decomposition
+
+| # | Task | Files |
+|---|------|-------|
+| 1 | Add `quartzite-examples` to workspace `Cargo.toml` | `Cargo.toml` |
+| 2 | Create `quartzite-examples/Cargo.toml` + `src/lib.rs` | `quartzite-examples/` |
+| 3 | Add public sub-crate re-exports to `quartzite/src/lib.rs` | `quartzite/src/lib.rs` |
+| 4 | `hello_object.rs` | `quartzite-examples/examples/hello_object.rs` |
+| 5 | `signals_slots.rs` | `quartzite-examples/examples/signals_slots.rs` |
+| 6 | `object_tree.rs` | `quartzite-examples/examples/object_tree.rs` |
+| 7 | `timer.rs` | `quartzite-examples/examples/timer.rs` |
+| 8 | Update `AGENTS.md` | `AGENTS.md` |
+| 9 | Update `README.md` | `README.md` |
+| 10 | Update `ai-docs/context.md` | `ai-docs/context.md` |
+
+## Risks
+
+- **`missing_docs` on re-exports:** mitigated by `///` doc comments on both `pub use` lines.
+- **`Application` singleton in timer:** example is a separate binary — naturally isolated.
+- **Timer in CI:** bounded at 3 ticks (~150 ms), will not block CI.
+- **`quartzite-macros` tests unaffected:** codegen unchanged; no new dev-deps needed.
+
+## Test Design
+
+AC2–AC5: run each binary, verify exit code 0 and expected stdout:
+
+| Example | Expected stdout |
+|---------|-----------------|
+| `hello_object` | `Int(0)` → `Int(42)` → `Int(0)` via `read_property` |
+| `signals_slots` | Typed slot line + dynamic slot line, both from single `emit` |
+| `object_tree` | Parent ID, children slice, found-by-name IDs, root name |
+| `timer` | "tick 1"/"tick 2"/"tick 3", then "done after 3 ticks" |
+
+AC1: `cargo build`
+AC6: `cargo clippy -- -D warnings`
+AC7: `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace`
+AC8/AC9/AC10/AC11: manual file review
+
+## Open questions
+
+(none)

--- a/ai-docs/plans/done/2026-05-02-examples-crate.spec.md
+++ b/ai-docs/plans/done/2026-05-02-examples-crate.spec.md
@@ -1,0 +1,71 @@
+# Examples Crate
+
+**Source:** user description
+**Date:** 2026-05-02
+
+## Scope
+
+1. New `quartzite-examples` workspace member added to root `Cargo.toml`
+2. Four working example binaries in `examples/` directory:
+   - `hello_object.rs` — define a type with `#[derive(Object)]` + `#[prop]`, read/write a property
+   - `signals_slots.rs` — define signals, connect a slot, emit the signal, observe the call
+   - `object_tree.rs` — create objects in an `ObjectTree`, set parent/child, find by name
+   - `timer.rs` — `Application` + `EventLoop`, create a `Timer`, fire a slot on tick, stop after N ticks
+3. All examples compile and run without errors
+4. `AGENTS.md` updated to document that `quartzite-examples` is excluded from the `#![deny(missing_docs)]` rule and the `#[cfg(test)]` requirement (example targets, not library code)
+5. `README.md` updated to list `quartzite-examples` in the status table with description of available examples
+6. `quartzite/src/lib.rs` publicly re-exports `quartzite_core` and `quartzite_runtime` as named items — gives users access via `quartzite::quartzite_core::X`, ensures type identity when mixing facade and direct sub-crate deps, and provides a clear migration path to direct deps
+7. `ai-docs/context.md` updated with an open question on `proc_macro_crate` ergonomics
+8. `.claude/agents/self-review.md` and `.claude/agents/review-findings.md` updated with `quartzite-examples` exemptions so future reviews don't flag missing `#[cfg(test)]` or `#![deny(missing_docs)]` incorrectly
+
+## Out of scope
+
+- Examples for unimplemented crates (geometry, events, widgets, paint, style)
+- Unit tests inside example files
+- Python interop examples
+- Changing `quartzite-macros` codegen (deferred — `proc_macro_crate` is a separate future task)
+
+## Deferred
+
+- Examples for geometry-events, widgets, paint-style | those crates not yet implemented
+- `proc_macro_crate` based path detection in `quartzite-macros` | would let users depend on only `quartzite` or only `quartzite-core`; non-trivial, separate task
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Crate name | `quartzite-examples` |
+| Binary structure | `examples/` directory — run via `cargo run --example <name> -p quartzite-examples` |
+| Macro user deps | `quartzite` + `quartzite-core` both required — macros emit `::quartzite_core::` paths that require the sub-crate as a direct dep regardless of facade presence |
+| Facade re-exports | `pub use quartzite_core;` + `pub use quartzite_runtime;` — public API, not a workaround; ensures type identity and easy migration |
+| "One-dep facade" | Not claimed — the facade is a prelude convenience and stable re-export surface; dep reduction requires future `proc_macro_crate` work |
+| `missing_docs` gate | `quartzite-examples` exempted — minimal `src/lib.rs` with crate doc comment, no public items |
+| `#[cfg(test)]` requirement | Exempted for example files — they are short runnable demos |
+
+## Technical constraints
+
+- Must compile with `cargo build` (workspace)
+- Must pass `cargo clippy -- -D warnings` (all crates)
+- Must pass `cargo fmt -- --check`
+- `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` must remain clean
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `cargo build` in workspace root succeeds with `quartzite-examples` included |
+| AC2 | `cargo run --example hello_object -p quartzite-examples` runs and exits cleanly, printing evidence of property read/write |
+| AC3 | `cargo run --example signals_slots -p quartzite-examples` runs and exits cleanly, printing evidence that a slot was called |
+| AC4 | `cargo run --example object_tree -p quartzite-examples` runs and exits cleanly, printing evidence of parent/child and name lookup |
+| AC5 | `cargo run --example timer -p quartzite-examples` runs, fires at least one tick, prints evidence, then stops and exits cleanly |
+| AC6 | `cargo clippy -- -D warnings` passes for all workspace crates |
+| AC7 | `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` passes |
+| AC8 | `AGENTS.md` documents the `quartzite-examples` exclusion from `#![deny(missing_docs)]` and `#[cfg(test)]` rules |
+| AC9 | `README.md` lists `quartzite-examples` in the status table with description of available examples |
+| AC10 | `quartzite::quartzite_core` and `quartzite::quartzite_runtime` are accessible as public items in the `quartzite` facade |
+| AC11 | `ai-docs/context.md` records `proc_macro_crate` ergonomics as an open question |
+| AC12 | `.claude/agents/self-review.md` and `.claude/agents/review-findings.md` carry the `quartzite-examples` exemption for `#[cfg(test)]` and `#![deny(missing_docs)]` checks |
+
+## Open questions
+
+(none — `proc_macro_crate` is captured as deferred)

--- a/quartzite-examples/Cargo.toml
+++ b/quartzite-examples/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "quartzite-examples"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runnable examples for the quartzite object framework"
+publish = false
+
+[dependencies]
+quartzite = { path = "../quartzite" }
+quartzite-core = { path = "../quartzite-core" }

--- a/quartzite-examples/examples/hello_object.rs
+++ b/quartzite-examples/examples/hello_object.rs
@@ -1,0 +1,34 @@
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Counter {
+    #[base]
+    object_base: ObjectBase,
+    #[prop(notify = count_changed)]
+    pub count: i32,
+    #[signal]
+    pub count_changed: Signal<(i32,)>,
+}
+
+#[object_impl]
+impl Counter {
+    #[slot]
+    fn reset(&mut self) {
+        self.count = 0;
+    }
+}
+
+fn main() {
+    let mut c = Counter {
+        object_base: ObjectBase::new(),
+        count: 0,
+        count_changed: Signal::new(),
+    };
+    println!("initial count: {:?}", c.read_property("count")); // Some(Int(0))
+    c.write_property("count", Value::Int(42));
+    println!("after write:   {:?}", c.read_property("count")); // Some(Int(42))
+    c.invoke_method("reset", &[]);
+    println!("after reset:   {:?}", c.read_property("count")); // Some(Int(0))
+}

--- a/quartzite-examples/examples/object_tree.rs
+++ b/quartzite-examples/examples/object_tree.rs
@@ -1,0 +1,36 @@
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Node {
+    #[base]
+    object_base: ObjectBase,
+}
+
+#[object_impl]
+impl Node {}
+
+impl Node {
+    #[inline]
+    fn named(name: &str) -> Self {
+        Self {
+            object_base: ObjectBase::named(name),
+        }
+    }
+}
+
+fn main() {
+    let mut tree = ObjectTree::new();
+
+    let root_id = tree.insert(Box::new(Node::named("root")), None);
+    let child_id = tree.insert(Box::new(Node::named("child")), Some(root_id));
+    let _grand_id = tree.insert(Box::new(Node::named("grandchild")), Some(child_id));
+
+    println!("parent of child:   {:?}", tree.parent_of(child_id));
+    println!("children of root:  {:?}", tree.children_of(root_id));
+    println!("find 'grandchild': {:?}", tree.find_by_name("grandchild"));
+    tree.with(root_id, |obj| {
+        println!("root name:         {:?}", obj.object_base().name());
+    });
+}

--- a/quartzite-examples/examples/signals_slots.rs
+++ b/quartzite-examples/examples/signals_slots.rs
@@ -1,0 +1,33 @@
+use quartzite::prelude::*;
+use quartzite_core::ObjectBase;
+
+#[derive(Extend, DeriveObject)]
+#[root]
+struct Greeter {
+    #[base]
+    object_base: ObjectBase,
+    #[signal]
+    pub greeted: Signal<(String,)>,
+}
+
+#[object_impl]
+impl Greeter {}
+
+fn main() {
+    let mut g = Greeter {
+        object_base: ObjectBase::new(),
+        greeted: Signal::new(),
+    };
+
+    // Typed connect: direct field access, compile-time argument types.
+    g.greeted
+        .connect(|args| println!("typed slot: hello, {}", args.0));
+
+    // Dynamic connect: runtime dispatch via Object trait, args as &[Value].
+    g.connect_signal(
+        "greeted",
+        Box::new(|vals| println!("dynamic slot received {} value(s)", vals.len())),
+    );
+
+    g.greeted.emit(&(String::from("world"),));
+}

--- a/quartzite-examples/examples/timer.rs
+++ b/quartzite-examples/examples/timer.rs
@@ -1,0 +1,28 @@
+use quartzite::prelude::*;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+
+fn main() {
+    let app = Application::new().expect("only one Application per process");
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter2 = Arc::clone(&counter);
+
+    let mut timer = Timer::new(Duration::from_millis(50));
+    timer.connect_timeout(move |_| {
+        let n = counter2.fetch_add(1, Ordering::SeqCst) + 1;
+        println!("tick {n}");
+        if n >= 3 {
+            Application::global()
+                .expect("Application must exist")
+                .quit();
+        }
+    });
+    timer.start(app.event_loop().sender());
+
+    app.exec();
+    println!("done after {} ticks", counter.load(Ordering::SeqCst));
+}

--- a/quartzite-examples/src/lib.rs
+++ b/quartzite-examples/src/lib.rs
@@ -1,0 +1,11 @@
+//! Runnable examples for the quartzite object framework.
+//!
+//! Each example in the `examples/` directory is a self-contained program.
+//! Run an example with:
+//!
+//! ```text
+//! cargo run --example hello_object -p quartzite-examples
+//! cargo run --example signals_slots -p quartzite-examples
+//! cargo run --example object_tree -p quartzite-examples
+//! cargo run --example timer -p quartzite-examples
+//! ```

--- a/quartzite/src/lib.rs
+++ b/quartzite/src/lib.rs
@@ -13,6 +13,14 @@
 //! The `quartzite-macros` crate also exports `MetaEnum` for enum reflection; it
 //! is available directly from `quartzite_macros::MetaEnum` for users who need it.
 
+/// Re-export of [`quartzite_core`] for direct access to core types and as a
+/// migration target when switching from this facade to the sub-crate directly.
+pub use quartzite_core;
+
+/// Re-export of [`quartzite_runtime`] for direct access to runtime types and
+/// as a migration target when switching from this facade to the sub-crate directly.
+pub use quartzite_runtime;
+
 /// Curated set of commonly used quartzite types, re-exported for convenience.
 ///
 /// Import with `use quartzite::prelude::*;` to bring the core object model,


### PR DESCRIPTION
## Summary

- Adds `quartzite-examples` workspace member with four runnable examples demonstrating the core public API: `hello_object`, `signals_slots`, `object_tree`, `timer`
- Adds `pub use quartzite_core;` and `pub use quartzite_runtime;` to the `quartzite` facade for type-identity guarantee and easy migration from facade to direct sub-crate deps
- Documents that macro users need `quartzite-core` as a direct dep (`::quartzite_core::` paths in codegen); records `proc_macro_crate` ergonomics as an open question in `ai-docs/context.md`
- Updates `AGENTS.md`, `.claude/agents/self-review.md`, and `.claude/agents/review-findings.md` with `quartzite-examples` exemptions from `#![deny(missing_docs)]` and `#[cfg(test)]` rules

## Test plan

- [ ] AC1: `cargo build` succeeds with `quartzite-examples` in workspace
- [ ] AC2: `cargo run --example hello_object -p quartzite-examples` prints `Int(0)` → `Int(42)` → `Int(0)`
- [ ] AC3: `cargo run --example signals_slots -p quartzite-examples` prints typed slot + dynamic slot lines
- [ ] AC4: `cargo run --example object_tree -p quartzite-examples` prints parent, children, find-by-name, name
- [ ] AC5: `cargo run --example timer -p quartzite-examples` prints tick 1–3, then "done after 3 ticks"
- [ ] AC6: `cargo clippy -- -D warnings` clean
- [ ] AC7: `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` passes
- [ ] AC8: `AGENTS.md` documents `quartzite-examples` exemptions
- [ ] AC9: `README.md` lists `quartzite-examples` with example names
- [ ] AC10: `quartzite::quartzite_core` and `quartzite::quartzite_runtime` accessible as public items
- [ ] AC11: `ai-docs/context.md` records `proc_macro_crate` open question
- [ ] AC12: `self-review.md` and `review-findings.md` carry `quartzite-examples` exemptions