### PR TITLE
feat(skill): add /pr-merged for post-merge branch cleanup

### DIFF
--- a/.claude/skills/pr-merged/SKILL.md
+++ b/.claude/skills/pr-merged/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: pr-merged
+description: "After a PR merge: switch to master, pull, and delete the local PR branch."
+disable-model-invocation: true
+allowed-tools: Bash(git checkout master) Bash(git pull) Bash(git pull *) Bash(git branch -d *) Bash(git branch --show-current) Bash(git status) Bash(git status --porcelain)
+---
+
+Current branch: !`git branch --show-current`
+
+Working tree:
+```!
+git status --porcelain
+```
+
+If the current branch is `master`, stop and tell the user this skill must be run while standing on the merged PR branch.
+
+If `git status --porcelain` above is non-empty (any modified, staged, or untracked entries), stop and ask the user how to proceed (commit, stash, discard, ignore). Do not run any further commands until the user answers.
+
+Otherwise, run in order:
+
+1. `git checkout master`
+2. `git pull`
+3. `git branch -d <previous-branch>` — always `-d`, never `-D`. If `-d` refuses because the branch is not fully merged, stop and report the message; do not force-delete.


### PR DESCRIPTION
## Summary
- New user-invocable skill at `.claude/skills/pr-merged/SKILL.md` that automates the post-merge cleanup loop: switch to `master`, `git pull`, `git branch -d <pr-branch>`.
- Two guards before any destructive action: stops if invoked on `master`, and stops to prompt the user if `git status --porcelain` is non-empty (modified, staged, or untracked entries).
- Uses `-d` only — never `-D` — so unmerged branches surface as a refusal instead of silent loss.
- `disable-model-invocation: true`: only the user can fire it via `/pr-merged`. Pre-approves the four git commands the skill needs so it runs without permission prompts after workspace trust.

## Test plan
- [ ] Open a fresh session; confirm `/pr-merged` appears in the slash menu.
- [ ] Run `/pr-merged` while on `master` → skill halts with the master-guard message.
- [ ] On a feature branch with an untracked file → skill halts and asks how to proceed.
- [ ] On a feature branch with a clean tree, branch fully merged into master → skill checks out master, pulls, and `git branch -d`s the previous branch.
- [ ] On a feature branch whose commits are not in master → `git branch -d` refuses; skill reports the message and does not force-delete.