### PR TITLE
docs(agents): /improve from learnings — interview blacklist, panic+pr-sync hooks, graphql recipe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,23 @@
             "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f && [[ \"$f\" == *.rs ]] && cargo fmt --quiet --manifest-path \"$CLAUDE_PROJECT_DIR/Cargo.toml\"; } || true",
             "timeout": 60,
             "statusMessage": "Formatting Rust..."
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; if [[ \"$f\" == *.rs && \"$f\" != *\"/tests/\"* && \"$f\" != *\"/examples/\"* ]] && [ -f \"$f\" ]; then hits=$(awk '/^\\s*#\\[cfg\\(test\\)\\]/{flag=1; next} flag && /^\\s*mod\\s+[a-zA-Z_]+\\s*\\{/{intest=1; depth=1; flag=0; next} intest{depth+=gsub(/\\{/,\"{\")-gsub(/\\}/,\"}\"); if(depth<=0){intest=0}; next} /\\.unwrap\\(\\)|\\.expect\\(|panic!\\(/ && !/^\\s*\\/\\//{print FILENAME\":\"NR\": \"$0}' \"$f\"); if [ -n \"$hits\" ]; then printf '\\n[panic-gate] panicking calls in production code (outside #[cfg(test)]):\\n%s\\n[panic-gate] verify each is genuinely unrecoverable — see AGENTS.md library safety idioms; substitution table in .claude/agents/self-review.md \\u00a74.\\n' \"$hits\" >&2; fi; fi; } || true",
+            "timeout": 10,
+            "statusMessage": "Checking for panicking calls..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE '(^|[ ;&|`])git[[:space:]]+push\\b' && ! echo \"$cmd\" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create'; then branch=$(git branch --show-current 2>/dev/null); if [ -n \"$branch\" ] && [ \"$branch\" != \"master\" ]; then pr_json=$(gh pr view --json number,state,url 2>/dev/null); if [ -n \"$pr_json\" ]; then state=$(echo \"$pr_json\" | jq -r '.state // empty'); number=$(echo \"$pr_json\" | jq -r '.number // empty'); if [ \"$state\" = \"OPEN\" ]; then printf '\\n[pr-sync] open PR #%s on %s — re-read body with `gh pr view %s --json title,body` and sync via `gh pr edit` if scope/names/ACs drifted (AGENTS.md \"PR body sync after every push\"). Exception: this push immediately preceded `gh pr create`.\\n' \"$number\" \"$branch\" \"$number\" >&2; fi; fi; fi; fi",
+            "timeout": 15,
+            "statusMessage": "Checking PR body sync..."
           }
         ]
       }

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -18,6 +18,17 @@ Output: refined task spec saved as `ai-docs/plans/YYYY-MM-DD-name.spec.md`, bidi
 2. **Max 4 rounds** total.
 3. Don't ask about the obvious — focus on edge cases, technical constraints, scope ambiguities.
 4. **Pre-flight: read `AGENTS.md` before drafting any question.** If `AGENTS.md` already answers a candidate question, apply the rule silently — do not ask. Topics commonly pre-resolved: API stability / compat shims / deprecation, panic-vs-`Result` policy for libraries, `_unchecked` naming, allowed Rust idioms (let chains, stdlib comparison helpers), test coverage requirements. When in doubt, re-read `AGENTS.md` — do not ask.
+5. **Forbidden question framings (mechanical substring blacklist).** If a draft question contains any of the substrings below, **discard it** and apply the documented rule silently. This rule exists because the same questions kept being asked despite Rule 4 — see `ai-docs/learnings.md` 2026-05-03, 2026-05-05.
+
+   | Forbidden substring (case-insensitive) | Documented answer to apply silently |
+   |----------------------------------------|--------------------------------------|
+   | `backward compat`, `back-compat`, `backcompat`, `compat shim`, `compat layer` | AGENTS.md § *API Stability*: pre-crates.io, free to break — no shims |
+   | `deprecat` (matches *deprecate*, *deprecated*, *deprecation*) | AGENTS.md § *API Stability*: no `#[deprecated]` wrappers |
+   | `keep old`, `preserve existing`, `existing API stay`, `keep the old name` | AGENTS.md § *API Stability*: rename freely |
+   | `should X panic`, `panic or return`, `should it panic`, `panic vs return`, `should this panic` | AGENTS.md § *API Naming* + *Library safety idioms*: non-panicking by default; `try_*` returning `Result`/`Option` |
+   | `for users`, `for downstream`, `existing callers` | AGENTS.md § *API Stability*: no downstream clients yet |
+
+   Mechanical check before sending a question round: `printf '%s\n' "<draft questions>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers'` — any hit means rewrite or drop the question.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,19 @@ When adding or editing dependencies in `Cargo.toml`:
 - Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files. **Exception:** files under `examples/` are runnable demos, not library code — no `#[cfg(test)]` block required.
 - `.gitignore` (not `.arcignore`).
 - After generating or moving any markdown file with relative links to siblings (`../`, `../../`), trace at least one link by hand or with `realpath` before committing. From `ai-docs/deferred/file.md`: `..` reaches `ai-docs/`, `../..` reaches the repo root.
