### PR TITLE
refactor: remove dead struct fields

### DIFF
--- a/quartzite-core/src/object_base.rs
+++ b/quartzite-core/src/object_base.rs
@@ -4,10 +4,7 @@ use alloc::{string::String, sync::Arc};
 #[cfg(feature = "std")]
 use std::{string::String, sync::Arc};
 
-use crate::{
-    id::ObjectId,
-    receiver_guard::ReceiverGuard,
-};
+use crate::{id::ObjectId, receiver_guard::ReceiverGuard};
 
 /// Core data carried by every object in the quartzite object tree.
 ///

--- a/quartzite-core/src/object_base.rs
+++ b/quartzite-core/src/object_base.rs
@@ -1,20 +1,18 @@
 //! Base state shared by every quartzite object.
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, string::String, sync::Arc};
+use alloc::{string::String, sync::Arc};
 #[cfg(feature = "std")]
-use std::{collections::BTreeMap, string::String, sync::Arc};
+use std::{string::String, sync::Arc};
 
 use crate::{
     id::ObjectId,
     receiver_guard::ReceiverGuard,
-    value::Value,
 };
 
 /// Core data carried by every object in the quartzite object tree.
 ///
 /// `ObjectBase` provides identity ([`ObjectId`]), optional name, thread-affinity
-/// tracking, a lifetime token for safe signal delivery ([`ReceiverGuard`]), and
-/// storage for dynamic properties.
+/// tracking, and a lifetime token for safe signal delivery ([`ReceiverGuard`]).
 ///
 /// Objects are typically created through a higher-level type that includes an
 /// `ObjectBase` field and derives `Extend` (from `quartzite-macros`).
