### PR TITLE
docs: cross-link deferred plan specs to their tracking issues (#45-#47)

### DIFF
--- a/ai-docs/plans/deferred/2026-05-01-geometry-events.spec.md
+++ b/ai-docs/plans/deferred/2026-05-01-geometry-events.spec.md
@@ -2,6 +2,7 @@
 
 **Source:** AI design dialogue (tmp/qt_01..14.log)
 **Date:** 2026-05-01
+**Tracked in:** https://github.com/maratik123/quartzite/issues/45
 
 ## Scope
 

--- a/ai-docs/plans/deferred/2026-05-01-paint-style.spec.md
+++ b/ai-docs/plans/deferred/2026-05-01-paint-style.spec.md
@@ -2,6 +2,7 @@
 
 **Source:** AI design dialogue (tmp/qt_01..14.log)
 **Date:** 2026-05-01
+**Tracked in:** https://github.com/maratik123/quartzite/issues/47
 
 ## Scope
 

--- a/ai-docs/plans/deferred/2026-05-01-widgets.spec.md
+++ b/ai-docs/plans/deferred/2026-05-01-widgets.spec.md
@@ -2,6 +2,7 @@
 
 **Source:** AI design dialogue (tmp/qt_01..14.log)
 **Date:** 2026-05-01
+**Tracked in:** https://github.com/maratik123/quartzite/issues/46
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- Added `**Tracked in:** <url>` to the header of each deferred plan spec:
  - `2026-05-01-geometry-events.spec.md` → #45
  - `2026-05-01-widgets.spec.md` → #46
  - `2026-05-01-paint-style.spec.md` → #47
- Updated the **Source** sections of issues #45, #46, #47 to use full GitHub URLs (clickable from issue pages rather than repo-relative paths)

## Test plan

- [ ] Each spec's `Tracked in:` URL opens the correct issue
- [ ] Each issue's **Source** spec link opens the correct file on GitHub