### PR TITLE
docs: mark resolved items in deferred tracking files

### DIFF
--- a/ai-docs/deferred/ci-docs-workflow.md
+++ b/ai-docs/deferred/ci-docs-workflow.md
@@ -4,25 +4,25 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| Badge links in README \| will be added later by user | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) |
-| Contributing guide, roadmap \| user will add later | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) |
-| Additional facade features \| will be added based on needs as the project grows | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Badge links in README \| will be added later by user | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | |
+| Contributing guide, roadmap \| user will add later | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | |
+| Additional facade features \| will be added based on needs as the project grows | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) |
-| Auto-merge | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) |
-| Code coverage, benchmarks, release workflow | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) |
-| Removing `rstest` from `quartzite-core` — it is genuinely used in `quartzite-core/src/value.rs` | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) |
-| Any other code-quality changes not listed above | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) |
-| `std` feature on `quartzite-runtime` (would gate nothing today) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) |
-| Full wildcard re-exports beyond `prelude` | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) |
-| Future features (`extension`, `8k_pages`, etc.) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) |
-| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) |
-| Unit tests inside example files | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
-| Private/internal items | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) |
-| Separate EXAMPLES.md or README additions beyond existing content | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | |
+| Auto-merge | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | |
+| Code coverage, benchmarks, release workflow | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | |
+| Removing `rstest` from `quartzite-core` — it is genuinely used in `quartzite-core/src/value.rs` | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | |
+| Any other code-quality changes not listed above | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | |
+| `std` feature on `quartzite-runtime` (would gate nothing today) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | |
+| Full wildcard re-exports beyond `prelude` | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | |
+| Future features (`extension`, `8k_pages`, etc.) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | |
+| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | |
+| Unit tests inside example files | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
+| Private/internal items | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | |
+| Separate EXAMPLES.md or README additions beyond existing content | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | |

--- a/ai-docs/deferred/future-crates.md
+++ b/ai-docs/deferred/future-crates.md
@@ -4,23 +4,23 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| Examples for geometry-events, widgets, paint-style \| those crates not yet implemented | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Examples for geometry-events, widgets, paint-style \| those crates not yet implemented | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| Proc macros (separate crate) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Widget hierarchy (quartzite-widgets) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Event system (quartzite-events) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Python interop (deferred) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Widget rendering (quartzite-widgets) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Event model types (quartzite-events) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Python interop (deferred) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Examples for unimplemented crates (geometry, events, widgets, paint, style) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
-| Python interop examples | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
-| `quartzite-widgets` (not yet implemented) | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) |
-| Python interop | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
-| Python interop (deferred plan) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Proc macros (separate crate) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
+| Widget hierarchy (quartzite-widgets) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Event system (quartzite-events) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Python interop (deferred) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Widget rendering (quartzite-widgets) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Event model types (quartzite-events) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Python interop (deferred) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Examples for unimplemented crates (geometry, events, widgets, paint, style) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
+| Python interop examples | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
+| `quartzite-widgets` (not yet implemented) | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | |
+| Python interop | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
+| Python interop (deferred plan) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |

--- a/ai-docs/deferred/macros-codegen.md
+++ b/ai-docs/deferred/macros-codegen.md
@@ -4,28 +4,28 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| `#[object_impl]` on multiple impl blocks for one type \| single impl block only for now | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| `proc_macro_crate` based path detection in `quartzite-macros` \| would let users depend on only `quartzite` or only `quartzite-core`; non-trivial, separate task | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| `#[object_impl]` on multiple impl blocks for one type \| single impl block only for now | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
+| `proc_macro_crate` based path detection in `quartzite-macros` \| would let users depend on only `quartzite` or only `quartzite-core`; non-trivial, separate task | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| Runtime-specific code in macros (macros emit code that calls quartzite-core APIs) | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| Python-specific code generation (deferred) | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| `#[derive(Extend)]` on enums or tuple structs (named fields only) | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| Generic functions and blanket-impl trait methods (`ObjectRef<T>`, `WeakRef<T>`, `Signal<Args>`, `ObjectExt` default methods) — monomorphized, no cross-crate inlining benefit | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) |
-| Test-only `AsObject` impls inside `#[cfg(test)]` modules | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) |
-| Any generated or hand-written function with branches, loops, or more than one function call | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) |
-| Changing `quartzite-macros` codegen (deferred — `proc_macro_crate` is a separate future task) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Runtime-specific code in macros (macros emit code that calls quartzite-core APIs) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done |
+| Python-specific code generation (deferred) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
+| `#[derive(Extend)]` on enums or tuple structs (named fields only) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
+| Generic functions and blanket-impl trait methods (`ObjectRef<T>`, `WeakRef<T>`, `Signal<Args>`, `ObjectExt` default methods) — monomorphized, no cross-crate inlining benefit | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | |
+| Test-only `AsObject` impls inside `#[cfg(test)]` modules | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | |
+| Any generated or hand-written function with branches, loops, or more than one function call | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | |
+| Changing `quartzite-macros` codegen (deferred — `proc_macro_crate` is a separate future task) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
 
 ## Open questions
 
