### PR TITLE
feat(core): implement Display + Error for DispatcherAlreadySet

### DIFF
--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -123,3 +123,4 @@ This closes the loop: the spec references the issue via `**Tracked in:**`, and t
 - Forgetting to save the spec before moving to design
 - Saving the spec without `**Tracked in:**` (unless user explicitly opted out)
 - Skipping the cross-link comment on the tracking issue
+- **Silently switching to implementation mid-interview.** If the interview reveals the task is trivially small (< ~20 lines, no design decisions), pause and offer: "This is small enough to implement directly — want me to skip the spec and just make the change?" Do not write code until the user confirms the mode switch.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1,5 +1,15 @@
 # Learnings
 
+### 2026-05-03 — process — /interview has no "too small for a spec" off-ramp; flag and ask instead of silently switching to implementation
+
+**What happened:** `/interview errors should iml Error` was started. Mid-interview the user redirected: "ok, add the two impl blocks under the same cfg." Instead of completing the interview (producing a spec) or explicitly flagging the pivot, execution switched silently to direct implementation. The `/interview` skill produced code changes rather than a spec.
+
+**Rule:** When a task arrives via `/interview` (or `/task`) but turns out to be trivially small during the interview, do not silently abandon the spec and implement. Flag explicitly: "This is small enough to implement directly — want me to skip the spec and just make the change?" Wait for the user to confirm the mode switch before writing any code.
+
+**How to apply:** If the interview answers reveal the entire change is < ~20 lines with no design decisions, pause and offer to skip the spec rather than silently pivoting. The user stays in control of when the workflow gets bypassed.
+
+**Escalated?** skill:interview
+
 ### 2026-05-03 — process — commit and push without waiting for explicit approval when inside a /task workflow
 
 **What happened:** All rename changes were complete, verified, and ready to push, but no commit or push was made until the user explicitly asked. The stated reason was the global system instruction "only create commits when requested." The user clarified that this instruction does not override the /task workflow, which already authorizes commits at Steps 8 and 12.

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -87,6 +87,17 @@ static QUEUED_DISPATCHER: std::sync::OnceLock<Arc<dyn QueuedDispatcher>> =
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DispatcherAlreadySet;
 
+#[cfg(feature = "std")]
+impl std::fmt::Display for DispatcherAlreadySet {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "queued dispatcher is already installed")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DispatcherAlreadySet {}
+
 /// Register the process-wide queued dispatcher. Called by `Application::new()`.
 /// Returns `Ok(())` on the first call; `Err(DispatcherAlreadySet)` on subsequent calls.
 ///


### PR DESCRIPTION
## Summary

- Adds `impl Display` and `impl std::error::Error` for `DispatcherAlreadySet` under `#[cfg(feature = "std")]`, matching the gate on the type itself
- Consistent with `ApplicationError` and `FactoryAlreadySet` which already implement `Display + Error`

## Test plan

- [ ] `cargo build -p quartzite-core` clean
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo build -p quartzite --no-default-features` clean (cfg gate verified)