### PR TITLE
refactor: derive Default and have new() delegate to default()

### DIFF
--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -209,9 +209,14 @@ pub struct Signal<Args: 'static> {
 }
 
 impl<Args: 'static> Default for Signal<Args> {
-    #[inline]
     fn default() -> Self {
-        Self::new()
+        Signal {
+            slots: IndexMap::new(),
+            #[cfg(feature = "std")]
+            queued_slots: IndexMap::new(),
+            #[cfg(feature = "std")]
+            auto_slots: IndexMap::new(),
+        }
     }
 }
 
@@ -226,14 +231,9 @@ impl<Args: 'static> Signal<Args> {
     /// let mut sig: Signal<(i32,)> = Signal::new();
     /// sig.connect(|args| println!("received {}", args.0));
     /// ```
+    #[inline]
     pub fn new() -> Self {
-        Signal {
-            slots: IndexMap::new(),
-            #[cfg(feature = "std")]
-            queued_slots: IndexMap::new(),
-            #[cfg(feature = "std")]
-            auto_slots: IndexMap::new(),
-        }
+        Self::default()
     }
 
     /// Connect a `Direct` slot. Returns the `ConnectionId` that can be used to

--- a/quartzite-runtime/src/factory.rs
+++ b/quartzite-runtime/src/factory.rs
@@ -6,6 +6,7 @@ use quartzite_core::traits::Object;
 type Constructor = Box<dyn Fn() -> Box<dyn Object> + Send + Sync>;
 
 /// Creates objects by class name string — used by scripting and serialization.
+#[derive(Default)]
 pub struct ObjectFactory {
     registry: HashMap<String, Constructor>,
 }
@@ -21,10 +22,9 @@ impl ObjectFactory {
     /// let factory = ObjectFactory::new();
     /// assert!(factory.create("Unknown").is_none());
     /// ```
+    #[inline]
     pub fn new() -> Self {
-        Self {
-            registry: HashMap::new(),
-        }
+        Self::default()
     }
 
     /// Register a constructor for `class_name`. Overwrites any existing entry.
@@ -56,13 +56,6 @@ impl ObjectFactory {
     /// ```
     pub fn create(&self, class_name: &str) -> Option<Box<dyn Object>> {
         self.registry.get(class_name).map(|ctor| ctor())
-    }
-}
-
-impl Default for ObjectFactory {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/quartzite-runtime/src/object_tree.rs
+++ b/quartzite-runtime/src/object_tree.rs
@@ -14,6 +14,7 @@ use crate::object_id::SlotKey;
 ///
 /// `ObjectTree: Send` follows automatically from `Object: Send`. Callers
 /// requiring shared access should wrap the tree in `Mutex<ObjectTree>`.
+#[derive(Default)]
 pub struct ObjectTree {
     store: SlotMap<DefaultKey, Box<dyn Object>>,
     /// ObjectId → arena slot (forward index)
@@ -40,15 +41,9 @@ impl ObjectTree {
     /// let tree = ObjectTree::new();
     /// assert!(!tree.contains(ObjectId::new()));
     /// ```
+    #[inline]
     pub fn new() -> Self {
-        Self {
-            store: SlotMap::new(),
-            forward: HashMap::new(),
-            reverse: HashMap::new(),
-            parent_map: HashMap::new(),
-            children_map: HashMap::new(),
-            by_name: HashMap::new(),
-        }
+        Self::default()
     }
 
     /// Insert `obj` into the tree, optionally under `parent_id`.
@@ -320,13 +315,6 @@ impl ObjectTree {
                 by_name.remove(name);
             }
         }
-    }
-}
-
-impl Default for ObjectTree {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
## Summary

- `ObjectFactory` and `ObjectTree`: replace manual `impl Default` with `#[derive(Default)]`; `new()` becomes an `#[inline]` wrapper over `Self::default()`
- `Signal<Args>`: cannot use `#[derive(Default)]` — it would add a spurious `Args: Default` bound (fields are `IndexMap<_, …>` which implement `Default` without requiring the value type to); manual `Default` impl kept, logic moved there, `new()` becomes `#[inline]` + `Self::default()`

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes