### PR TITLE
feat(skill): add /next for recommending next issue or plan

### DIFF
--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: next
+description: "Recommend one task to work on next — an open GitHub issue or a ready plan from ai-docs/plans/INDEX.md — with rationale and 2–3 runner-ups. Pass `small` to limit to quick wins / groundwork that prepares the codebase for larger milestones."
+argument-hint: "[small]"
+disable-model-invocation: true
+---
+
+## Open GitHub issues
+
+```!
+gh issue list --limit 50 --state open --json number,title,labels,updatedAt
+```
+
+## Plan index
+
+```!
+cat ai-docs/plans/INDEX.md
+```
+
+## Task
+
+Mode: `$ARGUMENTS` — if this is the literal string `small`, apply **small mode** below; otherwise apply **default mode**.
+
+### Default mode (no argument)
+
+Pick ONE item to recommend next from the issues and plans above.
+
+Selection rules:
+- Prefer plans marked 🟢 ready (no blockers in the "Blocked by" column).
+- Prefer items that unblock the most other plans — consult the "Dependency order" section of `INDEX.md`.
+- A time-sensitive GitHub issue (bug, regression, security) outranks a plan of comparable readiness.
+- Skip items marked 🔴 blocked or 🟡 spec-only without a design.
+
+### Small mode (`/next small`)
+
+Recommend ONE **small** item — the goal is to lay groundwork for upcoming larger milestones, not to start a milestone itself.
+
+Selection rules:
+- Prefer scope: bugfix, refactor, cleanup, docs polish, small dependency upgrade, or a single-crate change.
+- Prefer items that unblock or de-risk a larger plan further down the dependency chain — consult the "Dependency order" section of `INDEX.md` and pick prerequisites of bigger blocked plans.
+- Skip items marked 🔴 blocked or full-milestone plans (multi-crate, design-heavy).
+- 🟡 spec-only items qualify only if writing the design itself is the small task.
+- If an issue bundles one small sub-item with larger ones, recommend it scope-narrowed to the small sub-item and call out that the issue should be split.
+
+### Output (both modes)
+
+- **Recommendation:** title + link or file path + a 2–4 sentence rationale (scope, readiness, why now; in small mode, also why it counts as small and which larger work it sets up).
+- **Runner-ups (2–3):** one line each, with the reason each ranked lower.


### PR DESCRIPTION
## Summary

- New project skill at `.claude/skills/next/SKILL.md`. Invoke with `/next` (default) or `/next small` (groundwork mode).
- Skill body injects live data via `!` blocks: `gh issue list --state open --json …` and `cat ai-docs/plans/INDEX.md`. No `allowed-tools` declared — repo `settings.json` already permits `Bash(gh *)` and `Bash(git *)`.
- `disable-model-invocation: true` so the skill only fires on explicit user invocation.
- Default mode prefers 🟢 ready plans, ranks by readiness and unblocking power, lets time-sensitive issues outrank plans of equal readiness.
- Small mode prefers narrow scope (bugfix / refactor / docs / single-crate change), favors prerequisites of larger blocked plans, skips full-milestone plans, and allows recommending an issue scope-narrowed to a small sub-item with a note that the issue should be split.
- Output shape is shared: one **Recommendation** with rationale + 2–3 **Runner-ups**.

## Test plan

- [ ] `/next` lists exactly one recommendation plus 2–3 runner-ups, prefers a 🟢 ready plan over 🟡/🔴, and surfaces a time-sensitive issue (bug/regression) above an equally-ready plan.
- [ ] `/next small` skips `graphics-stack` (multi-crate milestone) and the deferred 🟡 plans, and recommends an issue with single-crate scope or a small sub-item.
- [ ] Skill is hidden from automatic model invocation (only triggers when typed as a slash command).
- [ ] `!` injection runs `gh issue list` and `cat ai-docs/plans/INDEX.md` successfully under the existing repo permissions (no per-call approval prompt).