### PR TITLE
feat(quartzite-core): replace PropertyFlags bool-struct with enumflags2 bitfield

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +246,7 @@ name = "quartzite-core"
 version = "0.1.0"
 dependencies = [
  "document-features",
+ "enumflags2",
  "hashbrown 0.15.5",
  "indexmap",
  "rstest",

--- a/ai-docs/context.md
+++ b/ai-docs/context.md
@@ -113,6 +113,7 @@ AsObject        AsWidget        AsWidget (generated)
 | `emit_<signal>` codegen | `#[derive(Object)]` generates `pub fn emit_<signal>(&mut self, arg0: T0, ...)` methods (flattened tuple args) on the struct. Guard uses `AsObject::object_base(self).signals_blocked()` — works for root and derived types alike. |
 | `connect_<signal>_auto` codegen | `#[derive(Object)]` generates `pub fn connect_<signal>_auto(&mut self, receiver: &ObjectBase, f: F)` methods (gated `#[cfg(feature = "std")]`, `#[inline]`) on the struct. Extracts `receiver.thread_id` and `Arc::downgrade(receiver.receiver_guard())` internally; delegates to `Signal::connect_auto`. |
 | `connect_<signal>_queued` codegen | `#[derive(Object)]` generates `pub fn connect_<signal>_queued(&mut self, receiver: &ObjectBase, f: F)` methods (gated `#[cfg(feature = "std")]`, `#[inline]`) on the struct. Extracts `Arc::downgrade(receiver.receiver_guard())` internally; delegates to `Signal::connect_queued(f, guard)` (`f` first — opposite order from `connect_auto`). No `thread_id` argument needed. |
+| `PropertyFlags` representation | `pub type PropertyFlags = BitFlags<PropertyFlag>` via `enumflags2`. `PropertyFlag` is a `#[bitflags(default = Readable \| Writable \| Stored \| Designable)] #[repr(u8)]` enum. Named constructors (`none`, `read_write`, `read_only`) are `const fn` on `impl PropertyFlag`. Proc-macro codegen uses `make_bitflags!(PropertyFlag::{…})` via a `use ::quartzite::core::PropertyFlag;` import inside the generated hidden module; `enumflags2` is `#[doc(hidden)]` re-exported from `quartzite-core` for that path. |
 
 ## Plans (Implementation Order)
 
@@ -127,7 +128,7 @@ Crate-level plans:
 7. `quartzite-widgets` — WidgetBase + concrete widgets + layouts
 8. `quartzite-paint` + `quartzite-style` — painter + theming
 
-Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns), examples-crate (runnable API examples), signals-blocked (typed emit wrappers + `signals_blocked` guard), receiver-guard-auto (`Weak<ReceiverGuard>` for Auto connections + `connect_<signal>_auto` codegen), connect-queued-codegen (`connect_<signal>_queued` typed wrappers).
+Maintenance plans (cross-cutting, all ✅): auto-connection (signal/slot extension), code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf (O(1) signal disconnect, name index, match-based meta lookup), inline-simple-fns (`#[inline]` on simple non-generic fns), examples-crate (runnable API examples), signals-blocked (typed emit wrappers + `signals_blocked` guard), receiver-guard-auto (`Weak<ReceiverGuard>` for Auto connections + `connect_<signal>_auto` codegen), connect-queued-codegen (`connect_<signal>_queued` typed wrappers), enumflags2-property-flags (`PropertyFlags` replaced by `BitFlags<PropertyFlag>` backed by `u8` via `enumflags2`).
 
 ## Open Questions
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -20,6 +20,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [signals-blocked](done/2026-05-02-signals-blocked.spec.md) | `quartzite-core` `quartzite-macros` | ✅ implemented (13 new tests) | — |
 | [receiver-guard-auto](done/2026-05-03-receiver-guard-auto.spec.md) | `quartzite-core` `quartzite-macros` | ✅ implemented (4 new tests) | — |
 | [connect-queued-codegen](done/2026-05-03-connect-queued-codegen.spec.md) | `quartzite-macros` | ✅ implemented (3 new tests) | — |
+| [enumflags2-property-flags](done/2026-05-03-enumflags2-property-flags.spec.md) | `quartzite-core` `quartzite-macros` | ✅ implemented (6 new tests) | — |
 
 ## Deferred plans
 

