### PR TITLE
docs(agents): add file-size limits to Code Style + review checklists

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -56,6 +56,7 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 - Public items undocumented (`///` missing on `pub` functions/types)?
 - Dead code that clippy does not catch?
 - Simple non-generic functions missing `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen files: simple generated `fn`s must emit `#[inline]`.
+- **File size (AGENTS.md "Code Style"):** any non-exempt `.rs` file over the **hard limit** (1000 lines excl. `#[cfg(test)]` / 1500 incl. tests) → `major`, refactor required. Files over the **soft limit** (500 / 800) that visibly mix responsibilities → `minor` with a split suggestion. Exemptions: auto-generated / codegen output, single large state machine or `match`, `macro_rules!` definitions. Measure excl-tests with `awk '/^#\[cfg\(test\)\]/{exit} {n++} END{print n}' file.rs`. Do **not** flag cohesive small-to-medium files for being "monolithic" — one-struct-per-file is anti-idiomatic in Rust.
 
 ### 6. Documentation conformance ([`ai-docs/doc-convention.md`](../../ai-docs/doc-convention.md))
 

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -66,6 +66,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 - All new source files in Rust (`.rs`)?
 - No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
 - Every simple, non-generic function added by this diff has `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen: new simple generated `fn`s must emit `#[inline]`.
+- **File size (AGENTS.md "Code Style"):** any file added or grown by this diff over the **hard limit** (1000 lines excl. `#[cfg(test)]` / 1500 incl. tests) → REJECT unless an exemption applies (auto-generated / codegen output, a single state machine or `match` where splitting obscures control flow, `macro_rules!` definitions). Files crossing the **soft limit** (500 / 800) and visibly mixing responsibilities → flag as `nit` with a split suggestion (split by responsibility — `models.rs` / `db.rs` / `handlers.rs` — never mechanically by line count). Do **not** flag cohesive small-to-medium files for being "monolithic" — one-struct-per-file is anti-idiomatic in Rust.
 
 ### 6. Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ Follow `std` ecosystem conventions. The unsuffixed name is the **safe, ergonomic
 - **Library safety idioms.** Concrete forms of the "non-panicking APIs for libraries" rule (see *API Naming*):
   - **Mutex locks in `Option`/`Result`-returning fns:** use `mutex.lock().ok()?` (or `.unwrap_or_else(|e| e.into_inner())` to recover the inner value). Reserve `.lock().unwrap()` for cases where poisoning genuinely indicates an unrecoverable broken global invariant — and even then prefer `.expect("reason")`.
   - **Prefer safe primitives over raw pointers.** If a `OnceLock` / `Arc` / `Weak` already in scope holds the value, an `AtomicBool` flag is enough to track liveness — do not reach for `AtomicPtr` + `unsafe`. Reserve `unsafe` for cases where no safe construct expresses the semantic.
+- **File size.** Target **200–400 lines per `.rs` file excluding `#[cfg(test)]`** (readability sweet spot — fits in mental RAM, supports cohesive grouping of a struct + its `impl` blocks + related errors).
+  - **Soft limit:** 500 lines excl. tests / 800 incl. tests. Trigger a split-by-responsibility check (e.g. `models.rs` / `db.rs` / `handlers.rs`) — do **not** split mechanically by line count.
+  - **Hard limit:** 1000 lines excl. tests / 1500 incl. tests. Refactor before merge unless an exemption applies.
+  - **Exemptions:** auto-generated / codegen output (build scripts, proc-macro emission targets); a single state machine or `match` where splitting would obscure the control flow; `macro_rules!` definitions.
+  - **Counter-rule — do not over-split.** One-struct-per-file (Java / C# habit) is not Rust idiom and bloats the `mod` tree. Prefer one cohesive 300-line file over three 100-line fragments.
+  - **Per-function:** Clippy's `too_many_lines` (>100) is the canonical fn-level signal — keep functions under it. Small functions naturally yield small files.
 
 ## Dependency Versions
 


### PR DESCRIPTION
## Summary

- Adds a **File size** rule to `AGENTS.md` "Code Style": target **200–400 lines per `.rs` file excluding `#[cfg(test)]`** (readability sweet spot). Soft limit **500/800** (excl./incl. tests) → split-by-responsibility check. Hard limit **1000/1500** → refactor before merge unless exempt. Exemptions: auto-generated / codegen output, a single state machine or `match` where splitting obscures control flow, `macro_rules!` definitions. Explicit counter-rule against one-struct-per-file over-splitting (anti-idiomatic in Rust). References Clippy `too_many_lines` (>100) as the canonical fn-level companion.
- Propagated to the **review sync group**:
  - `.claude/agents/review-findings.md` §5 Style — hard-limit violations → `major`, soft-limit + mixed-responsibility files → `minor`. Includes an `awk` snippet to measure excl-tests line count.
  - `.claude/agents/self-review.md` §5 Style — diff-added/grown files crossing the hard limit → REJECT; soft-limit crossings with mixed responsibilities → `nit`.
- Numbers chosen against existing repo state: largest non-codegen file (`timer.rs` 1283 → 959 excl. tests) sits just under the hard cap; codegen files fall under the auto-generated exemption.

## Test plan

- [x] `grep` across `.claude/agents/`, `.claude/skills/`, `AGENTS.md` confirms the three sync-group files reference the same limits and exemptions
- [x] Existing `>300 lines` mention in `review-findings.md:19` (read-in-sections procedure) intentionally left untouched — orthogonal to the new size cap
- [x] No unrelated rule references found in other instruction files