### PR TITLE
feat(macros): generate connect_<signal>_queued typed wrappers

### DIFF
--- a/ai-docs/context.md
+++ b/ai-docs/context.md
@@ -112,6 +112,7 @@ AsObject        AsWidget        AsWidget (generated)
 | `ObjectBase::signals_blocked` | Private `bool` field; toggled via `block_signals()` / `unblock_signals()`. Generated `emit_<signal>` wrappers and property notify emissions check it before firing; direct `Signal::emit` calls do not (see issue #38). |
 | `emit_<signal>` codegen | `#[derive(Object)]` generates `pub fn emit_<signal>(&mut self, arg0: T0, ...)` methods (flattened tuple args) on the struct. Guard uses `AsObject::object_base(self).signals_blocked()` — works for root and derived types alike. |
 | `connect_<signal>_auto` codegen | `#[derive(Object)]` generates `pub fn connect_<signal>_auto(&mut self, receiver: &ObjectBase, f: F)` methods (gated `#[cfg(feature = "std")]`, `#[inline]`) on the struct. Extracts `receiver.thread_id` and `Arc::downgrade(receiver.receiver_guard())` internally; delegates to `Signal::connect_auto`. |
+| `connect_<signal>_queued` codegen | `#[derive(Object)]` generates `pub fn connect_<signal>_queued(&mut self, receiver: &ObjectBase, f: F)` methods (gated `#[cfg(feature = "std")]`, `#[inline]`) on the struct. Extracts `Arc::downgrade(receiver.receiver_guard())` internally; delegates to `Signal::connect_queued(f, guard)` (`f` first — opposite order from `connect_auto`). No `thread_id` argument needed. |
 
 ## Plans (Implementation Order)
 
@@ -126,7 +127,7 @@ Crate-level plans:
 7. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
 8. `quartzite-paint` + `quartzite-style` — painter + theming
 
-Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns), examples-crate (runnable API examples), signals-blocked (typed emit wrappers + `signals_blocked` guard), receiver-guard-auto (`Weak<ReceiverGuard>` for Auto connections + `connect_<signal>_auto` codegen).
+Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns), examples-crate (runnable API examples), signals-blocked (typed emit wrappers + `signals_blocked` guard), receiver-guard-auto (`Weak<ReceiverGuard>` for Auto connections + `connect_<signal>_auto` codegen), connect-queued-codegen (`connect_<signal>_queued` typed wrappers).
 
 ## Open Questions
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -19,6 +19,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [examples-crate](done/2026-05-02-examples-crate.spec.md) | `quartzite-examples` `quartzite` | ✅ implemented (0 new tests; 4 runnable examples) | — |
 | [signals-blocked](done/2026-05-02-signals-blocked.spec.md) | `quartzite-core` `quartzite-macros` | ✅ implemented (13 new tests) | — |
 | [receiver-guard-auto](done/2026-05-03-receiver-guard-auto.spec.md) | `quartzite-core` `quartzite-macros` | ✅ implemented (4 new tests) | — |
+| [connect-queued-codegen](done/2026-05-03-connect-queued-codegen.spec.md) | `quartzite-macros` | ✅ implemented (3 new tests) | — |
 
 ## Deferred plans
 
@@ -43,12 +44,11 @@ core-types ✅
 └── github-workflow ✅     (independent)
 ```
 
-Maintenance plans (cross-cutting, all ✅): code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf, inline-simple-fns, signals-blocked. These touched multiple crates and are not part of the dependency tree.
+Maintenance plans (cross-cutting, all ✅): code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf, inline-simple-fns, signals-blocked, receiver-guard-auto, connect-queued-codegen. These touched multiple crates and are not part of the dependency tree.
 
 ## Suggested next steps
 
 1. **Start** geometry-events (no blockers, unblocks widgets and paint-style)
-2. **Consider** `connect_<signal>_queued` codegen wrappers — natural follow-up to `connect_<signal>_auto` (#50 landed), tracked in #66
 2. **Expand** `quartzite` facade prelude as new crates are implemented
 3. Any future PR adding public items must satisfy `#![deny(missing_docs)]` + `# Examples` (enforced by CI and self-review checklist)
 4. Match-based lookups are in place for properties/signals/methods/enums; enum lookup (`#[object_impl]` generates noop) could be wired up to `#[meta_enum]`-annotated enums when widgets land