--- a/ai-docs/plans/done/2026-05-03-enumflags2-property-flags.design.md
+++ b/ai-docs/plans/done/2026-05-03-enumflags2-property-flags.design.md
@@ -1,0 +1,291 @@
+# Design: Replace PropertyFlags bool-struct with enumflags2 bitfield
+
+**Issue:** #69
+**Date:** 2026-05-03
+
+## Approach
+
+Replace the hand-rolled `PropertyFlags` bool-struct with a `#[bitflags] #[repr(u8)] enum PropertyFlag`
+backed by `enumflags2::BitFlags<PropertyFlag>`. This is a clean breaking change accepted by the spec.
+
+### Chosen solution
+
+1. **`PropertyFlag` enum** — defined in `quartzite-core/src/meta.rs` alongside all other metadata
+   types. No new file needed; the module is small and cohesive. The enum carries `#[bitflags]` and
+   `#[repr(u8)]`, and the existing `#[derive(Debug, Clone, Copy, PartialEq, Eq)]` cluster is replaced
+   by what `enumflags2` requires (the macro emits `Copy + Clone`; `Debug`, `PartialEq`, `Eq` come from
+   the derive on the enum itself).
+
+2. **`PropertyFlags` type alias** — `pub type PropertyFlags = BitFlags<PropertyFlag>`. The alias keeps
+   all downstream call-sites (`PropertyMeta::new(…, PropertyFlags::read_write())`) compiling without
+   change, because the named constructors (`none`, `read_write`, `read_only`) are moved to
+   `impl PropertyFlag` returning `BitFlags<Self>` — the same name, same call syntax via the alias.
+
+3. **`const fn` constructors** — `enumflags2` exposes `make_bitflags!(T::{A | B})` which is explicitly
+   documented as `const`-compatible and expands to `from_bits_unchecked_c` with `CONST_TOKEN`. The
+   macro body uses `let mut n = 0; n |= flag as Numeric;` inside a block — both `let mut` and `|=` in
+   a const context have been stable since Rust 1.57, well below the project MSRV of 1.95. All three
+   constructors (`none`, `read_write`, `read_only`) use `make_bitflags!` and are declared `pub const
+   fn`. This satisfies the constraint that `PropertyMeta::new` is a `const fn` used in `static`
+   initialisers.
+
+   Concretely:
+   ```rust
+   pub const fn none() -> BitFlags<Self> {
+       BitFlags::EMPTY   // make_bitflags! does not accept an empty brace list
+   }
+   pub const fn read_write() -> BitFlags<Self> {
+       enumflags2::make_bitflags!(PropertyFlag::{Readable | Writable | Stored | Designable})
+   }
+   pub const fn read_only() -> BitFlags<Self> {
+       enumflags2::make_bitflags!(PropertyFlag::{Readable | Stored | Designable | Constant})
+   }
+   ```
+   `BitFlags::EMPTY` is a `const` associated constant — usable in `const fn` contexts. The
+   `make_bitflags!` macro does not accept an empty brace list for `none()`, so `BitFlags::EMPTY` is
+   used directly.
+
+4. **`Default` for `PropertyFlags`** — AC4 requires `Default for PropertyFlags` to return
+   `read_write()`. `enumflags2` already provides `impl<T: BitFlag> Default for BitFlags<T>`; the
+   orphan rule does not apply. The `#[bitflags]` proc-macro supports a `default = ...` argument that
+   sets the value returned by `Default::default()` for `BitFlags<T>`.
+
+   The enum declaration becomes:
+   ```rust
+   #[bitflags(default = Readable | Writable | Stored | Designable)]
+   #[repr(u8)]
+   #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+   pub enum PropertyFlag { … }
+   ```
+   `BitFlags::<PropertyFlag>::default()` then returns the same set as `PropertyFlag::read_write()`.
+   No manual `impl Default` block is needed. No newtype is introduced.
+
+5. **Dependency declaration** — `enumflags2 = "0.7.12"` added to `quartzite-core/Cargo.toml` as a
+   direct crate-level dependency (not workspace-level), since only `quartzite-core` uses it.
+   `no_std` is supported natively (`#![cfg_attr(all(not(test), not(feature = "std")), no_std)]` inside
+   `enumflags2`); the `std` feature in `enumflags2` only adds `Error` impl on `FromBitsError` and is
+   not needed. No `default-features = false` override is required because `enumflags2` has no default
+   features that pull in `std` unconditionally.
+
+6. **Proc-macro codegen** — `quartzite-macros/src/object/codegen.rs` currently emits a struct literal:
+   ```rust
+   ::quartzite::core::PropertyFlags { readable: #readable, writable: #writable, … }
+   ```
+   This is replaced by a `make_bitflags!`-style conditional union built from the same `bool` variables.
+   Because `make_bitflags!` requires variant names statically (not runtime bools), the codegen must
+   emit an explicit bit-union expression:
+
+   ```rust
+   {
+       let mut __f = ::quartzite::core::PropertyFlag::none();
+       if #readable  { __f |= ::quartzite::core::PropertyFlag::Readable;  }
+       if #writable  { __f |= ::quartzite::core::PropertyFlag::Writable;  }
+       if #notify    { __f |= ::quartzite::core::PropertyFlag::Notify;    }
+       if #stored    { __f |= ::quartzite::core::PropertyFlag::Stored;    }
+       if #designable{ __f |= ::quartzite::core::PropertyFlag::Designable;}
+       if #user      { __f |= ::quartzite::core::PropertyFlag::User;      }
+       if #constant  { __f |= ::quartzite::core::PropertyFlag::Constant;  }
+       __f
+   }
+   ```
+
+   However, the booleans in the codegen are **compile-time literals** (each is a `bool` literal in the
+   `quote!` expansion, computed by the proc-macro at macro-expansion time, not at the user's runtime).
+   Therefore `make_bitflags!` **can** be used: the codegen constructs the flag set at Rust-compile time
+   by pattern-matching the booleans and emitting the appropriate `make_bitflags!` call directly.
+
+   Concretely, `emit_props_static` already computes `readable`, `writable`, etc. as Rust `bool` values
+   inside the proc-macro. The codegen emits a `make_bitflags!` call whose variant list is built by
+   filtering those booleans.
+
+   **`make_bitflags!` path constraint:** The macro's grammar is `$enum:ident ::{…}` — it accepts
+   only a bare identifier, not a qualified path. Emitting
+   `make_bitflags!(::quartzite::core::PropertyFlag::{…})` does **not** compile. To work around this,
+   the generated hidden module (`mod __quartzite_Foo { … }`) already emits `use` items for other
+   quartzite types. The codegen must additionally emit
+   `use ::quartzite::core::PropertyFlag;` inside that hidden module so the bare identifier
+   `PropertyFlag` is in scope for `make_bitflags!(PropertyFlag::{…})`.
+
+   ```rust
+   // In emit_props_static (proc-macro Rust code, not generated code):
+   let flag_variants: Vec<TokenStream> = [
+       (readable,   quote!(Readable)),
+       (writable,   quote!(Writable)),
+       (notify,     quote!(Notify)),
+       (stored,     quote!(Stored)),
+       (designable, quote!(Designable)),
+       (user,       quote!(User)),
+       (constant,   quote!(Constant)),
+   ]
+   .into_iter()
+   .filter_map(|(active, tok)| active.then_some(tok))
+   .collect();
+
+   // The hidden module (generated by `codegen`) must include:
+   //   use ::quartzite::core::PropertyFlag;
+   // so the bare ident is resolvable inside the module.
+
+   // Then emit per-property:
+   quote! {
+       ::quartzite::core::PropertyMeta::new(
+           #name,
+           ::core::stringify!(#ty),
+           ::quartzite::core::enumflags2::make_bitflags!(PropertyFlag::{#(#flag_variants)|*}),
+       )
+   }
+   ```
+
+   The `use ::quartzite::core::PropertyFlag;` import is emitted once at the top of the hidden module,
+   alongside the existing use-imports. This makes `PropertyFlag` a bare ident in scope for every
+   `make_bitflags!` call in that module.
+
+   This produces a single `make_bitflags!` expression that is a `const` value, satisfying the
+   `const fn PropertyMeta::new` requirement.
+
+   > **Re-export path:** `quartzite-macros` does not depend on `enumflags2` directly and should not.
+   > The macro is accessed as `::quartzite::core::enumflags2::make_bitflags!` — which resolves
+   > because `quartzite-core` re-exports `enumflags2` (see item 8 below) and the facade re-exports
+   > `quartzite-core` wholesale.
+
+   Revised plan: add `#[doc(hidden)] pub use enumflags2;` to `quartzite-core/src/lib.rs` so that the
+   path `::quartzite::core::enumflags2::make_bitflags!(...)` resolves in user crates, and emit
+   `use ::quartzite::core::PropertyFlag;` inside the generated hidden module so `make_bitflags!` can
+   reference the bare ident `PropertyFlag`.
+
+7. **Field-access migration** — the only two call sites using `flags.field` notation are in
+   `quartzite-core/src/meta.rs` tests. These change to `flags.contains(PropertyFlag::Readable)` etc.
+   Doctest examples in `meta.rs` that use `f.readable` are updated to `f.contains(PropertyFlag::Readable)`.
+
+8. **Re-export chain** — `quartzite-core/src/lib.rs` exports:
+   ```rust
+   pub use meta::{…, PropertyFlag, PropertyFlags, …};
+   /// Re-exported solely for use by quartzite proc-macro generated code; not part of the public API.
+   #[doc(hidden)]
+   pub use enumflags2;
+   ```
+   Marking the re-export `#[doc(hidden)]` prevents it from appearing in `cargo doc` output while
+   still being accessible by path from generated code. The facade `src/lib.rs` uses
+   `pub use quartzite_core::*` (via `pub mod core`), so `quartzite::core::PropertyFlag`,
+   `quartzite::core::PropertyFlags`, and `quartzite::core::enumflags2` all become available
+   automatically.
+
+### Rejected alternatives
+
+- **newtype wrapper** — adds boilerplate `Deref`, `From`, `Into` impls; deferred per spec.
+- **separate `property_flag.rs` file** — unnecessary; the type is small and belongs with its peers in `meta.rs`.
+- **workspace-level `enumflags2` dep** — only `quartzite-core` needs it; crate-level is sufficient.
+- **runtime bit-union in codegen** (`if` chain) — unnecessarily produces non-`const` code; using `make_bitflags!` keeps the static array `const`.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Add `enumflags2 = "0.7.12"` to `quartzite-core/Cargo.toml`; run `cargo build -p quartzite-core` to update `Cargo.lock` | `quartzite-core/Cargo.toml`, `Cargo.lock` | — |
+| 2 | Define `#[bitflags] #[repr(u8)] pub enum PropertyFlag` with 7 variants in `meta.rs`; add `pub type PropertyFlags = BitFlags<PropertyFlag>` type alias; remove old struct | `quartzite-core/src/meta.rs` | 1 |
+| 3 | Add `impl PropertyFlag` with `const fn none()`, `const fn read_write()`, `const fn read_only()` using `make_bitflags!` / `BitFlags::EMPTY`; drop old `impl PropertyFlags` block and old `impl Default for PropertyFlags` block (`Default` is now provided by `enumflags2` via `#[bitflags(default = …)]`) | `quartzite-core/src/meta.rs` | 2 |
+| 4 | Re-export `PropertyFlag` and `enumflags2` from `quartzite-core/src/lib.rs` | `quartzite-core/src/lib.rs` | 2 |
+| 5 | Update in-file doctests in `meta.rs`: replace `f.readable` / `!f.writable` / `f.constant` with `f.contains(PropertyFlag::Readable)` etc.; update use-paths in doctests | `quartzite-core/src/meta.rs` | 3 |
+| 6 | Update unit tests in `meta.rs` `#[cfg(test)]` block: replace `prop.flags.readable` etc. with `prop.flags.contains(PropertyFlag::Readable)` | `quartzite-core/src/meta.rs` | 3 |
+| 7 | Update proc-macro codegen: replace struct-literal emission with `make_bitflags!`-based emission using filtered variant list; add `use ::quartzite::core::PropertyFlag;` to the hidden-module token stream; rewrite the 4 flag-related unit tests in `codegen.rs` that assert old struct-literal fragments | `quartzite-macros/src/object/codegen.rs` | 4 |
+| 8 | Run full test suite (`cargo test`), clippy (`cargo clippy -- -D warnings`), doc gate (`RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace`), and no_std path (`cargo build -p quartzite --no-default-features`) | — | 1–7 |
+
+## Risks
+
+- **`make_bitflags!` empty set syntax**: `make_bitflags!(PropertyFlag::{})` — the macro does not
+  accept an empty brace list for `none()`. Mitigation: confirmed — use `BitFlags::EMPTY` (a `const`
+  associated constant) directly for `none()`.
+- **`make_bitflags!` accepts only bare idents**: the macro grammar is `$enum:ident ::{…}`; qualified
+  paths like `::quartzite::core::PropertyFlag` do not parse. Mitigation: emit
+  `use ::quartzite::core::PropertyFlag;` inside the generated hidden module so the bare ident is in
+  scope (see codegen section above).
+- **`make_bitflags!` const-safety at MSRV 1.95**: The macro expands to `let mut n = 0; n |= flag as
+  Numeric;` inside a block. Both `let mut` in const and `|=` on integers in const have been stable
+  since Rust 1.57 — well below the project MSRV of 1.95. No risk.
+- **`Default` for `PropertyFlags`**: `enumflags2` provides `impl<T: BitFlag> Default for BitFlags<T>`
+  driven by `#[bitflags(default = …)]`. No orphan-rule issue. Mitigation: use
+  `#[bitflags(default = Readable | Writable | Stored | Designable)]` on the enum declaration.
+- **`make_bitflags!` path in generated code**: the macro must be reachable from user crates via
+  `::quartzite::core::enumflags2::make_bitflags!(...)`. Mitigation: add
+  `#[doc(hidden)] pub use enumflags2;` to `quartzite-core/src/lib.rs` and verify the path resolves
+  in integration tests.
+- **`PropertyMeta::new` const stability**: it is already `const fn`; `BitFlags` values produced by
+  `make_bitflags!` are `const`, so the static array in proc-macro output remains const. Low risk.
+- **`no_std` compatibility**: `enumflags2` supports `no_std` without any feature flag. Verify with
+  `cargo build -p quartzite --no-default-features` in task 8.
+- **`#[bitflags]` attribute requires `enumflags2_derive`**: the `enumflags2` crate re-exports its
+  derive macro, so adding only `enumflags2` to `[dependencies]` is sufficient — no separate
+  `enumflags2_derive` needed.
+
+## Test Design
+
+### Task 3 & 6 — Unit tests in `quartzite-core/src/meta.rs` `#[cfg(test)]`
+
+**Location:** `quartzite-core/src/meta.rs`, existing `mod tests`
+
+**Modified tests (field-access → `contains`):**
+- `property_meta_flags_readable_writable`: `prop.flags.readable` → `prop.flags.contains(PropertyFlag::Readable)`, etc.
+- `property_meta_flags_read_only_constant`: same pattern.
+
+**New tests to add:**
+- `property_flag_none_is_empty`: `PropertyFlag::none().is_empty()` is `true`.
+- `property_flag_read_write_contains`: asserts `Readable`, `Writable`, `Stored`, `Designable` are
+  set; `Notify`, `User`, `Constant` are not.
+- `property_flag_read_only_contains`: asserts `Readable`, `Stored`, `Designable`, `Constant` are
+  set; `Writable`, `Notify`, `User` are not.
+- `property_flags_default_is_read_write`: asserts
+  `PropertyFlags::default() == PropertyFlag::read_write()`. `Default` is provided by `enumflags2`
+  via `#[bitflags(default = Readable | Writable | Stored | Designable)]` — this test must pass.
+- `property_flag_const_constructors`: `const` items in the test module using the constructors to
+  verify they are usable in `const` contexts (compiler-checked, no runtime assertion needed).
+
+### Task 7 — Proc-macro codegen unit tests (existing tests that must be rewritten)
+
+**Location:** `quartzite-macros/src/object/codegen.rs` `#[cfg(test)]` module
+
+The current test suite contains 4 tests that call `codegen(ir).to_string()` and assert string
+fragments that match the old struct-literal syntax. After the change to `make_bitflags!`, these
+assertions fail. They **must** be rewritten as part of Task 7 — not treated as a separate task.
+
+**Tests to rewrite (all in `mod tests` of `codegen.rs`):**
+
+| Test name | Old assertions to remove | New assertions to add |
+|---|---|---|
+| `writable_prop_flags` | `"readable : true"`, `"writable : true"`, `"notify : false"` | `"make_bitflags"`, `"Readable"`, `"Writable"` present; `"Notify"` absent in flags expression |
+| `read_only_prop_has_writable_false` | `"writable : false"` | `"make_bitflags"` present; `"Writable"` absent in the flags tokens for that property |
+| `constant_prop_has_writable_false` | `"writable : false"`, `"constant : true"` | `"make_bitflags"` present; `"Constant"` present; `"Writable"` absent |
+| `notify_prop_has_notify_true` | `"notify : true"` | `"make_bitflags"` present; `"Notify"` present |
+
+**Strategy note:** `to_string()` on a `TokenStream` produces space-separated tokens. For the new
+codegen, a writable property expands to a fragment like:
+```
+make_bitflags ! (PropertyFlag ::{ Readable | Writable | Stored | Designable })
+```
+Assertions should check:
+- `out.contains("make_bitflags")` — macro was emitted.
+- `out.contains("Readable")` — Readable flag present when expected.
+- `out.contains("Writable")` — presence or absence depending on property kind.
+- `out.contains("Notify")` — presence or absence.
+- `out.contains("Constant")` — presence or absence.
+- `out.contains("use :: quartzite :: core :: PropertyFlag")` — the use-import is emitted inside the
+  hidden module, making the bare ident available for `make_bitflags!`.
+
+**All other tests in `codegen.rs` are unaffected** by this change (they test signals, read/write
+dispatch, wrappers, etc.) and require no modification.
+
+### Task 7 — Proc-macro codegen integration tests
+
+**Location:** `quartzite-macros/tests/object.rs` or `quartzite-macros/tests/object_impl.rs`
+
+**Entry point:** existing `#[derive(Object)]` / `#[object_impl]` usage that exercises property codegen.
+
+**Scenarios:**
+- Inspect `META.properties[n].flags.contains(PropertyFlag::Readable)` for a known property with
+  `#[prop]` — happy path.
+- A `#[prop(constant)]` property has `Constant` set and `Writable` unset.
+- A `#[prop(notify = signal)]` property has `Notify` set.
+- These scenarios already exist implicitly if the compilation succeeds; add explicit `assert!` calls
+  where the tests currently do not inspect flags.
+
+## Open questions
+
+- None.

--- a/ai-docs/plans/done/2026-05-03-enumflags2-property-flags.spec.md
+++ b/ai-docs/plans/done/2026-05-03-enumflags2-property-flags.spec.md
@@ -1,0 +1,53 @@
+# Replace PropertyFlags bool-struct with enumflags2 bitfield
+
+**Source:** user description
+**Date:** 2026-05-03
+**Tracked in:** #69
+
+## Scope
+- Add `enumflags2` dependency to `quartzite-core`
+- Define `#[bitflags] #[repr(u8)] pub enum PropertyFlag` with 7 variants: `Readable`, `Writable`, `Notify`, `Stored`, `Designable`, `User`, `Constant`
+- Expose `pub type PropertyFlags = BitFlags<PropertyFlag>` as the public composite type
+- Re-export both `PropertyFlag` and `PropertyFlags` from `quartzite-core` public API
+- Move named constructors (`none()`, `read_write()`, `read_only()`) to `impl PropertyFlag` returning `BitFlags<Self>`
+- Keep `Default` returning `PropertyFlag::read_write()`
+- Update proc-macro codegen (`quartzite-macros`) to construct `BitFlags` from per-field booleans
+- Update all field-access sites in the codebase (`flags.readable` → `flags.contains(PropertyFlag::Readable)`)
+
+## Out of scope
+- Serialization / deserialization (serde) support
+- FFI / integer wire format
+- Any changes to other metadata types (`SignalMeta`, `MethodMeta`, etc.)
+
+## Deferred
+- `from_bits` / integer round-trip API | not needed today; can be added later
+
+## Key decisions
+| Question | Decision |
+|---|---|
+| Breaking change acceptable? | Yes |
+| `PropertyFlag` exposed as public API? | Yes |
+| Type alias or newtype for `PropertyFlags`? | Type alias: `pub type PropertyFlags = BitFlags<PropertyFlag>` |
+| Named constructors location? | `impl PropertyFlag` — methods returning `BitFlags<Self>` |
+| `enumflags2` version? | Latest stable; verify `const` support and `no_std` compatibility |
+
+## Technical constraints
+- `quartzite-core` must remain `no_std` compatible — `enumflags2` supports this
+- `PropertyMeta::new` is `const fn` and used in `static` initialisers — named constructors must also be `const fn`
+- Proc-macro codegen in `quartzite-macros` constructs `PropertyFlags` via struct literal today; must switch to `BitFlags`-compatible construction
+- `enumflags2` requires `#[repr(u8)]` (or other integer repr) on the enum
+
+## Acceptance Criteria
+| # | Criterion |
+|---|-----------|
+| AC1 | `PropertyFlag` is a public `#[bitflags] #[repr(u8)]` enum in `quartzite-core` with variants `Readable`, `Writable`, `Notify`, `Stored`, `Designable`, `User`, `Constant` |
+| AC2 | `PropertyFlags` is a public type alias `BitFlags<PropertyFlag>` exported from `quartzite-core` |
+| AC3 | `PropertyFlag::none()`, `PropertyFlag::read_write()`, `PropertyFlag::read_only()` are `const fn` methods returning `BitFlags<Self>` with the same flag combinations as the old struct constructors |
+| AC4 | `Default` for `PropertyFlags` returns `PropertyFlag::read_write()` |
+| AC5 | Proc-macro codegen produces valid `BitFlags<PropertyFlag>` values — existing `#[derive(Object)]` / `#[object_impl]` usage compiles without change to user code |
+| AC6 | All existing test assertions that checked individual bool fields pass against the new `contains()`-based API |
+| AC7 | `cargo build -p quartzite --no-default-features` compiles clean (no_std path) |
+| AC8 | `cargo clippy -- -D warnings` passes with no new warnings |
+
+## Open questions
+- None

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -16,6 +16,7 @@ std = ["indexmap/std"]
 
 [dependencies]
 document-features = "~0.2"
+enumflags2 = "0.7.12"
 indexmap = { version = "2", default-features = false }
 hashbrown = { version = "0.15", default-features = false }
 

--- a/quartzite-core/src/lib.rs
+++ b/quartzite-core/src/lib.rs
@@ -31,9 +31,13 @@ pub mod __macro {
 
 // --- Top-level re-exports ---
 
+/// Re-exported solely for use by quartzite proc-macro generated code; not part of the public API.
+#[doc(hidden)]
+pub use enumflags2;
 pub use id::{ConnectionId, ObjectId};
 pub use meta::{
-    EnumEntry, EnumMeta, MetaObject, MethodMeta, ParamMeta, PropertyFlags, PropertyMeta, SignalMeta,
+    EnumEntry, EnumMeta, MetaObject, MethodMeta, ParamMeta, PropertyFlag, PropertyFlags,
+    PropertyMeta, SignalMeta,
 };
 pub use object_base::ObjectBase;
 pub use receiver_guard::ReceiverGuard;

--- a/quartzite-core/src/meta.rs
+++ b/quartzite-core/src/meta.rs
@@ -4,48 +4,70 @@
 //! stored as `'static` values. They can also be constructed manually for
 //! types that do not use the derive macros.
 
-/// Flags describing how a property can be accessed.
+use enumflags2::{BitFlags, bitflags};
+
+/// A single property-access capability. Combine with `|` to form [`PropertyFlags`].
+///
+/// # Examples
+///
+/// ```
+/// use quartzite_core::meta::{PropertyFlag, PropertyFlags};
+///
+/// let f: PropertyFlags = PropertyFlag::Readable | PropertyFlag::Writable;
+/// assert!(f.contains(PropertyFlag::Readable));
+/// assert!(!f.contains(PropertyFlag::Notify));
+/// ```
+#[bitflags(default = Readable | Writable | Stored | Designable)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PropertyFlags {
+pub enum PropertyFlag {
     /// Property value can be read via `read_property`.
-    pub readable: bool,
+    Readable = 0b0000_0001,
     /// Property value can be written via `write_property`.
-    pub writable: bool,
+    Writable = 0b0000_0010,
     /// A change notification signal exists for this property.
-    pub notify: bool,
+    Notify = 0b0000_0100,
     /// Property value is saved when the object is serialized.
-    pub stored: bool,
+    Stored = 0b0000_1000,
     /// Property is visible in design tools.
-    pub designable: bool,
+    Designable = 0b0001_0000,
     /// Property is intended for direct user interaction (e.g., a form field).
-    pub user: bool,
+    User = 0b0010_0000,
     /// Property value never changes after construction; implies not writable.
-    pub constant: bool,
+    Constant = 0b0100_0000,
 }
 
-impl PropertyFlags {
-    /// All flags false — useful as a starting point before enabling specific flags.
+/// A set of [`PropertyFlag`] values describing how a property can be accessed.
+///
+/// Construct with the named helpers on [`PropertyFlag`], or combine flags directly with `|`.
+///
+/// # Examples
+///
+/// ```
+/// use quartzite_core::meta::{PropertyFlag, PropertyFlags};
+///
+/// let f = PropertyFlag::read_write();
+/// assert!(f.contains(PropertyFlag::Readable));
+/// assert!(f.contains(PropertyFlag::Writable));
+/// assert!(!f.contains(PropertyFlag::Constant));
+/// ```
+pub type PropertyFlags = BitFlags<PropertyFlag>;
+
+impl PropertyFlag {
+    /// All flags unset — useful as a starting point before enabling specific flags.
     ///
     /// # Examples
     ///
     /// ```
-    /// use quartzite_core::meta::PropertyFlags;
+    /// use quartzite_core::meta::{PropertyFlag, PropertyFlags};
     ///
-    /// let f = PropertyFlags::none();
-    /// assert!(!f.readable);
-    /// assert!(!f.writable);
+    /// let f = PropertyFlag::none();
+    /// assert!(!f.contains(PropertyFlag::Readable));
+    /// assert!(!f.contains(PropertyFlag::Writable));
     /// ```
     #[inline]
-    pub const fn none() -> Self {
-        Self {
-            readable: false,
-            writable: false,
-            notify: false,
-            stored: false,
-            designable: false,
-            user: false,
-            constant: false,
-        }
+    pub const fn none() -> PropertyFlags {
+        BitFlags::EMPTY
     }
 
     /// The most common combination: readable + writable + stored + designable.
@@ -53,24 +75,16 @@ impl PropertyFlags {
     /// # Examples
     ///
     /// ```
-    /// use quartzite_core::meta::PropertyFlags;
+    /// use quartzite_core::meta::{PropertyFlag, PropertyFlags};
     ///
-    /// let f = PropertyFlags::read_write();
-    /// assert!(f.readable);
-    /// assert!(f.writable);
-    /// assert!(!f.constant);
+    /// let f = PropertyFlag::read_write();
+    /// assert!(f.contains(PropertyFlag::Readable));
+    /// assert!(f.contains(PropertyFlag::Writable));
+    /// assert!(!f.contains(PropertyFlag::Constant));
     /// ```
     #[inline]
-    pub const fn read_write() -> Self {
-        Self {
-            readable: true,
-            writable: true,
-            notify: false,
-            stored: true,
-            designable: true,
-            user: false,
-            constant: false,
-        }
+    pub const fn read_write() -> PropertyFlags {
+        enumflags2::make_bitflags!(PropertyFlag::{Readable | Writable | Stored | Designable})
     }
 
     /// Readable, stored, designable, constant (not writable).
@@ -78,31 +92,16 @@ impl PropertyFlags {
     /// # Examples
     ///
     /// ```
-    /// use quartzite_core::meta::PropertyFlags;
+    /// use quartzite_core::meta::{PropertyFlag, PropertyFlags};
     ///
-    /// let f = PropertyFlags::read_only();
-    /// assert!(f.readable);
-    /// assert!(!f.writable);
-    /// assert!(f.constant);
+    /// let f = PropertyFlag::read_only();
+    /// assert!(f.contains(PropertyFlag::Readable));
+    /// assert!(!f.contains(PropertyFlag::Writable));
+    /// assert!(f.contains(PropertyFlag::Constant));
     /// ```
     #[inline]
-    pub const fn read_only() -> Self {
-        Self {
-            readable: true,
-            writable: false,
-            notify: false,
-            stored: true,
-            designable: true,
-            user: false,
-            constant: true,
-        }
-    }
-}
-
-impl Default for PropertyFlags {
-    #[inline]
-    fn default() -> Self {
-        Self::read_write()
+    pub const fn read_only() -> PropertyFlags {
+        enumflags2::make_bitflags!(PropertyFlag::{Readable | Stored | Designable | Constant})
     }
 }
 
@@ -123,9 +122,9 @@ impl PropertyMeta {
     /// # Examples
     ///
     /// ```
-    /// use quartzite_core::meta::{PropertyFlags, PropertyMeta};
+    /// use quartzite_core::meta::{PropertyFlag, PropertyMeta};
     ///
-    /// let meta = PropertyMeta::new("count", "i64", PropertyFlags::read_write());
+    /// let meta = PropertyMeta::new("count", "i64", PropertyFlag::read_write());
     /// assert_eq!(meta.name, "count");
     /// ```
     #[inline]
@@ -494,11 +493,11 @@ impl MetaObject {
     ///
     /// ```
     /// use quartzite_core::meta::{
-    ///     MetaObject, PropertyFlags, PropertyMeta,
+    ///     MetaObject, PropertyFlag, PropertyMeta,
     ///     noop_lookup_signal, noop_lookup_method, noop_lookup_enum,
     /// };
     ///
-    /// static PROP: PropertyMeta = PropertyMeta::new("count", "i64", PropertyFlags::read_write());
+    /// static PROP: PropertyMeta = PropertyMeta::new("count", "i64", PropertyFlag::read_write());
     /// static PROPS: &[PropertyMeta] = &[PROP];
     ///
     /// fn lookup_prop(name: &str) -> Option<PropertyMeta> {
@@ -676,20 +675,64 @@ mod tests {
 
     #[test]
     fn property_meta_flags_readable_writable() {
-        let flags = PropertyFlags::read_write();
+        let flags = PropertyFlag::read_write();
         let prop = PropertyMeta::new("count", "i64", flags);
-        assert!(prop.flags.readable);
-        assert!(prop.flags.writable);
-        assert!(!prop.flags.constant);
+        assert!(prop.flags.contains(PropertyFlag::Readable));
+        assert!(prop.flags.contains(PropertyFlag::Writable));
+        assert!(!prop.flags.contains(PropertyFlag::Constant));
     }
 
     #[test]
     fn property_meta_flags_read_only_constant() {
-        let flags = PropertyFlags::read_only();
+        let flags = PropertyFlag::read_only();
         let prop = PropertyMeta::new("version", "i64", flags);
-        assert!(prop.flags.readable);
-        assert!(!prop.flags.writable);
-        assert!(prop.flags.constant);
+        assert!(prop.flags.contains(PropertyFlag::Readable));
+        assert!(!prop.flags.contains(PropertyFlag::Writable));
+        assert!(prop.flags.contains(PropertyFlag::Constant));
+    }
+
+    #[test]
+    fn property_flag_none_is_empty() {
+        assert!(PropertyFlag::none().is_empty());
+    }
+
+    #[test]
+    fn property_flag_read_write_contains() {
+        let f = PropertyFlag::read_write();
+        assert!(f.contains(PropertyFlag::Readable));
+        assert!(f.contains(PropertyFlag::Writable));
+        assert!(f.contains(PropertyFlag::Stored));
+        assert!(f.contains(PropertyFlag::Designable));
+        assert!(!f.contains(PropertyFlag::Notify));
+        assert!(!f.contains(PropertyFlag::User));
+        assert!(!f.contains(PropertyFlag::Constant));
+    }
+
+    #[test]
+    fn property_flag_read_only_contains() {
+        let f = PropertyFlag::read_only();
+        assert!(f.contains(PropertyFlag::Readable));
+        assert!(!f.contains(PropertyFlag::Writable));
+        assert!(f.contains(PropertyFlag::Stored));
+        assert!(f.contains(PropertyFlag::Designable));
+        assert!(f.contains(PropertyFlag::Constant));
+        assert!(!f.contains(PropertyFlag::Notify));
+        assert!(!f.contains(PropertyFlag::User));
+    }
+
+    #[test]
+    fn property_flags_default_is_read_write() {
+        assert_eq!(PropertyFlags::default(), PropertyFlag::read_write());
+    }
+
+    #[test]
+    fn property_flag_const_constructors() {
+        const NONE: PropertyFlags = PropertyFlag::none();
+        const RW: PropertyFlags = PropertyFlag::read_write();
+        const RO: PropertyFlags = PropertyFlag::read_only();
+        assert!(NONE.is_empty());
+        assert!(RW.contains(PropertyFlag::Writable));
+        assert!(RO.contains(PropertyFlag::Constant));
     }
 
     #[test]
@@ -707,7 +750,7 @@ mod tests {
         static PROPS: &[PropertyMeta] = &[PropertyMeta::new(
             "name",
             "String",
-            PropertyFlags::read_write(),
+            PropertyFlag::read_write(),
         )];
         let m = meta("Widget", PROPS, &[], &[], &[]);
         // noop lookup returns None even for known properties
@@ -747,7 +790,7 @@ mod tests {
 
     #[test]
     fn meta_object_property_lookup_via_fn_pointer() {
-        static PROP: PropertyMeta = PropertyMeta::new("count", "i64", PropertyFlags::read_write());
+        static PROP: PropertyMeta = PropertyMeta::new("count", "i64", PropertyFlag::read_write());
         static PROPS: &[PropertyMeta] = &[PROP];
 
         fn lookup_prop(name: &str) -> Option<PropertyMeta> {

--- a/quartzite-macros/src/object/codegen.rs
+++ b/quartzite-macros/src/object/codegen.rs
@@ -24,6 +24,7 @@ pub(crate) fn codegen(ir: ObjectInput) -> TokenStream {
         #[doc(hidden)]
         #[allow(non_snake_case, non_upper_case_globals)]
         mod #mod_ident {
+            use ::quartzite::core::PropertyFlag;
             #props_static
             #signals_static
             #read_fn
@@ -67,19 +68,25 @@ fn emit_props_static(type_ident: &Ident, props: &[PropField]) -> TokenStream {
         let designable = p.designable;
         let user = p.user;
         let constant = p.constant;
+        // Build variant list at proc-macro time; make_bitflags! takes a bare ident (not a
+        // qualified path), so PropertyFlag must be in scope via `use` in the hidden module.
+        let flag_variants: Vec<TokenStream> = [
+            (readable, quote!(Readable)),
+            (writable, quote!(Writable)),
+            (notify, quote!(Notify)),
+            (stored, quote!(Stored)),
+            (designable, quote!(Designable)),
+            (user, quote!(User)),
+            (constant, quote!(Constant)),
+        ]
+        .into_iter()
+        .filter_map(|(active, tok)| active.then_some(tok))
+        .collect();
         quote! {
             ::quartzite::core::PropertyMeta::new(
                 #name,
                 ::core::stringify!(#ty),
-                ::quartzite::core::PropertyFlags {
-                    readable: #readable,
-                    writable: #writable,
-                    notify: #notify,
-                    stored: #stored,
-                    designable: #designable,
-                    user: #user,
-                    constant: #constant,
-                },
+                ::quartzite::core::enumflags2::make_bitflags!(PropertyFlag::{#(#flag_variants)|*}),
             )
         }
     });
@@ -457,9 +464,17 @@ mod tests {
                 pub count: i32,
             }
         });
-        assert!(out.contains("readable : true"), "missing readable: {out}");
-        assert!(out.contains("writable : true"), "missing writable: {out}");
-        assert!(out.contains("notify : false"), "unexpected notify: {out}");
+        assert!(
+            out.contains("make_bitflags"),
+            "missing make_bitflags: {out}"
+        );
+        assert!(
+            out.contains("use :: quartzite :: core :: PropertyFlag"),
+            "missing PropertyFlag use import: {out}"
+        );
+        assert!(out.contains("Readable"), "missing Readable flag: {out}");
+        assert!(out.contains("Writable"), "missing Writable flag: {out}");
+        assert!(!out.contains("Notify"), "unexpected Notify flag: {out}");
     }
 
     #[test]
@@ -471,9 +486,10 @@ mod tests {
             }
         });
         assert!(
-            out.contains("writable : false"),
-            "expected writable false: {out}"
+            out.contains("make_bitflags"),
+            "missing make_bitflags: {out}"
         );
+        assert!(!out.contains("Writable"), "expected Writable absent: {out}");
     }
 
     #[test]
@@ -485,10 +501,11 @@ mod tests {
             }
         });
         assert!(
-            out.contains("writable : false"),
-            "expected writable false: {out}"
+            out.contains("make_bitflags"),
+            "missing make_bitflags: {out}"
         );
-        assert!(out.contains("constant : true"), "missing constant: {out}");
+        assert!(!out.contains("Writable"), "expected Writable absent: {out}");
+        assert!(out.contains("Constant"), "missing Constant flag: {out}");
     }
 
     #[test]
@@ -501,7 +518,11 @@ mod tests {
                 pub changed: Signal<(i32,)>,
             }
         });
-        assert!(out.contains("notify : true"), "missing notify flag: {out}");
+        assert!(
+            out.contains("make_bitflags"),
+            "missing make_bitflags: {out}"
+        );
+        assert!(out.contains("Notify"), "missing Notify flag: {out}");
     }
 
     // Signals static: name, auto-named params (arg0, arg1…), type stringify.

--- a/quartzite-macros/tests/object.rs
+++ b/quartzite-macros/tests/object.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use quartzite::core::{AsObject, FromValue, Object, ObjectBase, Signal, Value};
+use quartzite::core::{AsObject, FromValue, Object, ObjectBase, PropertyFlag, Signal, Value};
 use quartzite_macros::{Extend, Object, object_impl};
 
 #[derive(Extend, Object)]
@@ -153,6 +153,24 @@ fn write_property_notify_fires_when_unblocked() {
     c.write_property("count", Value::Int(5));
 
     assert!(*notified.lock().unwrap(), "notify must fire when unblocked");
+}
+
+// Property flag values: readable/writable/notify/constant from generated metadata.
+#[test]
+fn property_flags_in_generated_meta() {
+    let c = make_counter();
+    let meta = c.meta_object();
+
+    let count_flags = meta.property("count").expect("count property").flags;
+    assert!(count_flags.contains(PropertyFlag::Readable));
+    assert!(count_flags.contains(PropertyFlag::Writable));
+    assert!(count_flags.contains(PropertyFlag::Notify));
+    assert!(!count_flags.contains(PropertyFlag::Constant));
+
+    let version_flags = meta.property("version").expect("version property").flags;
+    assert!(version_flags.contains(PropertyFlag::Readable));
+    assert!(!version_flags.contains(PropertyFlag::Writable));
+    assert!(!version_flags.contains(PropertyFlag::Notify));
 }
 
 // AC1+AC3: unblock_signals restores delivery after block.


### PR DESCRIPTION
## Summary

- `PropertyFlags` was a plain struct of 7 `bool` fields (7 bytes); replaced with `pub type PropertyFlags = BitFlags<PropertyFlag>` backed by a `u8` via `enumflags2 0.7.12`
- `PropertyFlag` is a new `#[bitflags(default = Readable | Writable | Stored | Designable)] #[repr(u8)]` enum with 7 variants, exposed as public API from `quartzite-core`
- Named constructors (`none`, `read_write`, `read_only`) moved to `impl PropertyFlag` as `const fn` methods returning `BitFlags<Self>`
- `Default for PropertyFlags` satisfied via `#[bitflags(default = …)]` (no manual impl needed)
- Proc-macro codegen now emits `make_bitflags!(PropertyFlag::{…})` instead of a struct literal; `use ::quartzite::core::PropertyFlag` is emitted in the generated hidden module so the bare ident resolves; `enumflags2` is `#[doc(hidden)]` re-exported from `quartzite-core` for the macro path
- All field-access sites (`flags.readable`) migrated to `flags.contains(PropertyFlag::Readable)`

**Breaking change:** `PropertyFlags` struct fields removed; `PropertyFlag` enum variants are the new API.

## Tracking

Closes #69

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test --workspace` — all 379 tests green (6 new tests added)
- [x] `cargo fmt -- --check` — no drift
- [x] `cargo clippy -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — clean
- [x] `cargo build -p quartzite --no-default-features` — `no_std` path compiles
- [x] AC1: `PropertyFlag` enum with 7 variants, `#[bitflags] #[repr(u8)]`, public
- [x] AC2: `PropertyFlags = BitFlags<PropertyFlag>` type alias, public
- [x] AC3: `none()`, `read_write()`, `read_only()` as `const fn` on `impl PropertyFlag`
- [x] AC4: `Default` returns `read_write()` — verified by `property_flags_default_is_read_write` test
- [x] AC5: proc-macro codegen emits valid `BitFlags` — existing `#[derive(Object)]` usage compiles unchanged
- [x] AC6: flag assertions pass via `contains()` — verified by `property_flags_in_generated_meta` integration test
- [x] AC7: `no_std` path compiles
- [x] AC8: clippy clean