-- **PR review comment resolution:** After pushing fixes, resolve only the comments that were addressed by a code change. Comments where you posted an objection (explaining why no change was made) must **not** be resolved — leave them for the reviewer to accept or push back on.
+- **PR review comment resolution:** After pushing fixes, resolve only the comments that were addressed by a code change. Comments where you posted an objection (explaining why no change was made) must **not** be resolved — leave them for the reviewer to accept or push back on. **Mechanics (GitHub stores review threads, not just comments — REST `/pulls/{N}/comments` does not expose `isResolved`; use GraphQL):**
+  1. Reply to each comment via `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments/<comment-id>/replies -f body='...'`.
+  2. Query unresolved thread IDs:
+     ```bash
+     gh api graphql -f query='{ repository(owner:"<OWNER>", name:"<REPO>") { pullRequest(number:<N>) { reviewThreads(first:50) { nodes { id isResolved path comments(first:1) { nodes { databaseId body } } } } } } }'
+     ```
+     Filter to `isResolved == false` and match each thread to the comment it was opened on (via `comments.nodes[0].databaseId` or `path`). Never guess thread IDs — `NOT_FOUND` means the ID is wrong, not that resolution is unavailable.
+  3. Resolve each fixed thread:
+     ```bash
+     gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<id>"}) { thread { isResolved } } }'
+     ```
+     Verify `isResolved: true` in the response.
+  4. Skip threads where you posted an objection — those stay open for the reviewer.
 - **PR body sync after every push.** When the current branch has an open PR, every `git push` is followed by `gh pr view <N> --json title,body` *unconditionally* — read the body first, then decide whether to edit. Sync via `gh pr edit` if the body now contradicts the diff (renames, scope drift, AC checkbox flips, cited counts that drifted, dropped/added items). Routine commits within already-described scope do not need an edit, but the **read** is non-negotiable. Reasoning your way out of the read is the failure mode this rule prevents. **Exception:** the read is not required when `gh pr create` immediately followed the push (the body is what you just authored — nothing to discover). The rule starts firing on the *next* push to the branch. The **upstream tracking issue's** title and body are the user's original problem statement — do not rewrite them; communicate scope changes via `gh issue comment` instead.
 
 ## Propagation Rule

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -310,7 +310,7 @@ then filter `isResolved == false` before reading any comment bodies.
 
 **How to apply:** Post-push checklist: `gh pr view <N> --json title,body`. If the body matches reality → done. If not → `gh pr edit`. The cost is one command; the benefit is catching invisible drift.
 
-**Escalated?** AGENTS.md, skill:task
+**Escalated?** AGENTS.md, skill:task, hook (PostToolUse Bash pr-sync reminder in `.claude/settings.json`)
 
 ### 2026-05-05 — process — resolve fixed review comments; leave objected ones for the reviewer
 
@@ -342,7 +342,7 @@ then filter `isResolved == false` before reading any comment bodies.
 
 **How to apply:** Add a "re-read PR body" step to your post-push checklist whenever the open-PR-on-branch state holds. Cheapest shape: `gh pr view <N> --json title,body | rg -i '<thing-you-just-changed>'` — if any hit, the body needs an edit. The cost of an extra `gh pr edit` is minutes; the cost of a reviewer reading a body that contradicts the diff is wasted reviewer trust.
 
-**Escalated?** AGENTS.md, skill:task
+**Escalated?** AGENTS.md, skill:task, hook (PostToolUse Bash pr-sync reminder in `.claude/settings.json`)
 
 ### 2026-05-05 — process — `gh pr view` not needed immediately after `gh pr create`
 