--- a/ai-docs/plans/done/2026-05-03-connect-queued-codegen.design.md
+++ b/ai-docs/plans/done/2026-05-03-connect-queued-codegen.design.md
@@ -1,0 +1,105 @@
+# Design: connect_<signal>_queued codegen
+
+**Issue:** #66
+**Date:** 2026-05-03
+
+## Approach
+
+Add `emit_connect_queued_wrappers` in `quartzite-macros/src/object/codegen.rs` as a direct mirror of
+`emit_connect_auto_wrappers`, substituting the `connect_queued` call site and dropping the
+`thread_id` argument (which `connect_queued` does not take).
+
+Signature difference between the two runtime methods:
+
+| Method | Args |
+|---|---|
+| `Signal::connect_auto` | `receiver_thread_id, guard, f` |
+| `Signal::connect_queued` | `f, guard` |
+
+The generated `connect_<signal>_queued` method therefore omits `receiver.thread_id` from the
+delegation call and places `f` before `guard`, matching `Signal::connect_queued`'s parameter order.
+
+Everything else is identical to the `connect_auto` path:
+- `#[cfg(feature = "std")]` + `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]`
+- `#[allow(unexpected_cfgs)]` on the outer `impl` block
+- `#[inline]` on each generated method
+- Early-return `quote! {}` when signals slice is empty
+- Lives outside the `#[doc(hidden)]` mod in the same position in `quote! { … }` as `connect_auto_wrappers`
+
+### Rejected alternatives
+
+**Shared helper / macro over both generators** — premature abstraction; there are only two
+connection-type wrappers and their shapes are nearly identical single-function bodies. YAGNI.
+
+**Merging queued and auto into one impl block** — would complicate the layout test that finds
+`rfind("impl Foo")` to verify the outer position. Keep them separate, same as the spec says to
+mirror the existing pattern exactly.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 0 | Update `connect_auto_wrapper_lives_outside_hidden_mod` — replace `rfind`-based single-suffix check with `match_indices`-based multi-impl positioning (collect all `"impl Foo"` positions, assert `connect_ticked_auto` appears between `positions[1]` and `positions[2]`) | `quartzite-macros/src/object/codegen.rs` (`#[cfg(test)]`) | — |
+| 1 | Add `emit_connect_queued_wrappers` function | `quartzite-macros/src/object/codegen.rs` | 0 |
+| 2 | Wire function into `codegen()` top-level and `quote!` output | `quartzite-macros/src/object/codegen.rs` | 1 |
+| 3 | Write unit tests for the new codegen path | `quartzite-macros/src/object/codegen.rs` (`#[cfg(test)]`) | 2 |
+
+All four tasks touch one file; tasks 1 and 2 are logically separate (function body vs. wiring) but
+can be implemented in a single commit.
+
+## Risks
+
+- **Parameter order mismatch** (`f, guard` vs `guard, f`): `Signal::connect_queued` takes `f`
+  first, then `guard` — the opposite mental model from `connect_auto`. The generated call must be
+  `self.#field.connect_queued(f, ::std::sync::Arc::downgrade(receiver.receiver_guard()))`.
+  Mitigation: unit test explicitly asserts `connect_queued` is present in output and that
+  `receiver_guard` is referenced.
+- **`Args: Clone + Send` bound**: `connect_queued` requires these bounds (same as `connect_auto`);
+  the existing `where F: Fn(Args) + Send + Sync + 'static` clause is unchanged — the runtime
+  enforces `Clone + Send` on `Args` independently, no macro-side change needed.
+- **`#[allow(unexpected_cfgs)]` placement**: must be on the `impl` block, not on the individual
+  `fn`. Mirrors existing `emit_connect_auto_wrappers`. Mitigation: test asserts the attribute.
+- **No new public API surface in `quartzite-core`**: the feature is purely codegen; zero risk of
+  breaking core.
+
+## Test Design
+
+**Location:** `quartzite-macros/src/object/codegen.rs` — `#[cfg(test)] mod tests` (existing module)
+
+All tests use the existing `emit(ts: TokenStream) -> String` helper and `assert!(out.contains(…))` /
+`assert!(!out.contains(…))` assertions — matching the style of the `connect_auto_wrapper_*` tests
+immediately above.
+
+### Test: `connect_queued_wrapper_generated_for_signal`
+
+- **Entry point:** `codegen()` via `emit()`
+- **Input:** struct with one `#[signal] pub value_changed: Signal<(i32,)>`
+- **Scenarios (happy path):**
+  - `out.contains("pub fn connect_value_changed_queued")` — method emitted
+  - `out.contains("cfg (feature = \"std\")")` — feature gate present
+  - `out.contains("# [inline] pub fn connect_value_changed_queued")` — `#[inline]` present
+  - `out.contains("receiver : & :: quartzite :: core :: ObjectBase")` — receiver param
+  - `out.contains("connect_queued")` — delegates to `connect_queued`
+  - `out.contains("receiver . receiver_guard ()")` — guard extracted from receiver
+  - `out.contains("allow (unexpected_cfgs)")` — attribute on impl block
+
+### Test: `connect_queued_wrapper_lives_outside_hidden_mod`
+
+- **Entry point:** `codegen()` via `emit()`
+- **Input:** struct with `#[signal] pub ticked: Signal<(i32,)>`
+- **Scenarios (position check):**
+  - Locate `mod __quartzite_Foo` start position
+  - Use `rfind("impl Foo")` to find the last impl block
+  - Assert `connect_ticked_queued` does not appear in the slice from mod start to last impl
+  - Assert `connect_ticked_queued` appears in the slice from last impl to end
+
+### Test: `connect_queued_wrapper_absent_with_no_signals`
+
+- **Entry point:** `codegen()` via `emit()`
+- **Input:** struct with only a `#[prop]` field, no signals
+- **Scenario (negative):**
+  - `!out.contains("connect_queued")` — no wrapper emitted
+
+## Open questions
+
+- none