-| Item | Source |
-|------|--------|
-| Should `Base` suffix be stripped when forming `As{Name}` trait? (`WidgetBase` → `AsWidget` or `AsWidgetBase`?) | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| Should `#[derive(Object)]` require `#[derive(Extend)]` to be present, or are they independent? | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| How to handle generic structs with `#[derive(Extend)]`? | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
-| Should `MetaObject::new()` be extended with fn pointer params or replaced by struct literal construction in the macro? Decide in design phase. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Should `Base` suffix be stripped when forming `As{Name}` trait? (`WidgetBase` → `AsWidget` or `AsWidgetBase`?) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done |
+| Should `#[derive(Object)]` require `#[derive(Extend)]` to be present, or are they independent? | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done |
+| How to handle generic structs with `#[derive(Extend)]`? | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
+| Should `MetaObject::new()` be extended with fn pointer params or replaced by struct literal construction in the macro? Decide in design phase. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | ✅ done |

--- a/ai-docs/deferred/object-tree.md
+++ b/ai-docs/deferred/object-tree.md
@@ -4,25 +4,25 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| `ObjectTree::find_by_name` subtree scoping \| future; flat search sufficient for v1 | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| `ObjectTree::find_by_name` subtree scoping \| future; flat search sufficient for v1 | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| Object tree / arena / ownership model (quartzite-runtime) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Subtree-scoped `find_by_name` (flat search sufficient for now) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
-| Async/reactive name-change notifications (needs event system) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Object tree / arena / ownership model (quartzite-runtime) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
+| Subtree-scoped `find_by_name` (flat search sufficient for now) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
+| Async/reactive name-change notifications (needs event system) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
 
 ## Open questions
 
-| Item | Source |
-|------|--------|
-| Should `WeakObjectRef` be a type alias or a newtype? (Depends on runtime ownership choice) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Should `ObjectBase` derive `Debug`? (Useful for testing; `dynamic_properties` contains `Value`) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| **Object ownership**: arena (SlotMap + ObjectId keys) vs `Rc<RefCell<dyn Object>>`? This is the primary decision blocking implementation. | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Should `ObjectRef<T>` be a typed wrapper around `ObjectId` or around `Rc<RefCell<T>>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| **`ObjectExt::parent()` / `children()` accessor mechanism**: With parent/children removed from `ObjectBase`, these methods need to reach `ObjectTree`. The simplest approach is a process-global `fn with_tree<R>(f: impl FnOnce(&ObjectTree) -> R) -> R` registered by `Application`. Needs decision before Task 4 finalizes the `ObjectExt` blanket impl. | [runtime design](../plans/done/2026-05-01-runtime.design.md) |
-| Should `ObjectTree::rename` be a no-op when called with the object's current name? Implementation must be correct either way; no special case required. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Should `WeakObjectRef` be a type alias or a newtype? (Depends on runtime ownership choice) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
+| Should `ObjectBase` derive `Debug`? (Useful for testing; `dynamic_properties` contains `Value`) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| **Object ownership**: arena (SlotMap + ObjectId keys) vs `Rc<RefCell<dyn Object>>`? This is the primary decision blocking implementation. | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done |
+| Should `ObjectRef<T>` be a typed wrapper around `ObjectId` or around `Rc<RefCell<T>>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done |
+| **`ObjectExt::parent()` / `children()` accessor mechanism**: With parent/children removed from `ObjectBase`, these methods need to reach `ObjectTree`. The simplest approach is a process-global `fn with_tree<R>(f: impl FnOnce(&ObjectTree) -> R) -> R` registered by `Application`. Needs decision before Task 4 finalizes the `ObjectExt` blanket impl. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | |
+| Should `ObjectTree::rename` be a no-op when called with the object's current name? Implementation must be correct either way; no special case required. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |

--- a/ai-docs/deferred/properties.md
+++ b/ai-docs/deferred/properties.md
@@ -4,8 +4,8 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| Computed properties (stored = false + getter closure) \| use methods for now | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Property bindings (two-way sync) \| BindingEngine is future work | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| `#[prop(stored = false)]` with custom getter/setter closure \| needs design decision on how closures are stored in static context | [macros spec](../plans/done/2026-05-01-macros.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Computed properties (stored = false + getter closure) \| use methods for now | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Property bindings (two-way sync) \| BindingEngine is future work | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| `#[prop(stored = false)]` with custom getter/setter closure \| needs design decision on how closures are stored in static context | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |

--- a/ai-docs/deferred/signals-slots.md
+++ b/ai-docs/deferred/signals-slots.md
@@ -4,29 +4,29 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| `BlockingQueued` connection type \| threading model not yet decided | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Signal-to-signal connections \| needs runtime design first | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| `BlockingQueued` connection type \| depends on per-thread loops | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Enforcing the signals_blocked check at `Signal` level rather than codegen level \| requires API redesign (#38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) |
-| `auto_cross_thread_slot_not_posted_after_receiver_destroyed` test \| requires `Weak<ReceiverGuard>` in the auto slot entry; `AutoSlotInner` does not hold a guard in v1 | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) |
-| `ReceiverGuard` for `Auto` connections \| `connect_auto` currently accepts no guard; cross-thread Auto slots will post even after the receiver is destroyed; requires `ConnectionTable` integration | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| `BlockingQueued` connection type \| threading model not yet decided | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Signal-to-signal connections \| needs runtime design first | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| `BlockingQueued` connection type \| depends on per-thread loops | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Enforcing the signals_blocked check at `Signal` level rather than codegen level \| requires API redesign (#38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |
+| `auto_cross_thread_slot_not_posted_after_receiver_destroyed` test \| requires `Weak<ReceiverGuard>` in the auto slot entry; `AutoSlotInner` does not hold a guard in v1 | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | |
+| `ReceiverGuard` for `Auto` connections \| `connect_auto` currently accepts no guard; cross-thread Auto slots will post even after the receiver is destroyed; requires `ConnectionTable` integration | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| `BlockingQueued` — threading model not yet decided (already deferred in core-types spec) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
-| Signal-to-signal connections — blocked on runtime design (already deferred) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
-| Changes to `Signal::emit` itself (tracked in #38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) |
-| Serialization of `signals_blocked` state (tracked in #39) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| `BlockingQueued` — threading model not yet decided (already deferred in core-types spec) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | |
+| Signal-to-signal connections — blocked on runtime design (already deferred) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | |
+| Changes to `Signal::emit` itself (tracked in #38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |
+| Serialization of `signals_blocked` state (tracked in #39) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |
 
 ## Open questions
 
-| Item | Source |
-|------|--------|
-| Should `Signal` be `Send + Sync`? (Needed if objects move across threads) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Should `Auto` on a same-thread emit respect `signals_blocked` the same way as `Direct`? (Almost certainly yes — confirm when implementing `signals_blocked` logic) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
-| Should the `SlotEntry` for `Auto` store both a `Fn(&Args)` (direct path) and a `Fn(Args) + Send + Sync` (queued path), or a single `Fn(Args) + Send + Sync` called directly (with clone) on the same-thread path? Design doc to decide. | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
-| **`signals_blocked` interaction with `Auto`:** Deferred to the `signals_blocked` design. | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Should `Signal` be `Send + Sync`? (Needed if objects move across threads) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
+| Should `Auto` on a same-thread emit respect `signals_blocked` the same way as `Direct`? (Almost certainly yes — confirm when implementing `signals_blocked` logic) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | ✅ done |
+| Should the `SlotEntry` for `Auto` store both a `Fn(&Args)` (direct path) and a `Fn(Args) + Send + Sync` (queued path), or a single `Fn(Args) + Send + Sync` called directly (with clone) on the same-thread path? Design doc to decide. | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | ✅ done |
+| **`signals_blocked` interaction with `Auto`:** Deferred to the `signals_blocked` design. | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | ✅ done |

--- a/ai-docs/deferred/threading-runtime.md
+++ b/ai-docs/deferred/threading-runtime.md
@@ -4,26 +4,26 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 ## Deferred
 
-| Item | Source |
-|------|--------|
-| No-std validation \| design for it but don't enforce until runtime exists | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) |
-| Multi-window support \| needs platform backend first | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Thread event loops (one loop per thread) \| defer until threading model decided | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Stale `thread_id` invalidation \| needs object-mobility / thread-affinity-change API first | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
-| `AutoConnection` in no_std \| same gating as `Queued`; unblocked when std feature is defined | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| No-std validation \| design for it but don't enforce until runtime exists | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
+| Multi-window support \| needs platform backend first | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Thread event loops (one loop per thread) \| defer until threading model decided | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Stale `thread_id` invalidation \| needs object-mobility / thread-affinity-change API first | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | |
+| `AutoConnection` in no_std \| same gating as `Queued`; unblocked when std feature is defined | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | ✅ done |
 
 ## Out of scope
 
-| Item | Source |
-|------|--------|
-| Thread migration — if an object moves to another thread after a connection is established, the captured `thread_id` will be stale; this requires a separate object-mobility design | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Thread migration — if an object moves to another thread after a connection is established, the captured `thread_id` will be stale; this requires a separate object-mobility design | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | |
 
 ## Open questions
 
-| Item | Source |
-|------|--------|
-| Should `ConnectionTable` use `DashMap` (lock-free) or `Mutex<HashMap>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| Should the event loop be `async`-runtime-agnostic (pluggable executor) or std-thread-based only? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) |
-| **`QueuedDispatcher` trait location**: Proposed to live in quartzite-core behind `feature = "std"`. Alternative: define it in quartzite-runtime and have core use a raw function pointer or a `OnceLock<fn(Box<dyn FnOnce() + Send>)>`. Needs decision before Task 5. | [runtime design](../plans/done/2026-05-01-runtime.design.md) |
-| **`ObjectFactory` global vs. per-`Application`**: Should there be a process-wide factory singleton (like `ConnectionTable`), or one per `Application`? **Proposed**: per-`Application`, accessible via `Application::factory()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) |
-| **`ThreadPool` shutdown semantics**: Should `ThreadPool::drop` wait for in-flight tasks to complete (graceful) or abandon them? **Proposed**: graceful — close the sender and join all workers. Panic in a worker thread propagates as a resumed panic in `join()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) |
+| Item | Source | Status |
+|------|--------|--------|
+| Should `ConnectionTable` use `DashMap` (lock-free) or `Mutex<HashMap>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done |
+| Should the event loop be `async`-runtime-agnostic (pluggable executor) or std-thread-based only? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done |
+| **`QueuedDispatcher` trait location**: Proposed to live in quartzite-core behind `feature = "std"`. Alternative: define it in quartzite-runtime and have core use a raw function pointer or a `OnceLock<fn(Box<dyn FnOnce() + Send>)>`. Needs decision before Task 5. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | ✅ done |
+| **`ObjectFactory` global vs. per-`Application`**: Should there be a process-wide factory singleton (like `ConnectionTable`), or one per `Application`? **Proposed**: per-`Application`, accessible via `Application::factory()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | |
+| **`ThreadPool` shutdown semantics**: Should `ThreadPool::drop` wait for in-flight tasks to complete (graceful) or abandon them? **Proposed**: graceful — close the sender and join all workers. Panic in a worker thread propagates as a resumed panic in `join()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | ✅ done |


### PR DESCRIPTION
## Summary

Adds a `Status` column to all 7 deferred tracking files. Items verified as implemented are marked `✅ done`; open items have a blank status cell.

| File | ✅ done | Open |
|------|---------|------|
| signals-slots.md | 4 | 10 |
| object-tree.md | 4 | 6 |
| threading-runtime.md | 6 | 5 |
| macros-codegen.md | 4 | 9 |
| future-crates.md | 1 | 12 |
| properties.md | 0 | 3 |
| ci-docs-workflow.md | 0 | 15 |

Notable resolved items: all 4 open questions in signals-slots (Auto/signals_blocked decisions), arena ownership model, QueuedDispatcher location, ThreadPool shutdown, no-std validation, `Base` suffix stripping, `MetaObject::new` fn-pointer params.

## Test plan

- [ ] Every row in every table has a `Status` column
- [ ] No item text was changed, only status added