### PR TITLE
docs: extract Python interop items into dedicated group

### DIFF
--- a/ai-docs/deferred-items.md
+++ b/ai-docs/deferred-items.md
@@ -6,8 +6,9 @@ Extracted from completed plans in `ai-docs/plans/done/`. Split by functional are
 |-------|------|-------|
 | Signals & Slots | [signals-slots.md](deferred/signals-slots.md) | 14 |
 | Properties | [properties.md](deferred/properties.md) | 3 |
-| Macros & Codegen | [macros-codegen.md](deferred/macros-codegen.md) | 13 |
+| Macros & Codegen | [macros-codegen.md](deferred/macros-codegen.md) | 12 |
 | Object Tree | [object-tree.md](deferred/object-tree.md) | 10 |
 | Threading & Runtime | [threading-runtime.md](deferred/threading-runtime.md) | 11 |
-| Future Crates | [future-crates.md](deferred/future-crates.md) | 13 |
+| Future Crates | [future-crates.md](deferred/future-crates.md) | 8 |
 | CI, Docs & Workflow | [ci-docs-workflow.md](deferred/ci-docs-workflow.md) | 15 |
+| Python Interop | [python.md](deferred/python.md) | 6 |

--- a/ai-docs/deferred/future-crates.md
+++ b/ai-docs/deferred/future-crates.md
@@ -15,12 +15,7 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 | Proc macros (separate crate) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done |
 | Widget hierarchy (quartzite-widgets) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
 | Event system (quartzite-events) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
-| Python interop (deferred) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
 | Widget rendering (quartzite-widgets) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
 | Event model types (quartzite-events) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
-| Python interop (deferred) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
 | Examples for unimplemented crates (geometry, events, widgets, paint, style) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
-| Python interop examples | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
 | `quartzite-widgets` (not yet implemented) | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | |
-| Python interop | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
-| Python interop (deferred plan) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |

--- a/ai-docs/deferred/macros-codegen.md
+++ b/ai-docs/deferred/macros-codegen.md
@@ -14,7 +14,6 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 | Item | Source | Status |
 |------|--------|--------|
 | Runtime-specific code in macros (macros emit code that calls quartzite-core APIs) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done |
-| Python-specific code generation (deferred) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
 | `#[derive(Extend)]` on enums or tuple structs (named fields only) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
 | Generic functions and blanket-impl trait methods (`ObjectRef<T>`, `WeakRef<T>`, `Signal<Args>`, `ObjectExt` default methods) — monomorphized, no cross-crate inlining benefit | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | |
 | Test-only `AsObject` impls inside `#[cfg(test)]` modules | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | |

--- a/ai-docs/deferred/python.md
+++ b/ai-docs/deferred/python.md
@@ -1,0 +1,14 @@
+# Python Interop
+
+Items extracted from completed plans. See [index](../deferred-items.md).
+
+## Out of scope / deferred
+
+| Item | Source | Status |
+|------|--------|--------|
+| Python interop (deferred) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | |
+| Python interop (deferred) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | |
+| Python-specific code generation (deferred) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | |
+| Python interop examples | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | |
+| Python interop | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | |
+| Python interop (deferred plan) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | |


### PR DESCRIPTION
## Summary

- Created `ai-docs/deferred/python.md` with 6 Python-specific deferred items
- Removed 5 Python rows from `ai-docs/deferred/future-crates.md`
- Removed 1 Python row from `ai-docs/deferred/macros-codegen.md`
- Updated `ai-docs/deferred-items.md` index with new counts and Python Interop group entry

## Test plan

- [ ] Links in python.md resolve correctly (`../plans/done/` paths)
- [ ] future-crates.md no longer contains any Python items
- [ ] macros-codegen.md no longer contains any Python items
- [ ] deferred-items.md counts match actual row counts in each file