@@ -26,7 +24,6 @@ use crate::{
 ///
 /// let base = ObjectBase::named("my-button");
 /// assert_eq!(base.name(), Some("my-button"));
-/// assert!(!base.signals_blocked);
 /// ```
 pub struct ObjectBase {
     /// Private: uniqueness invariant — must never be overwritten after construction.
@@ -37,10 +34,6 @@ pub struct ObjectBase {
     /// Private: lifetime token — Arc is dropped when the object is dropped, invalidating
     /// all `Weak<ReceiverGuard>` held by queued connections.
     receiver_guard: Arc<ReceiverGuard>,
-    /// Runtime property bag for properties added outside the compile-time schema.
-    pub dynamic_properties: BTreeMap<String, Value>,
-    /// When `true`, emitting any signal on this object is a no-op.
-    pub signals_blocked: bool,
     /// The thread on which this object was created; used by `connect_auto` to decide
     /// between direct and queued delivery.
     #[cfg(feature = "std")]
@@ -58,7 +51,6 @@ impl ObjectBase {
     ///
     /// let base = ObjectBase::new();
     /// assert!(base.name().is_none());
-    /// assert!(!base.signals_blocked);
     /// ```
     pub fn new() -> Self {
         let (guard, _) = ReceiverGuard::new_pair();
@@ -66,8 +58,6 @@ impl ObjectBase {
             id: ObjectId::new(),
             name: None,
             receiver_guard: guard,
-            dynamic_properties: BTreeMap::new(),
-            signals_blocked: false,
             #[cfg(feature = "std")]
             thread_id: std::thread::current().id(),
         }
@@ -196,18 +186,6 @@ mod tests {
     fn new_records_thread_id() {
         let base = ObjectBase::new();
         assert!(base.is_on_current_thread());
-    }
-
-    #[test]
-    fn signals_blocked_default_false() {
-        let base = ObjectBase::new();
-        assert!(!base.signals_blocked);
-    }
-
-    #[test]
-    fn dynamic_properties_empty_on_new() {
-        let base = ObjectBase::new();
-        assert!(base.dynamic_properties.is_empty());
     }
 
     #[test]

--- a/quartzite-core/src/object_base.rs
+++ b/quartzite-core/src/object_base.rs
@@ -1,11 +1,11 @@
 //! Base state shared by every quartzite object.
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc};
 #[cfg(feature = "std")]
-use std::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use std::{collections::BTreeMap, string::String, sync::Arc};
 
 use crate::{
-    id::{ConnectionId, ObjectId},
+    id::ObjectId,
     receiver_guard::ReceiverGuard,
     value::Value,
 };
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// `ObjectBase` provides identity ([`ObjectId`]), optional name, thread-affinity
 /// tracking, a lifetime token for safe signal delivery ([`ReceiverGuard`]), and
-/// storage for dynamic properties and outgoing connection bookkeeping.
+/// storage for dynamic properties.
 ///
 /// Objects are typically created through a higher-level type that includes an
 /// `ObjectBase` field and derives `Extend` (from `quartzite-macros`).
@@ -37,10 +37,6 @@ pub struct ObjectBase {
     /// Private: lifetime token — Arc is dropped when the object is dropped, invalidating
     /// all `Weak<ReceiverGuard>` held by queued connections.
     receiver_guard: Arc<ReceiverGuard>,
-    /// Tracks outgoing signal connections; populated and managed by `quartzite-runtime`.
-    ///
-    /// `ObjectBase` itself does not modify this field.
-    pub outgoing_connections: Vec<ConnectionId>,
     /// Runtime property bag for properties added outside the compile-time schema.
     pub dynamic_properties: BTreeMap<String, Value>,
     /// When `true`, emitting any signal on this object is a no-op.
@@ -70,7 +66,6 @@ impl ObjectBase {
             id: ObjectId::new(),
             name: None,
             receiver_guard: guard,
-            outgoing_connections: Vec::new(),
             dynamic_properties: BTreeMap::new(),
             signals_blocked: false,
             #[cfg(feature = "std")]

--- a/quartzite-runtime/src/connection_table.rs
+++ b/quartzite-runtime/src/connection_table.rs
@@ -1,12 +1,11 @@
 //! Process-wide store of active signal–slot connections.
 use std::{
     collections::HashMap,
-    sync::{Arc, RwLock, Weak},
+    sync::{Arc, RwLock},
 };
 
 use quartzite_core::{
     ConnectionId, ObjectId,
-    receiver_guard::ReceiverGuard,
     signal::{DispatcherAlreadySet, QueuedDispatcher, set_queued_dispatcher},
 };
 
@@ -23,18 +22,6 @@ pub struct ConnectionRecord {
     pub signal_index: SignalIndex,
     /// `ObjectId` of the object that owns the slot.
     pub receiver_id: ObjectId,
-    /// Weak reference to the receiver's lifetime token; used to detect receiver destruction.
-    pub receiver_guard: Weak<ReceiverGuard>,
-    /// The callable slot, discriminated by delivery mode.
-    pub slot: SlotKind,
-}
-
-type DirectCallback = Box<dyn Fn(&[quartzite_core::Value]) + Send + Sync>;
-
-/// The callable part of a connection, discriminated by delivery mode.
-pub enum SlotKind {
-    /// Invoke the callback directly on the emitting thread.
-    Direct(DirectCallback),
 }
 
 /// Process-wide store of active connections.
@@ -89,38 +76,30 @@ impl ConnectionTable {
         set_queued_dispatcher(Arc::clone(self) as Arc<dyn QueuedDispatcher>)
     }
 
-    /// Register a new connection. Captures `receiver_guard` from the receiver's
-    /// `ObjectBase` at call time.
+    /// Register a new connection.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use std::sync::Arc;
-    /// use quartzite_core::{ObjectId, receiver_guard::ReceiverGuard};
+    /// use quartzite_core::ObjectId;
     /// use quartzite_runtime::{ConnectionTable, EventLoop};
-    /// use quartzite_runtime::connection_table::SlotKind;
     ///
     /// let el = Arc::new(EventLoop::new());
     /// let table = ConnectionTable::new(el);
-    /// let (_, guard_weak) = ReceiverGuard::new_pair();
-    /// let _id = table.register(ObjectId::new(), 0, ObjectId::new(), guard_weak,
-    ///     SlotKind::Direct(Box::new(|_| {})));
+    /// let _id = table.register(ObjectId::new(), 0, ObjectId::new());
     /// ```
     pub fn register(
         &self,
         sender_id: ObjectId,
         signal_index: SignalIndex,
         receiver_id: ObjectId,
-        receiver_guard: Weak<ReceiverGuard>,
-        slot: SlotKind,
     ) -> ConnectionId {
         let id = ConnectionId::new();
         let record = ConnectionRecord {
             sender_id,
             signal_index,
             receiver_id,
-            receiver_guard,
-            slot,
         };
         self.connections.write().unwrap().insert(id, record);
         self.by_receiver
@@ -144,15 +123,12 @@ impl ConnectionTable {
     ///
     /// ```no_run
     /// use std::sync::Arc;
-    /// use quartzite_core::{ObjectId, receiver_guard::ReceiverGuard};
+    /// use quartzite_core::ObjectId;
     /// use quartzite_runtime::{ConnectionTable, EventLoop};
-    /// use quartzite_runtime::connection_table::SlotKind;
     ///
     /// let el = Arc::new(EventLoop::new());
     /// let table = ConnectionTable::new(el);
-    /// let (_, guard_weak) = ReceiverGuard::new_pair();
-    /// let id = table.register(ObjectId::new(), 0, ObjectId::new(), guard_weak,
-    ///     SlotKind::Direct(Box::new(|_| {})));
+    /// let id = table.register(ObjectId::new(), 0, ObjectId::new());
     /// table.remove(id);
     /// ```
     pub fn remove(&self, id: ConnectionId) {
@@ -182,16 +158,13 @@ impl ConnectionTable {
     ///
     /// ```no_run
     /// use std::sync::Arc;
-    /// use quartzite_core::{ObjectId, receiver_guard::ReceiverGuard};
+    /// use quartzite_core::ObjectId;
     /// use quartzite_runtime::{ConnectionTable, EventLoop};
-    /// use quartzite_runtime::connection_table::SlotKind;
     ///
     /// let el = Arc::new(EventLoop::new());
     /// let table = ConnectionTable::new(el);
     /// let receiver_id = ObjectId::new();
-    /// let (_, guard_weak) = ReceiverGuard::new_pair();
-    /// table.register(ObjectId::new(), 0, receiver_id, guard_weak,
-    ///     SlotKind::Direct(Box::new(|_| {})));
+    /// table.register(ObjectId::new(), 0, receiver_id);
     /// table.remove_by_receiver(receiver_id); // removes all slots for this receiver
     /// ```
     pub fn remove_by_receiver(&self, id: ObjectId) {
@@ -249,7 +222,7 @@ impl QueuedDispatcher for ConnectionTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quartzite_core::{ObjectId, receiver_guard::ReceiverGuard};
+    use quartzite_core::ObjectId;
 
     fn make_table() -> Arc<ConnectionTable> {
         let el = Arc::new(EventLoop::new());
@@ -261,20 +234,12 @@ mod tests {
         let table = make_table();
         let sender = ObjectId::new();
         let receiver = ObjectId::new();
-        let (guard_arc, guard_weak) = ReceiverGuard::new_pair();
 
-        let id = table.register(
-            sender,
-            0,
-            receiver,
-            guard_weak,
-            SlotKind::Direct(Box::new(|_| {})),
-        );
+        let id = table.register(sender, 0, receiver);
 
         assert!(table.receivers_for_signal(sender, 0).contains(&id));
         table.remove(id);
         assert!(!table.receivers_for_signal(sender, 0).contains(&id));
-        drop(guard_arc);
     }
 
     #[test]
@@ -282,18 +247,10 @@ mod tests {
         let table = make_table();
         let sender = ObjectId::new();
         let receiver = ObjectId::new();
-        let (guard_arc, guard_weak) = ReceiverGuard::new_pair();
 
-        table.register(
-            sender,
-            0,
-            receiver,
-            guard_weak,
-            SlotKind::Direct(Box::new(|_| {})),
-        );
+        table.register(sender, 0, receiver);
 
         table.remove_by_receiver(receiver);
         assert!(table.receivers_for_signal(sender, 0).is_empty());
-        drop(guard_arc);
     }
 }

--- a/quartzite-runtime/src/timer.rs
+++ b/quartzite-runtime/src/timer.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use quartzite_core::{ConnectionId, object_base::ObjectBase, signal::Signal};
+use quartzite_core::{ConnectionId, signal::Signal};
 
 /// Fires its `timeout` signal at a given interval via the event loop.
 ///
@@ -16,8 +16,6 @@ use quartzite_core::{ConnectionId, object_base::ObjectBase, signal::Signal};
 /// `Signal` is not `Sync`, so the signal is wrapped in `Arc<Mutex<>>` to allow
 /// the background thread to capture and emit it on the event-loop thread.
 pub struct Timer {
-    /// Base object state (id, name, thread affinity).
-    pub base: ObjectBase,
     /// Duration between `timeout` signal emissions.
     pub interval: Duration,
     /// When `true` the timer fires once and then stops automatically.
@@ -45,7 +43,6 @@ impl Timer {
     /// ```
     pub fn new(interval: Duration) -> Self {
         Self {
-            base: ObjectBase::new(),
             interval,
             single_shot: false,
             running: Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
## Summary

Removes six struct fields that were written (initialized) but never read in any production code path. All were placeholders for unimplemented features.

| Field | Struct | Reason removed |
|---|---|---|
| `outgoing_connections` | `ObjectBase` | Sender-side cleanup never implemented; `ConnectionTable` already has `by_signal` index |
| `receiver_guard` | `ConnectionRecord` | Dispatch lives in `Signal::emit()`, not `ConnectionTable` |
| `slot` | `ConnectionRecord` | Same — `ConnectionTable` never invokes slots |
| `signals_blocked` | `ObjectBase` | `Signal::emit()` has no access to `ObjectBase`; macro codegen needs typed wrappers first (see #34) |
| `dynamic_properties` | `ObjectBase` | No read/write API exists yet (see #35) |
| `base` | `Timer` | `Timer` is not a quartzite object yet; `AsObject` not implemented (see #36) |

Also removes the now-unused `SlotKind` enum, `DirectCallback` type alias, and dead imports (`Vec`, `ConnectionId`, `BTreeMap`, `Value`, `Weak`, `ReceiverGuard`, `ObjectBase`).

## Related issues

- #34 — `signals_blocked` implementation (typed emit wrappers in macro codegen)
- #35 — `dynamic_properties` implementation (runtime non-schema property API)
- #36 — promote `Timer` to a first-class quartzite object