### PR TITLE
chore(instructions): /ai-audit + /improve fixes

### DIFF
--- a/.claude/agents/learnings-escalation-audit.md
+++ b/.claude/agents/learnings-escalation-audit.md
@@ -31,6 +31,7 @@ Per AGENTS.md "Corrections Log":
 | `agent:[name]` | Rule lives in `.claude/agents/<name>.md`. | File exists; rule is there. |
 | `hook` | Rule is a hook in `.claude/settings.json`. | A hook with a matcher + command that addresses the mistake exists. |
 | `settings` | Rule is a non-hook setting (permission allow/deny, env). | Listed in `.claude/settings.json` `permissions.*` or `env`. |
+| `doc-convention` | Rule lives in `ai-docs/doc-convention.md`. | File exists; rule is there. Use only for documentation-style rules that genuinely belong in the workspace doc-convention reference. |
 
 Multiple values are comma-separated (`AGENTS.md, hook`). Each must independently verify.
 
@@ -59,6 +60,7 @@ For each entry where `Escalated?` is **not** `no` / `memory`:
   - **`agent:<name>`** — same as `skill:` against `.claude/agents/<name>.md`.
   - **`hook`** — read `.claude/settings.json`, scan `hooks.*[].hooks[].command` for the keyword. If no hook references the relevant tool/behavior → mismatch.
   - **`settings`** — scan `.claude/settings.json` `permissions.allow`, `permissions.deny`, `env`. Mismatch if absent.
+  - **`doc-convention`** — verify `ai-docs/doc-convention.md` exists, then grep for keyword. If file missing → blocker. If keyword absent → mismatch.
 
 Record each entry's status:
 

--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -61,6 +61,8 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 - Public items undocumented (`///` missing on `pub` functions/types)?
 - Dead code that clippy does not catch?
 - Simple non-generic functions missing `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen files: simple generated `fn`s must emit `#[inline]`.
+- **Error types:** any new error enum/struct with hand-rolled `Display` / `std::error::Error` impls that could use `thiserror` instead? AGENTS.md "Code Style" mandates `thiserror` for new error types unless the derive cannot express the required behaviour.
+- **Crate-level lints:** every new crate's `lib.rs` carries both `#![deny(missing_docs)]` and `#![warn(clippy::undocumented_unsafe_blocks)]`?
 - **File size (AGENTS.md "Code Style"):** any non-exempt `.rs` file over the **hard limit** (1000 lines excl. `#[cfg(test)]` / 1500 incl. tests) → `major`, refactor required. Files over the **soft limit** (500 / 800) that visibly mix responsibilities → `minor` with a split suggestion. Exemptions: auto-generated / codegen output, single large state machine or `match`, `macro_rules!` definitions. Measure excl-tests with `awk '/^#\[cfg\(test\)\]/{exit} {n++} END{print n}' file.rs`. Do **not** flag cohesive small-to-medium files for being "monolithic" — one-struct-per-file is anti-idiomatic in Rust.
 
 ### 6. Documentation conformance ([`ai-docs/doc-convention.md`](../../ai-docs/doc-convention.md))

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -71,6 +71,8 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 - All new source files in Rust (`.rs`)?
 - No `#[allow(dead_code)]` / `#[allow(unused)]` without comment?
 - Every simple, non-generic function added by this diff has `#[inline]`? "Simple" = no branches or loops, at most one function call. Exclude generic functions and blanket-impl trait methods (monomorphized). Also check codegen: new simple generated `fn`s must emit `#[inline]`.
