### PR TITLE
ci: add --workspace to build, test, and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Build
-        run: cargo build
+        run: cargo build --workspace
 
       - name: Test
-        run: cargo test
+        run: cargo test --workspace
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Docs
         run: cargo doc --no-deps --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Format
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Build
         run: cargo build --workspace


### PR DESCRIPTION
## Summary

Without `--workspace`, `cargo build/test/clippy` at a workspace root that also has a `[package]` section operate on the root crate only. The 195+ tests in `quartzite-core`, `quartzite-macros`, and `quartzite-runtime` were never run in CI.

`cargo doc` already had `--workspace` ✅. The feature matrix job targets the facade crate specifically and is unchanged.

## Test plan

- [x] `cargo build --workspace` — verified locally
- [x] `cargo test --workspace` — all 200+ tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean