### PR TITLE
docs: fix README — examples location and workspace commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +43,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-macro"
@@ -109,16 +126,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -162,6 +229,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "rstest",
+ "serial_test",
 ]
 
 [[package]]
@@ -190,6 +258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -266,6 +343,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +390,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +429,12 @@ checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -358,6 +488,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Early development. Core crates are implemented; widget and painting layers are n
 | `quartzite-core` | ✅ implemented |
 | `quartzite-macros` | ✅ implemented |
 | `quartzite-runtime` | ✅ implemented |
-| `quartzite-examples` | ✅ runnable examples: `hello_object`, `signals_slots`, `object_tree`, `timer` |
+| `examples/` | ✅ runnable examples: `hello_object`, `signals_slots`, `object_tree`, `timer` |
 | `quartzite-geometry` / `quartzite-events` | planned |
 | `quartzite-widgets` | planned |
 | `quartzite-paint` / `quartzite-style` | planned |
@@ -54,26 +54,26 @@ quartzite = { git = "...", default-features = false, features = ["std"] }
 ## Build
 
 ```bash
-cargo build
+cargo build --workspace
 ```
 
 ## Test
 
 ```bash
-cargo test
+cargo test --workspace
 ```
 
 ## Lint
 
 ```bash
-cargo clippy -- -D warnings
+cargo clippy --workspace -- -D warnings
 ```
 
 ## Format
 
 ```bash
-cargo fmt              # apply
-cargo fmt -- --check   # verify (CI gate)
+cargo fmt --all              # apply
+cargo fmt --all -- --check   # verify (CI gate)
 ```
 
 ## Docs

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -21,6 +21,7 @@ hashbrown = { version = "0.15", default-features = false }
 
 [dev-dependencies]
 rstest = "0.26.1"
+serial_test = "3"
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -436,6 +436,8 @@ impl<Args: 'static> Signal<Args> {
 mod tests {
     use super::*;
     #[cfg(feature = "std")]
+    use serial_test::serial;
+    #[cfg(feature = "std")]
     use std::sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
@@ -685,6 +687,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn queued_slot_not_posted_after_receiver_destroyed() {
         use crate::receiver_guard::ReceiverGuard;
 
@@ -716,6 +719,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_same_thread_calls_slot_synchronously() {
         let dispatcher = install_test_dispatcher();
         let pre_len = dispatcher.posted.lock().unwrap().len();
@@ -747,6 +751,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_cross_thread_posts_to_dispatcher() {
         let dispatcher = install_test_dispatcher();
         let pre_len = dispatcher.posted.lock().unwrap().len();
@@ -786,6 +791,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_thread_id_same_thread_calls_directly() {
         let dispatcher = install_test_dispatcher();
         let pre_len = dispatcher.posted.lock().unwrap().len();
@@ -817,6 +823,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_thread_id_foreign_thread_posts_to_dispatcher() {
         let dispatcher = install_test_dispatcher();
         let pre_len = dispatcher.posted.lock().unwrap().len();
@@ -856,6 +863,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_disconnect_removes_slot() {
         let dispatcher = install_test_dispatcher();
         let pre_len = dispatcher.posted.lock().unwrap().len();
@@ -888,6 +896,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "std")]
+    #[serial]
     fn auto_same_thread_does_not_grow_dispatcher_queue_when_foreign_entry_exists() {
         let dispatcher = install_test_dispatcher();
 


### PR DESCRIPTION
## Summary

- Replace `quartzite-examples` crate row with `examples/` (migrated in #31)
- Add `--workspace` to `cargo build` and `cargo test`
- Add `--workspace` to `cargo clippy`
- Add `--all` to `cargo fmt` / `cargo fmt -- --check`

All commands now match the CI gates added in #32.