+- **Error types (AGENTS.md "Code Style"):** any new error enum/struct introduced by this diff with hand-rolled `Display` / `std::error::Error` impls that could use `thiserror` instead → REJECT. Hand-rolled impls are reserved for cases where `thiserror`'s derive cannot express the required behaviour (call out which capability is missing).
+- **Crate-level lints:** any new crate added by this diff whose `lib.rs` is missing `#![deny(missing_docs)]` or `#![warn(clippy::undocumented_unsafe_blocks)]` → REJECT.
 - **File size (AGENTS.md "Code Style"):** any file added or grown by this diff over the **hard limit** (1000 lines excl. `#[cfg(test)]` / 1500 incl. tests) → REJECT unless an exemption applies (auto-generated / codegen output, a single state machine or `match` where splitting obscures control flow, `macro_rules!` definitions). Files crossing the **soft limit** (500 / 800) and visibly mixing responsibilities → flag as `nit` with a split suggestion (split by responsibility — `models.rs` / `db.rs` / `handlers.rs` — never mechanically by line count). Do **not** flag cohesive small-to-medium files for being "monolithic" — one-struct-per-file is anti-idiomatic in Rust.
 
 ### 6. Documentation

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"REQUIRED SESSION START to read rules from CLAUDE.md. Show user a summary of this rules\"}}'",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"REQUIRED SESSION START to read rules from CLAUDE.md. Show user a summary of these rules\"}}'",
             "timeout": 30,
             "statusMessage": "Read session rules..."
           }

--- a/.claude/skills/ai-audit/SKILL.md
+++ b/.claude/skills/ai-audit/SKILL.md
@@ -113,7 +113,7 @@ Per the official docs:
 - `allowed-tools` syntax matches `ToolName(pattern)` form documented at `code.claude.com/docs/en/skills`.
 
 #### E. Frontmatter conformance (agents)
-- Every `.claude/agents/*.md` starts with frontmatter (post-2026-05-06 fix per recent learning entry — verify all five files conform).
+- Every `.claude/agents/*.md` starts with YAML frontmatter (`---`-delimited block at top of file). An agent without frontmatter is not a subagent — it's a stray document. Enumerate the directory at audit time rather than baking in a count.
 - `name` field equals the file basename.
 - `description` is one line and tells the orchestrator when to spawn this agent.
 

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -49,8 +49,18 @@ Show list to user: in scope / out of scope / deferred.
 
 ### Step 4: Question rounds (max 4)
 
+**MANDATORY GATE — run before every round, no exceptions.** Draft the round's questions in a scratch buffer, then run the substring check from Rule 5:
+
+```bash
+printf '%s\n' "<draft questions>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers'
+```
+
+- Any hit → discard or rewrite the offending question. Do not send the round until the grep returns empty.
+- Record in your reasoning: "interview Rule 5 grep: clean" before posting the round. If you cannot truthfully record this, you skipped the gate — go back and run it.
+- This gate exists because Rule 5's prose blacklist alone has failed four times (`ai-docs/learnings.md` 2026-05-03, 2026-05-05 ×2, plus a recurrence after escalation). The mechanical check is the enforcement.
+
 - Round 1: scope confirmation, key decisions
-- Round 2: edge cases, API backward compatibility
+- Round 2: edge cases (NOT backward compatibility — see Rule 5; pre-crates.io)
 - Round 3: technical constraints, trade-offs
 - Round 4 (if needed): final clarifications
 

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -30,6 +30,7 @@ Selection rules:
 - Prefer items that unblock the most other plans — consult the "Dependency order" section of `INDEX.md`.
 - A time-sensitive GitHub issue (bug, regression, security) outranks a plan of comparable readiness.
 - Skip items marked 🔴 blocked or 🟡 spec-only without a design.
+- Skip GitHub issues carrying the `blocked` label (see *Blocked-issues label* below) — body text like "Blocked by: #N" is not visible here, so the label is the canonical signal.
 
 ### Small mode (`/next small`)
 
@@ -39,8 +40,17 @@ Selection rules:
 - Prefer scope: bugfix, refactor, cleanup, docs polish, small dependency upgrade, or a single-crate change.
 - Prefer items that unblock or de-risk a larger plan further down the dependency chain — consult the "Dependency order" section of `INDEX.md` and pick prerequisites of bigger blocked plans.
 - Skip items marked 🔴 blocked or full-milestone plans (multi-crate, design-heavy).
+- Skip GitHub issues carrying the `blocked` label (see *Blocked-issues label* below).
 - 🟡 spec-only items qualify only if writing the design itself is the small task.
 - If an issue bundles one small sub-item with larger ones, recommend it scope-narrowed to the small sub-item and call out that the issue should be split.