--- a/ai-docs/plans/done/2026-05-03-connect-queued-codegen.spec.md
+++ b/ai-docs/plans/done/2026-05-03-connect-queued-codegen.spec.md
@@ -1,0 +1,52 @@
+# connect_<signal>_queued codegen
+
+**Source:** issue #66
+**Date:** 2026-05-03
+**Tracked in:** #66
+
+## Scope
+
+1. Add `emit_connect_queued_wrappers` function in `quartzite-macros/src/object/codegen.rs`
+2. Generate `connect_<signal>_queued(&mut self, receiver: &ObjectBase, f: F) -> ConnectionId` per signal
+   - Internally calls `Arc::downgrade(receiver.receiver_guard())`; delegates to `Signal::connect_queued`
+   - Gated `#[cfg(feature = "std")]`, `#[inline]`
+   - `#[allow(unexpected_cfgs)]` on the outer impl block (same pattern as `connect_auto` wrappers)
+3. Tests: generated method present, `receiver_guard` in output, wrapper lives outside hidden mod, absent when no signals
+
+## Out of scope
+
+- `connect_<signal>_direct` or any other connection type wrappers
+- Changes to runtime or core crates
+
+## Deferred
+
+- none
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| What to emit when struct has no signals? | Return `quote! {}` — omit the entire impl block, same as `emit_connect_auto_wrappers` |
+
+## Technical constraints
+
+- Mirror `emit_connect_auto_wrappers` exactly in structure; reuse all patterns from it
+- `#[allow(unexpected_cfgs)]` on the generated `impl` block (not the fn) — same as auto wrappers
+- Doc comment on each generated method; `# Examples` block required (use `no_run`)
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `#[derive(Object)]` on a struct with signals generates a `connect_<signal>_queued` method for each signal |
+| AC2 | The generated method accepts `&mut self`, `receiver: &ObjectBase`, and a closure `f: F`; returns `ConnectionId` |
+| AC3 | The generated method internally calls `Arc::downgrade(receiver.receiver_guard())` and delegates to `Signal::connect_queued` |
+| AC4 | The generated method is gated `#[cfg(feature = "std")]` and carries `#[inline]` |
+| AC5 | The generated `impl` block carries `#[allow(unexpected_cfgs)]` |
+| AC6 | The generated method lives outside the `#[doc(hidden)]` mod (same as `connect_auto` wrappers) |
+| AC7 | `#[derive(Object)]` on a struct with no signals emits no `connect_queued` impl block |
+| AC8 | Each generated method has a `///` doc comment and a `# Examples` (`no_run`) block |
+
+## Open questions
+
+- none

