### PR TITLE
chore: normalize dep version constraints and bump hashbrown to 0.17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ Search: `rg <pattern> --type rust [-l | -C 3]`
 - **Documentation:** Every crate must have `#![deny(missing_docs)]` in its `lib.rs`. Every public item must have at least a one-line `///` doc comment. Every new public item with only a single-line doc must include a `# Examples` block. Proc-macro examples use `no_run`; runtime items needing an event loop use `no_run`; pure library types use compiling doctests.
 - **`#[inline]`:** Add `#[inline]` to every simple, non-generic function: no branches or loops, at most one function call, no binary bloat. Typical targets: field getters (`self.field`), trivial wrappers (`.as_deref()`, single delegation call), `Default::default()` that calls `Self::new()`, `const fn` struct-literal constructors. **Exclude** generic functions and blanket-impl trait methods — the compiler already has their bodies via monomorphization. Apply the same rule in proc-macro codegen: emit `#[inline]` before each simple generated `fn`.
 
+## Dependency Versions
+
+When adding or editing dependencies in `Cargo.toml`:
+
+- Use `0.x` for `0.x.y` versions — never pin the patch.
+- Use `x` for `x.y.z` versions — never pin minor or patch.
+- No `~` prefix — Cargo's default `^` semantics are sufficient.
+- After changing version constraints, run `cargo update` to pull latest compatible versions, then `cargo build` to verify.
+
 ## Workflow
 
 - Merge PRs with a merge commit (`gh pr merge --merge`). Never squash or rebase-merge.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,12 +119,6 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
@@ -142,7 +136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -247,7 +241,7 @@ version = "0.1.0"
 dependencies = [
  "document-features",
  "enumflags2",
- "hashbrown 0.15.5",
+ "hashbrown",
  "indexmap",
  "rstest",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ derive = ["dep:quartzite-macros"]
 quartzite-core    = { path = "quartzite-core", default-features = false }
 quartzite-macros  = { path = "quartzite-macros", optional = true }
 quartzite-runtime = { path = "quartzite-runtime" }
-document-features = "~0.2"
+document-features = "0.2"
 
 [[example]]
 name = "hello_object"

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -15,13 +15,13 @@ default = ["std"]
 std = ["indexmap/std"]
 
 [dependencies]
-document-features = "~0.2"
-enumflags2 = "0.7.12"
+document-features = "0.2"
+enumflags2 = "0.7"
 indexmap = { version = "2", default-features = false }
-hashbrown = { version = "0.15", default-features = false }
+hashbrown = { version = "0.17", default-features = false }
 
 [dev-dependencies]
-rstest = "0.26.1"
+rstest = "0.26"
 serial_test = "3"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Summary

- Normalize version constraints: `0.x.y` → `0.x`, `x.y.z` → `x`, drop `~` prefix
- Bump `hashbrown` `0.15` → `0.17` (only dependency behind latest)

## Test plan

- [x] `cargo build` passes
- [x] `cargo update --verbose` shows no packages behind latest