+
+### Blocked-issues label
+
+This skill fetches issues via `gh issue list --json number,title,labels,updatedAt` — labels are visible, **issue bodies are not.** A "Blocked by: #N" line in an issue body therefore has no effect on `/next`. The convention is:
+
+- After opening or triaging a new issue that depends on another open issue, run `gh issue edit <N> --add-label blocked` (creating the label first via `gh label create blocked` if the repo doesn't have it yet).
+- When the blocking dependency is resolved, run `gh issue edit <N> --remove-label blocked`.
+- `/next` filters out any issue whose `labels` array contains `blocked` in both default and small modes.
 
 ### Output (both modes)
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -225,7 +225,8 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 3. `cargo clippy -- -D warnings` — clean
 4. Update `.progress.md`
 5. **PR body sync (unconditional).** Run `gh pr view <N> --json title,body` and re-read the body. Decide *after* reading whether `gh pr edit` is needed: edit if the body contradicts the new commits (renames, scope drift, AC status flips, cited counts that drifted), skip if it's still accurate. Never skip the read. Applies to every push during this step — not just review-fix commits that change public API. See AGENTS.md *Workflow*.
-6. Return to Step 10.
+6. **Resolve fixed review threads (unconditional).** For every PR review comment addressed by a `✅ Fixed` finding in this round, follow the GraphQL recipe in AGENTS.md *Workflow* → "PR review comment resolution" verbatim — reply via REST, query unresolved thread IDs via `reviewThreads`, then `resolveReviewThread` each fixed thread and verify `isResolved: true`. Threads behind `⚠️ Objected` findings stay open. Skipping this sub-step has caused the same correction twice (`ai-docs/learnings.md` entries #33 and #44) — the recipe is already in AGENTS.md; this sub-step exists so it is actually consulted.
+7. Return to Step 10.
 
 ### Step 12: Finalise docs, commit, and create PR
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Follow `std` ecosystem conventions. The unsuffixed name is the **safe, ergonomic
 - **Library safety idioms.** Concrete forms of the "non-panicking APIs for libraries" rule (see *API Naming*):
   - **Mutex locks in `Option`/`Result`-returning fns:** use `mutex.lock().ok()?` (or `.unwrap_or_else(|e| e.into_inner())` to recover the inner value). Reserve `.lock().unwrap()` for cases where poisoning genuinely indicates an unrecoverable broken global invariant — and even then prefer `.expect("reason")`.
   - **Prefer safe primitives over raw pointers.** If a `OnceLock` / `Arc` / `Weak` already in scope holds the value, an `AtomicBool` flag is enough to track liveness — do not reach for `AtomicPtr` + `unsafe`. Reserve `unsafe` for cases where no safe construct expresses the semantic.
+- **Error types.** Use `thiserror` for any new error enum/struct in this workspace — it eliminates boilerplate `Display` / `std::error::Error` impls and keeps error definitions concise. Hand-rolled `Display` / `Error` impls are reserved for cases where `thiserror`'s derive cannot express the required behaviour.
 - **File size.** Target **200–400 lines per `.rs` file excluding `#[cfg(test)]`** (readability sweet spot — fits in mental RAM, supports cohesive grouping of a struct + its `impl` blocks + related errors).
   - **Soft limit:** 500 lines excl. tests / 800 incl. tests. Trigger a split-by-responsibility check (e.g. `models.rs` / `db.rs` / `handlers.rs`) — do **not** split mechanically by line count.
   - **Hard limit:** 1000 lines excl. tests / 1500 incl. tests. Refactor before merge unless an exemption applies.
@@ -82,7 +83,7 @@ When adding or editing dependencies in `Cargo.toml`:
 ## Workflow
 
 - Merge PRs with a merge commit (`gh pr merge --merge`). Never squash or rebase-merge.
-- **Never commit to local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any commits. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
+- **Never edit on local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any file edit — not just before commit. Accumulating uncommitted edits on `master` is the failure mode this rule guards: it leaves the working tree dirty on the wrong branch and forces a reactive switch later. The first action of any skill/workflow that produces commits (`/task`, `/improve`, `/ai-audit`, etc.) is `git branch --show-current`; if `master`, switch before any `Edit`/`Write`. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
   - Recovery (commits on local master, not yet pushed): stash any uncommitted changes first (`git stash`), then `git checkout -b feat/...` → `git checkout master && git reset --soft origin/master && git restore --staged .` → push feature branch and open PR from it. Pop the stash on the feature branch if needed.
 - Run `cargo build` before committing so `Cargo.lock` is refreshed and included in the commit when it changes.
 - Stage files explicitly by name. **Never** use `git add -A` or `git add .` — they pull in unintended files (IDE state, accidental scratch files).
@@ -158,9 +159,10 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 ### YYYY-MM-DD — [category] — [short description]
 **What happened:** [quote or paraphrase]
 **Rule:** [what to do instead, or what to keep doing]
-**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | memory (comma-separate multiple)
+**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | doc-convention | memory (comma-separate multiple)
 
-> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (AGENTS.md / skill / agent / hook / settings). `settings.local` does NOT count as project-level.
+> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (AGENTS.md / skill / agent / hook / settings / doc-convention). `settings.local` does NOT count as project-level.
+> `doc-convention` = the rule landed in `ai-docs/doc-convention.md`. Use only for documentation-style rules that genuinely belong in the workspace doc-convention reference rather than in AGENTS.md or a skill.
 ```
 
 Categories: `code-style` | `process` | `architecture` | `testing` | `documentation` | `tooling` | `search` | `other`


### PR DESCRIPTION
## Summary
Two-skill cleanup of the instruction surface:
- **`/ai-audit`:** 4 user-approved Phase 1 escalation-drift fixes + 2 Phase 2 instruction-surface findings.
- **`/improve`:** 2 recurring-pattern escalations that the audit surfaced.

No new learning entries — corrections were routine drift cleanup, not new mistake classes.

### `/ai-audit` Phase 1 fixes (commit `54d2d1a`)
- Extend `Escalated?` schema with `doc-convention` (entry #25 used a non-schema target). Updated `AGENTS.md` Corrections Log + `learnings-escalation-audit` agent's verification table.
- Add `thiserror` rule to `AGENTS.md` Code Style (entry #34 was only half-landed). Propagated to `review-findings` + `self-review` checklists.
- Strengthen branch-before-edit rule in `AGENTS.md` Workflow (entry #39: AGENTS.md only had the weaker before-commit form).
- Add `blocked` GitHub-label rule to `.claude/skills/next/SKILL.md` (entry #43 was never landed in the skill).

### `/ai-audit` Phase 2 fixes (commit `54d2d1a`)
- `.claude/skills/ai-audit/SKILL.md` — replaced stale "five files" count + non-existent learning-entry reference with directory enumeration.
- `.claude/settings.json` — SessionStart `additionalContext` typo: "this rules" → "these rules".

### `/improve` escalations (commit `8b667f3`)
- **Pattern A (BLOCKER, 4× recurrence):** backward-compat / panic-vs-Result interview questions kept being asked despite `skill:interview` Rule 5's prose blacklist. `interview/SKILL.md` Step 4 now has a **mandatory grep gate** before every round, and Round 2's misleading "API backward compatibility" hint is removed.
- **Pattern B (MAJOR, 2× recurrence):** AGENTS.md's GraphQL "PR review comment resolution" recipe wasn't being consulted (entries #33, #44). `task/SKILL.md` Step 11 now has an unconditional sub-step that points the fix-loop at the recipe verbatim.

## Test plan
- [x] jq . .claude/settings.json parses cleanly
- [x] All edited skill / agent files retain valid YAML frontmatter
- [x] All relative links in edited instruction files resolve via realpath
- [x] No remaining "five files" reference in the audit skill
- [x] New mandatory grep regex in interview/SKILL.md Step 4 matches Rule 5 byte-for-byte
- [x] AGENTS.md "PR review comment resolution" anchor still resolves from task/SKILL.md Step 11
- [x] task/SKILL.md Step 11 sub-list renumbered cleanly (1–7)