--- a/quartzite-macros/src/object/codegen.rs
+++ b/quartzite-macros/src/object/codegen.rs
@@ -18,6 +18,7 @@ pub(crate) fn codegen(ir: ObjectInput) -> TokenStream {
     let lookup_signal_fn = emit_lookup_signal_fn(type_ident, &ir.signals);
     let emit_wrappers = emit_signal_wrappers(type_ident, &ir.signals);
     let connect_auto_wrappers = emit_connect_auto_wrappers(type_ident, &ir.signals);
+    let connect_queued_wrappers = emit_connect_queued_wrappers(type_ident, &ir.signals);
 
     quote! {
         #[doc(hidden)]
@@ -34,6 +35,7 @@ pub(crate) fn codegen(ir: ObjectInput) -> TokenStream {
 
         #emit_wrappers
         #connect_auto_wrappers
+        #connect_queued_wrappers
     }
 }
 
@@ -338,6 +340,54 @@ fn emit_connect_auto_wrappers(type_ident: &Ident, signals: &[SignalField]) -> To
                     receiver.thread_id,
                     ::std::sync::Arc::downgrade(receiver.receiver_guard()),
                     f,
+                )
+            }
+        }
+    });
+    quote! {
+        // `#[cfg(feature = "std")]` is evaluated against the destination crate.
+        // `#[allow(unexpected_cfgs)]` prevents a check-cfg warning in crates
+        // that do not declare `std` as an explicit feature.
+        #[allow(unexpected_cfgs)]
+        impl #type_ident {
+            #(#methods)*
+        }
+    }
+}
+
+fn emit_connect_queued_wrappers(type_ident: &Ident, signals: &[SignalField]) -> TokenStream {
+    if signals.is_empty() {
+        return quote! {};
+    }
+    let methods = signals.iter().map(|s| {
+        let field = &s.ident;
+        let fn_name = Ident::new(&format!("connect_{field}_queued"), field.span());
+        let fn_name_str = fn_name.to_string();
+        let args_ty = &s.args_ty;
+        let example_doc = format!(
+            " # Examples\n\n```no_run\n# fn example(obj: &mut Receiver, receiver: &quartzite::core::ObjectBase) {{\n#     obj.{fn_name_str}(receiver, |_| {{}});\n# }}\n```"
+        );
+        quote! {
+            /// Connects this signal to a slot with `Queued` delivery.
+            ///
+            /// The slot is always posted to the receiver's dispatcher, even when emitted
+            /// from the same thread. The slot is silently skipped once `receiver` has been
+            /// dropped.
+            #[doc = #example_doc]
+            #[cfg(feature = "std")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+            #[inline]
+            pub fn #fn_name<F>(
+                &mut self,
+                receiver: &::quartzite::core::ObjectBase,
+                f: F,
+            ) -> ::quartzite::core::ConnectionId
+            where
+                F: ::core::ops::Fn(#args_ty) + ::core::marker::Send + ::core::marker::Sync + 'static,
+            {
+                self.#field.connect_queued(
+                    f,
+                    ::std::sync::Arc::downgrade(receiver.receiver_guard()),
                 )
             }
         }
@@ -786,21 +836,25 @@ mod tests {
         let mod_start = out
             .find("mod __quartzite_Foo")
             .expect("hidden mod not found");
-        // There will be two `impl Foo` blocks — one for emit wrappers and one for
-        // connect_auto wrappers. Find the last one.
-        let last_impl = out.rfind("impl Foo").expect("outer impl block not found");
+        // Three `impl Foo` blocks: emit wrappers [0], connect_auto wrappers [1],
+        // connect_queued wrappers [2]. The auto block is at index 1.
+        let positions: Vec<usize> = out.match_indices("impl Foo").map(|(i, _)| i).collect();
+        assert_eq!(positions.len(), 3, "expected 3 impl Foo blocks: {out}");
+        let auto_impl = positions[1];
+        let queued_impl = positions[2];
         assert!(
-            last_impl > mod_start,
+            auto_impl > mod_start,
             "connect_auto impl Foo block not after hidden mod: {out}"
         );
-        let mod_section = &out[mod_start..last_impl];
+        let mod_section = &out[mod_start..auto_impl];
         assert!(
             !mod_section.contains("connect_ticked_auto"),
             "connect_ticked_auto found inside hidden mod section: {mod_section}"
         );
+        let auto_section = &out[auto_impl..queued_impl];
         assert!(
-            out[last_impl..].contains("connect_ticked_auto"),
-            "connect_ticked_auto not found in outer impl block: {out}"
+            auto_section.contains("connect_ticked_auto"),
+            "connect_ticked_auto not found in auto impl block: {auto_section}"
         );
     }
 
@@ -816,6 +870,93 @@ mod tests {
         assert!(
             !out.contains("connect_auto"),
             "unexpected connect_auto wrapper for no-signal struct: {out}"
+        );
+    }
+
+    // connect_queued wrappers: generated for each signal, gated cfg(feature="std"), #[inline].
+    #[test]
+    fn connect_queued_wrapper_generated_for_signal() {
+        let out = emit(quote! {
+            struct Foo {
+                #[signal]
+                pub value_changed: Signal<(i32,)>,
+            }
+        });
+        assert!(
+            out.contains("pub fn connect_value_changed_queued"),
+            "missing connect_queued wrapper: {out}"
+        );
+        assert!(
+            out.contains("cfg (feature = \"std\")"),
+            "missing cfg(feature=\"std\") gate: {out}"
+        );
+        assert!(
+            out.contains("# [inline] pub fn connect_value_changed_queued"),
+            "missing #[inline] on connect_queued wrapper: {out}"
+        );
+        assert!(
+            out.contains("receiver : & :: quartzite :: core :: ObjectBase"),
+            "missing receiver param: {out}"
+        );
+        assert!(
+            out.contains("connect_queued"),
+            "wrapper must delegate to connect_queued: {out}"
+        );
+        assert!(
+            out.contains("receiver . receiver_guard ()"),
+            "wrapper must pass receiver.receiver_guard() to connect_queued: {out}"
+        );
+        assert!(
+            out.contains("allow (unexpected_cfgs)"),
+            "missing #[allow(unexpected_cfgs)] on impl block: {out}"
+        );
+        assert!(
+            out.contains("no_run"),
+            "missing # Examples no_run fence in generated doc: {out}"
+        );
+    }
+
+    // connect_queued wrappers live outside the hidden module.
+    #[test]
+    fn connect_queued_wrapper_lives_outside_hidden_mod() {
+        let out = emit(quote! {
+            struct Foo {
+                #[signal]
+                pub ticked: Signal<(i32,)>,
+            }
+        });
+        let mod_start = out
+            .find("mod __quartzite_Foo")
+            .expect("hidden mod not found");
+        // The connect_queued impl block is the last (third) impl block.
+        let last_impl = out.rfind("impl Foo").expect("outer impl block not found");
+        assert!(
+            last_impl > mod_start,
+            "connect_queued impl Foo block not after hidden mod: {out}"
+        );
+        let mod_section = &out[mod_start..last_impl];
+        assert!(
+            !mod_section.contains("connect_ticked_queued"),
+            "connect_ticked_queued found inside hidden mod section: {mod_section}"
+        );
+        assert!(
+            out[last_impl..].contains("connect_ticked_queued"),
+            "connect_ticked_queued not found in outer impl block: {out}"
+        );
+    }
+
+    // No signals → no connect_queued wrappers.
+    #[test]
+    fn connect_queued_wrapper_absent_with_no_signals() {
+        let out = emit(quote! {
+            struct Foo {
+                #[prop]
+                pub count: i32,
+            }
+        });
+        assert!(
+            !out.contains("connect_queued"),
+            "unexpected connect_queued wrapper for no-signal struct: {out}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds `emit_connect_queued_wrappers` in `quartzite-macros/src/object/codegen.rs`, mirroring the existing `emit_connect_auto_wrappers`
- Each generated `connect_<signal>_queued` method is gated `#[cfg(feature = "std")]`, carries `#[inline]` and a `# Examples` `no_run` block, and delegates to `Signal::connect_queued(f, Arc::downgrade(receiver.receiver_guard()))` — note `f` comes first (opposite of `connect_auto`)
- Updates `connect_auto_wrapper_lives_outside_hidden_mod` test to use `match_indices`-based position indexing (now 3 `impl` blocks: emit, auto, queued) instead of `rfind`

## Tracking

Closes #66

## Test plan

- [x] `connect_queued_wrapper_generated_for_signal` — method emitted, `cfg(std)`, `#[inline]`, receiver param, delegates to `connect_queued`, `receiver_guard()` extracted, `#[allow(unexpected_cfgs)]`, `no_run` fence present
- [x] `connect_queued_wrapper_lives_outside_hidden_mod` — wrapper lives after the hidden mod, not inside it
- [x] `connect_queued_wrapper_absent_with_no_signals` — no wrapper emitted for signal-free structs
- [x] `connect_auto_wrapper_lives_outside_hidden_mod` updated and still passes
- [x] `cargo build` clean
- [x] `cargo test --workspace` all green
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` clean
- [x] `cargo build -p quartzite --no-default-features` clean