@@ -392,7 +392,7 @@ then filter `isResolved == false` before reading any comment bodies.
 
 **How to apply:** On any new driver, scheduler, or shared-state type: whenever a `Mutex::lock()` or `Condvar::wait()` call appears in production code (i.e., not in tests), use `unwrap_or_else(|e| e.into_inner())` by default. Reserve `.expect("reason")` only for cases where poisoning genuinely means an unrecoverable invariant violation (document why in the reason string).
 
-**Escalated?** no
+**Escalated?** hook (PostToolUse Edit/Write panic-gate in `.claude/settings.json`)
 
 ### 2026-05-06 — code-style — `.expect()` on mutex/condvar/Option is still a panic; checklist must catch it explicitly
 
@@ -413,7 +413,7 @@ Concrete substitutions:
 
 **How to apply — self-review agent:** After checking for `unwrap`, also `grep -n '\.expect(' src/` (excluding test modules) and verify each call. Acceptable forms: `.expect()` in tests, `.expect()` where poisoning means a genuine broken global invariant with the reason string explaining *why* it is unrecoverable. Anything else is a finding.
 
-**Escalated?** agent:self-review
+**Escalated?** agent:self-review, hook (PostToolUse Edit/Write panic-gate in `.claude/settings.json`)
 
 ### 2026-05-06 — process — "add to learnings" means learnings only; do not propagate to agent/skill files
 
@@ -445,4 +445,4 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **How to apply:** In the post-push step after every PR fix round: reply first, then query for thread IDs, then resolve. If resolution fails, diagnose before giving up.
 
-**Escalated?** no
+**Escalated?** AGENTS.md (GraphQL recipe added to "PR review comment resolution" bullet)


### PR DESCRIPTION
## Summary

Four escalations driven by `/improve` analysis of `ai-docs/learnings.md`. Each addresses a pattern that recurred ≥3 times despite existing rules.

- **`skill:interview` — mechanical forbidden-substring blacklist (Rule 5).** Adds a hard gate against question framings that AGENTS.md already resolves (backward-compat, deprecation, keep-old, should-X-panic, for-users, existing-callers). The same framings kept reappearing across 2026-05-03 and 2026-05-05 ×2 despite the pre-flight rule.
- **Hook B (`PostToolUse` Write/Edit) — panic-gate.** Awk-scans new `.rs` files (excluding `tests/`, `examples/`, `/tests/`) for `.unwrap()` / `.expect(` / `panic!(` outside `#[cfg(test)] mod` blocks and prints a stderr warning per offending line. Self-review missed `.expect()` over two rounds in 2026-05-06 — this catches it at write time.
- **Hook C (`PostToolUse` Bash) — pr-sync reminder.** When `git push` runs (and is not chained with `gh pr create`), if the current branch has an open PR, prints a stderr reminder to re-read the body via `gh pr view` and sync with `gh pr edit` if scope drifted. The exception for `gh pr create` matches AGENTS.md.
- **`AGENTS.md` — GraphQL recipe for "PR review comment resolution".** Embeds the 4-step `resolveReviewThread` flow (reply → query thread IDs → mutate → verify `isResolved: true`) so the mechanics are at the rule, not relearned each PR.

`ai-docs/learnings.md` entries updated to reflect the new escalation status (5 entries: 2026-05-05 PR body sync ×2, 2026-05-06 mutex expect ×2, 2026-05-06 GraphQL resolve).

## Test plan

- [x] Interview blacklist: `grep -iE 'backward.compat|...|should.*panic|...'` matches "(backward compatibility)" and "panic or return None" framings, passes legitimate scope/invariant questions
- [x] Panic-gate awk: against a fixture with 3 prod-code panics and 2 inside `#[cfg(test)] mod tests {}`, flags exactly the 3 prod-code lines
- [x] PR-sync hook: fires on `git push origin HEAD` while on `feat/2026-05-06-file-size-limits` (PR #97 OPEN); skips on plain `gh pr create`; skips on chained `git push -u origin HEAD && gh pr create`
- [x] `jq -e .` validates `.claude/settings.json`
- [x] Existing hooks (master-commit blocker, cargo-fmt-on-save) preserved untouched