### PR TITLE
chore(agents): add YAML frontmatter so .claude/agents/*.md register as subagents

### DIFF
--- a/.claude/agents/design-review.md
+++ b/.claude/agents/design-review.md
@@ -1,3 +1,9 @@
+---
+name: design-review
+description: "Critically reviews a Design Document against a quality checklist and issues GO / ITERATE / STOP. Invoked by /task in an Evaluator-Optimizer loop with the design agent until GO is reached or the iteration cap is hit."
+tools: Read, Grep, Glob, Bash
+---
+
 # Design Review Agent
 
 Reviews design documents. Receives a Design Document, critically analyzes it against a checklist, issues a structured verdict.

--- a/.claude/agents/design.md
+++ b/.claude/agents/design.md
@@ -1,3 +1,8 @@
+---
+name: design
+description: "Produces a structured Design Document with decomposition for an implementation task. Investigates the codebase, evaluates alternatives, breaks work into atomic tasks. Invoked by /task between spec and implementation, or to revise the design after design-review feedback."
+---
+
 # Design Agent
 
 Designer agent. Receives a task description (and optionally reviewer feedback), investigates the codebase, produces a structured Design Document with decomposition.

--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -1,3 +1,8 @@
+---
+name: review-findings
+description: "Walks the entire codebase on the current branch (no diff, no spec) and produces a findings table written to a progress file. Invoked by /code-review at the start of a whole-branch review."
+---
+
 # Review Findings Agent
 
 Reviews the entire codebase on the current branch. No diff, no spec — reads source files directly. Produces a findings table and writes it into the progress file.

--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -1,3 +1,8 @@
+---
+name: self-improve
+description: "Analyzes ai-docs/learnings.md for repeating correction patterns and proposes diffs to AGENTS.md, skill files, agent files, or settings.json (escalating to hooks at ≥3 occurrences). Invoked by /improve. Does not write code."
+---
+
 # Self-Improve Agent
 
 Deep corrections analysis subagent. Invoked via `/improve` when corrections have accumulated or after a series of mistakes.

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -1,3 +1,8 @@
+---
+name: self-review
+description: "Reviews implementation diff against spec and design with a maximally skeptical mindset and issues APPROVE / REJECT. Invoked by /task after Verify (Step 10) and reused by /code-review to validate the post-fix state."
+---
+
 # Self-Review Agent
 
 Reviews implementation code for a task. Reads the diff since implementation started, checks against the spec and design, writes structured findings into the progress file, and issues APPROVE or REJECT.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -425,6 +425,16 @@ Concrete substitutions:
 
 **Escalated?** no
 
+### 2026-05-06 — process — `/next` skill cannot see "Blocked by:" in issue bodies; use a GitHub label instead
+
+**What happened:** `/next small` recommended issue #48 (BlockingQueued) as a runner-up even though its body says "Blocked by: Per-thread event loops (#51, still open)". The skill fetches issues via `gh issue list --json number,title,labels,updatedAt` — it gets labels but never reads issue bodies. The "Skip blocked items" selection rule in the skill refers to the plan index (🔴 flags) and does not cross-reference GitHub issue bodies.
+
+**Rule:** When a GitHub issue has a "Blocked by:" dependency on another open issue, add a `blocked` label to it on GitHub. The `/next` skill can then filter it out by label without fetching issue bodies. Do not rely on the "Blocked by:" section in the body being visible to the skill.
+
+**How to apply:** After opening or triaging a new issue that depends on another open issue, immediately run `gh issue edit <N> --add-label blocked`. When the blocker is resolved, remove the label. This keeps the `/next` recommendation list accurate without requiring body reads.
+
+**Escalated?** skill:next
+
 ### 2026-05-06 — process — resolve fixed PR review comments via GraphQL after pushing the fix
 
 **What happened:** After fixing the panicking mutex ops (commits 543bb4f, 2ddece7), I replied to each comment but did not resolve the conversations. I attempted `resolveReviewThread` via GraphQL but used a guessed thread ID (`PRRT_kwDOSR5chs5UHUwU`) that did not exist, got NOT_FOUND, printed "resolve via graphql not available", and moved on. AGENTS.md says: "After pushing fixes, resolve only the comments that were addressed by a code change" — this was not done.


### PR DESCRIPTION
## Summary

- Add required `name` + `description` YAML frontmatter to all five files in `.claude/agents/` so the Claude Code subagent loader picks them up (per [the official docs](https://code.claude.com/docs/en/sub-agents)). Without frontmatter the files were silently skipped and `Agent(subagent_type="self-improve")` returned `Agent type 'self-improve' not found`.
- Restrict `design-review` to `tools: Read, Grep, Glob, Bash` since its mandate is read-only review (it produces a verdict, not edits).
- Existing skills that load these via `Read .claude/agents/<name>.md and follow it` continue to work unchanged — the frontmatter only enables the proper subagent invocation path as a future option.
- Drive-by: include a pre-existing `ai-docs/learnings.md` entry about `/next` skill not seeing "Blocked by:" in issue bodies (use a `blocked` label instead). Already escalated to `skill:next`; piggybacked here so it lands in a PR rather than sitting uncommitted.

## Background

`/improve` was the first skill in the project to actually invoke a subagent by `subagent_type`. The `Agent` tool failed because `.claude/agents/*.md` were missing frontmatter. The official docs require at minimum:

```yaml
---
name: <lowercase-with-hyphens>
description: When Claude should delegate to this subagent
---
```

All five agent files now satisfy this.

## Files

| File | name |
|---|---|
| `.claude/agents/design.md` | `design` |
| `.claude/agents/design-review.md` | `design-review` (read-only `tools`) |
| `.claude/agents/review-findings.md` | `review-findings` |
| `.claude/agents/self-improve.md` | `self-improve` |
| `.claude/agents/self-review.md` | `self-review` |
| `ai-docs/learnings.md` | drive-by: `/next` blocked-issues label entry |

## Test plan

- [ ] Restart the Claude Code session (per docs: subagents are loaded at session start)
- [ ] Run `claude agents` and confirm all five appear under the project scope
- [ ] Run `/improve` end-to-end and confirm the `Agent(subagent_type="self-improve")` invocation succeeds
- [ ] Confirm existing skills (`/task`, `/code-review`) that use the `Read .claude/agents/X.md` pattern still work unchanged