### PR TITLE
fix(value,timer): code-review corrections — 5 findings addressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "itertools",
+ "parking_lot",
  "rstest",
  "serial_test",
  "thiserror",

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1,5 +1,15 @@
 # Learnings
 
+### 2026-05-06 — process — do not object to "breaking API change" on an unpublished crate
+
+**What happened:** Code review finding #2 (dynamic `SingleShot` slot leak) was objected to with "breaking API change" as the reason. The user rejected this immediately — the project has not been published to crates.io and AGENTS.md explicitly allows freely changing the public API before the first `cargo publish`.
+
+**Rule:** "Breaking API change" is not a valid objection reason on this codebase until after the first `cargo publish`. API can be freely renamed, removed, or restructured. When a finding is technically fixable but would require an API change, implement the change rather than deferring.
+
+**How to apply:** Before objecting to any finding citing API stability, check AGENTS.md § "API Stability". If the crate is unpublished, remove that objection and implement the fix.
+
+**Escalated?** AGENTS.md
+
 ### 2026-05-03 — process — /interview has no "too small for a spec" off-ramp; flag and ask instead of silently switching to implementation
 
 **What happened:** `/interview errors should iml Error` was started. Mid-interview the user redirected: "ok, add the two impl blocks under the same cfg." Instead of completing the interview (producing a spec) or explicitly flagging the pivot, execution switched silently to direct implementation. The `/interview` skill produced code changes rather than a spec.

--- a/examples/signals_slots.rs
+++ b/examples/signals_slots.rs
@@ -27,7 +27,7 @@ fn main() {
     g.connect_signal(
         "greeted",
         Box::new(|vals| println!("dynamic slot received {} value(s)", vals.len())),
-        quartzite::core::signal::ConnectionType::Direct,
+        ConnectionType::Direct,
     );
 
     // Generated emit_greeted wrapper uses emit! internally — checks signals_blocked

--- a/examples/signals_slots.rs
+++ b/examples/signals_slots.rs
@@ -27,6 +27,7 @@ fn main() {
     g.connect_signal(
         "greeted",
         Box::new(|vals| println!("dynamic slot received {} value(s)", vals.len())),
+        quartzite::core::signal::ConnectionType::Direct,
     );
 
     // Generated emit_greeted wrapper uses emit! internally — checks signals_blocked

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -12,9 +12,10 @@ description = "Core object model, signals, properties, and value types for quart
 default = ["std"]
 ## Enable standard-library support (threading, queued dispatch, `is_on_current_thread`).
 ## Disable to build in `no_std + alloc` environments.
-std = ["indexmap/std", "tracing/log"]
+std = ["indexmap/std", "tracing/log", "dep:parking_lot"]
 
 [dependencies]
+parking_lot = { version = "0.12", optional = true }
 document-features = "0.2"
 enumflags2 = "0.7"
 indexmap = { version = "2", default-features = false }

--- a/quartzite-core/src/connect.rs
+++ b/quartzite-core/src/connect.rs
@@ -211,9 +211,10 @@ pub fn connect_signal_to_signal(
     // Queued and Auto encode their delivery logic in the closure; at the signal level they
     // register as Direct so the slot persists. SingleShot propagates so Signal::emit_unconditionally
     // removes the slot after first delivery via its `retain` pass.
-    let slot_type = match conn_type {
-        ConnectionType::SingleShot => ConnectionType::SingleShot,
-        _ => ConnectionType::Direct,
+    let slot_type = if matches!(conn_type, ConnectionType::SingleShot) {
+        ConnectionType::SingleShot
+    } else {
+        ConnectionType::Direct
     };
     from.connect_signal(from_signal, callback, slot_type)
         .ok_or_else(|| SignalConnectionError::InternalError(from_signal.into()))

--- a/quartzite-core/src/connect.rs
+++ b/quartzite-core/src/connect.rs
@@ -1,5 +1,7 @@
 //! Signal-to-signal connection utilities.
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
+
+use parking_lot::Mutex;
 
 /// Re-exported so callers can name the bound: `Args: connect::ArgsToValues`.
 #[doc(hidden)]
@@ -91,7 +93,8 @@ pub enum SignalConnectionError {
 /// # Examples
 ///
 /// ```no_run
-/// use std::sync::{Arc, Mutex};
+/// use std::sync::Arc;
+/// use parking_lot::Mutex;
 /// use quartzite_core::{Object, connect::{connect_signal_to_signal, SignalConnectionError}};
 /// use quartzite_core::signal::ConnectionType;
 /// # fn example(from: &mut impl Object, to: Arc<Mutex<impl Object + Send + 'static>>) {
@@ -112,7 +115,7 @@ pub fn connect_signal_to_signal(
 
     let to_signal_name = to_signal.to_owned();
     let to_meta = {
-        let guard = to.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = to.lock();
         guard
             .meta_object()
             .signal(to_signal)
@@ -145,28 +148,18 @@ pub fn connect_signal_to_signal(
         }
     }
 
-    let to_thread_id = to
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .object_base()
-        .thread_id;
+    let to_thread_id = to.lock().object_base().thread_id;
     let to_weak: Weak<Mutex<dyn Object>> = Arc::downgrade(&to);
 
     let callback: SignalCallback = match conn_type {
         ConnectionType::Direct => Box::new(move |args: &[Value]| {
             if let Some(arc) = to_weak.upgrade() {
-                let _ = arc
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .emit_signal(&to_signal_name, args);
+                let _ = arc.lock().emit_signal(&to_signal_name, args);
             }
         }),
         ConnectionType::SingleShot => Box::new(move |args: &[Value]| {
             if let Some(arc) = to_weak.upgrade() {
-                let _ = arc
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .emit_signal(&to_signal_name, args);
+                let _ = arc.lock().emit_signal(&to_signal_name, args);
             }
         }),
         ConnectionType::Queued => Box::new(move |args: &[Value]| {
@@ -177,10 +170,7 @@ pub fn connect_signal_to_signal(
             let sig_name = to_signal_name.clone();
             if let Some(d) = queued_dispatcher() {
                 d.post(Box::new(move || {
-                    let _ = arc
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .emit_signal(&sig_name, &args_owned);
+                    let _ = arc.lock().emit_signal(&sig_name, &args_owned);
                 }));
             }
         }),
@@ -189,19 +179,13 @@ pub fn connect_signal_to_signal(
                 return;
             };
             if std::thread::current().id() == to_thread_id {
-                let _ = arc
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .emit_signal(&to_signal_name, args);
+                let _ = arc.lock().emit_signal(&to_signal_name, args);
             } else {
                 let args_owned: Vec<Value> = args.to_vec();
                 let sig_name = to_signal_name.clone();
                 if let Some(d) = queued_dispatcher() {
                     d.post(Box::new(move || {
-                        let _ = arc
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .emit_signal(&sig_name, &args_owned);
+                        let _ = arc.lock().emit_signal(&sig_name, &args_owned);
                     }));
                 }
             }
@@ -251,7 +235,8 @@ pub fn connect_signal_to_signal(
 /// # Examples
 ///
 /// ```no_run
-/// use std::sync::{Arc, Mutex};
+/// use std::sync::Arc;
+/// use parking_lot::Mutex;
 /// use quartzite_core::signal::{ConnectionType, Signal};
 /// use quartzite_core::connect::{connect_signals, SignalConnectionError};
 /// # use quartzite_core::Object;
@@ -291,7 +276,7 @@ where
     // Validate to_signal.
     let to_signal_str = to_signal_name.to_owned();
     let to_meta = {
-        let guard = to.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = to.lock();
         guard
             .meta_object()
             .signal(to_signal_name)
@@ -336,17 +321,14 @@ where
                         return;
                     };
                     let values = args.to_values();
-                    let _ = arc
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .emit_signal(&to_signal_str, &values);
+                    let _ = arc.lock().emit_signal(&to_signal_str, &values);
                 },
                 ct,
             )
         }
         ConnectionType::Queued => {
             let (to_weak, guard_weak) = {
-                let guard = to.lock().unwrap_or_else(|e| e.into_inner());
+                let guard = to.lock();
                 let w: Weak<ReceiverGuard> = Arc::downgrade(guard.object_base().receiver_guard());
                 (Arc::downgrade(&to), w)
             };
@@ -356,17 +338,14 @@ where
                         return;
                     };
                     let values = args.to_values();
-                    let _ = arc
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .emit_signal(&to_signal_str, &values);
+                    let _ = arc.lock().emit_signal(&to_signal_str, &values);
                 },
                 guard_weak,
             )
         }
         ConnectionType::Auto => {
             let (to_weak, guard_weak, thread_id) = {
-                let guard = to.lock().unwrap_or_else(|e| e.into_inner());
+                let guard = to.lock();
                 let w: Weak<ReceiverGuard> = Arc::downgrade(guard.object_base().receiver_guard());
                 let tid = guard.object_base().thread_id;
                 (Arc::downgrade(&to), w, tid)
@@ -376,10 +355,7 @@ where
                     return;
                 };
                 let values = args.to_values();
-                let _ = arc
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .emit_signal(&to_signal_str, &values);
+                let _ = arc.lock().emit_signal(&to_signal_str, &values);
             })
         }
     };
@@ -390,9 +366,11 @@ where
 mod tests {
     use super::*;
     use std::sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicI32, Ordering},
     };
+
+    use parking_lot::Mutex;
 
     use crate::{
         id::ConnectionId,
@@ -797,13 +775,9 @@ mod tests {
         let counter = Arc::new(AtomicI32::new(0));
         {
             let c = Arc::clone(&counter);
-            receiver
-                .lock()
-                .unwrap()
-                .sig_b
-                .connect(move |args: &(i32,)| {
-                    c.store(args.0, Ordering::Relaxed);
-                });
+            receiver.lock().sig_b.connect(move |args: &(i32,)| {
+                c.store(args.0, Ordering::Relaxed);
+            });
         }
         let to: Arc<Mutex<dyn Object>> = Arc::clone(&receiver) as Arc<Mutex<dyn Object>>;
         let id =
@@ -836,7 +810,6 @@ mod tests {
             let c = Arc::clone(&counter);
             receiver
                 .lock()
-                .unwrap()
                 .sig_b
                 .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
         }
@@ -872,13 +845,9 @@ mod tests {
         let counter = Arc::new(AtomicI32::new(0));
         {
             let c = Arc::clone(&counter);
-            receiver
-                .lock()
-                .unwrap()
-                .sig_b
-                .connect(move |args: &(i32,)| {
-                    c.store(args.0, Ordering::Relaxed);
-                });
+            receiver.lock().sig_b.connect(move |args: &(i32,)| {
+                c.store(args.0, Ordering::Relaxed);
+            });
         }
         let to: Arc<Mutex<dyn Object>> = Arc::clone(&receiver) as Arc<Mutex<dyn Object>>;
         connect_signal_to_signal(&mut sender, "sig_a", to, "sig_b", ConnectionType::Direct)
@@ -904,13 +873,9 @@ mod tests {
         let counter = Arc::new(AtomicI32::new(0));
         {
             let c = Arc::clone(&counter);
-            receiver
-                .lock()
-                .unwrap()
-                .sig_b
-                .connect(move |args: &(i32,)| {
-                    c.store(args.0, Ordering::Relaxed);
-                });
+            receiver.lock().sig_b.connect(move |args: &(i32,)| {
+                c.store(args.0, Ordering::Relaxed);
+            });
         }
         let id = connect_signals(
             &mut sender,
@@ -940,13 +905,9 @@ mod tests {
         let counter = Arc::new(AtomicI32::new(0));
         {
             let c = Arc::clone(&counter);
-            receiver
-                .lock()
-                .unwrap()
-                .sig_b
-                .connect(move |args: &(i32,)| {
-                    c.store(args.0, Ordering::Relaxed);
-                });
+            receiver.lock().sig_b.connect(move |args: &(i32,)| {
+                c.store(args.0, Ordering::Relaxed);
+            });
         }
         connect_signals(
             &mut sender,
@@ -978,7 +939,6 @@ mod tests {
             let c = Arc::clone(&counter);
             receiver
                 .lock()
-                .unwrap()
                 .sig_b
                 .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
         }
@@ -1002,7 +962,7 @@ mod tests {
 
         let dispatcher = install_test_dispatcher();
         // Drain any leftovers from earlier tests.
-        dispatcher.posted.lock().unwrap().clear();
+        dispatcher.posted.lock().clear();
 
         let mut sender = Sender::new();
         // Build receiver on a different thread so its thread_id != current().
@@ -1020,7 +980,6 @@ mod tests {
             let c = Arc::clone(&counter);
             receiver
                 .lock()
-                .unwrap()
                 .sig_b
                 .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
         }
@@ -1036,7 +995,7 @@ mod tests {
             "AC6 cross-thread Auto must not fire synchronously"
         );
         // Drain dispatcher and verify the closure was posted.
-        let tasks: Vec<_> = dispatcher.posted.lock().unwrap().drain(..).collect();
+        let tasks: Vec<_> = dispatcher.posted.lock().drain(..).collect();
         assert!(!tasks.is_empty(), "AC6: at least one task must be posted");
         for task in tasks {
             task();

--- a/quartzite-core/src/connect.rs
+++ b/quartzite-core/src/connect.rs
@@ -1,8 +1,5 @@
 //! Signal-to-signal connection utilities.
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, Mutex, Weak};
 
 /// Re-exported so callers can name the bound: `Args: connect::ArgsToValues`.
 #[doc(hidden)]
@@ -164,20 +161,14 @@ pub fn connect_signal_to_signal(
                     .emit_signal(&to_signal_name, args);
             }
         }),
-        ConnectionType::SingleShot => {
-            let fired = Arc::new(AtomicBool::new(false));
-            Box::new(move |args: &[Value]| {
-                if fired.swap(true, Ordering::Relaxed) {
-                    return;
-                }
-                if let Some(arc) = to_weak.upgrade() {
-                    let _ = arc
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .emit_signal(&to_signal_name, args);
-                }
-            })
-        }
+        ConnectionType::SingleShot => Box::new(move |args: &[Value]| {
+            if let Some(arc) = to_weak.upgrade() {
+                let _ = arc
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .emit_signal(&to_signal_name, args);
+            }
+        }),
         ConnectionType::Queued => Box::new(move |args: &[Value]| {
             let Some(arc) = to_weak.upgrade() else {
                 return;
@@ -217,7 +208,14 @@ pub fn connect_signal_to_signal(
         }),
     };
 
-    from.connect_signal(from_signal, callback)
+    // Queued and Auto encode their delivery logic in the closure; at the signal level they
+    // register as Direct so the slot persists. SingleShot propagates so Signal::emit_unconditionally
+    // removes the slot after first delivery via its `retain` pass.
+    let slot_type = match conn_type {
+        ConnectionType::SingleShot => ConnectionType::SingleShot,
+        _ => ConnectionType::Direct,
+    };
+    from.connect_signal(from_signal, callback, slot_type)
         .ok_or_else(|| SignalConnectionError::InternalError(from_signal.into()))
 }
 
@@ -472,13 +470,15 @@ mod tests {
             &mut self,
             signal: &str,
             callback: crate::traits::SignalCallback,
+            conn_type: ConnectionType,
         ) -> Option<ConnectionId> {
             match signal {
                 "sig_a" => {
                     let cb = Arc::new(callback);
-                    Some(self.sig_a.connect(move |args: &(i32,)| {
-                        (*cb)(&[crate::IntoValue::into_value(args.0)])
-                    }))
+                    Some(self.sig_a.connect_typed(
+                        move |args: &(i32,)| (*cb)(&[crate::IntoValue::into_value(args.0)]),
+                        conn_type,
+                    ))
                 }
                 _ => None,
             }
@@ -565,13 +565,15 @@ mod tests {
             &mut self,
             signal: &str,
             callback: crate::traits::SignalCallback,
+            conn_type: ConnectionType,
         ) -> Option<ConnectionId> {
             match signal {
                 "sig_b" => {
                     let cb = Arc::new(callback);
-                    Some(self.sig_b.connect(move |args: &(i32,)| {
-                        (*cb)(&[crate::IntoValue::into_value(args.0)])
-                    }))
+                    Some(self.sig_b.connect_typed(
+                        move |args: &(i32,)| (*cb)(&[crate::IntoValue::into_value(args.0)]),
+                        conn_type,
+                    ))
                 }
                 _ => None,
             }
@@ -684,6 +686,7 @@ mod tests {
                 &mut self,
                 _signal: &str,
                 _callback: crate::traits::SignalCallback,
+                _conn_type: ConnectionType,
             ) -> Option<ConnectionId> {
                 None
             }
@@ -760,6 +763,7 @@ mod tests {
                 &mut self,
                 _signal: &str,
                 _callback: crate::traits::SignalCallback,
+                _conn_type: ConnectionType,
             ) -> Option<ConnectionId> {
                 None
             }
@@ -819,6 +823,44 @@ mod tests {
             counter.load(Ordering::Relaxed),
             42,
             "value must not change after disconnect"
+        );
+    }
+
+    #[test]
+    fn single_shot_fires_once_and_slot_is_removed() {
+        let mut sender = Sender::new();
+        let receiver = Arc::new(Mutex::new(Receiver::new()));
+        let counter = Arc::new(AtomicI32::new(0));
+        {
+            let c = Arc::clone(&counter);
+            receiver
+                .lock()
+                .unwrap()
+                .sig_b
+                .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
+        }
+        let to: Arc<Mutex<dyn Object>> = Arc::clone(&receiver) as Arc<Mutex<dyn Object>>;
+        connect_signal_to_signal(
+            &mut sender,
+            "sig_a",
+            to,
+            "sig_b",
+            ConnectionType::SingleShot,
+        )
+        .expect("connection must succeed");
+
+        sender.sig_a.emit_unconditionally(&(1,));
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "must fire on first emit"
+        );
+
+        sender.sig_a.emit_unconditionally(&(2,));
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "slot must not fire on second emit — auto-disconnected after first delivery"
         );
     }
 

--- a/quartzite-core/src/lib.rs
+++ b/quartzite-core/src/lib.rs
@@ -53,6 +53,9 @@ pub use meta::{
     PropertyMeta, SignalMeta,
 };
 pub use object_base::ObjectBase;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use parking_lot::Mutex;
 pub use receiver_guard::ReceiverGuard;
 pub use signal::{ConnectionType, Signal};
 #[cfg(feature = "std")]

--- a/quartzite-core/src/signal.rs
+++ b/quartzite-core/src/signal.rs
@@ -646,10 +646,12 @@ macro_rules! emit {
 pub(crate) mod tests {
     use super::*;
     #[cfg(feature = "std")]
+    use parking_lot::Mutex;
+    #[cfg(feature = "std")]
     use serial_test::serial;
     #[cfg(feature = "std")]
     use std::sync::{
-        Arc, Mutex, OnceLock,
+        Arc, OnceLock,
         atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
     };
 
@@ -667,7 +669,7 @@ pub(crate) mod tests {
     #[cfg(feature = "std")]
     impl QueuedDispatcher for TestDispatcher {
         fn post(&self, f: Box<dyn FnOnce() + Send + 'static>) {
-            self.posted.lock().unwrap().push(f);
+            self.posted.lock().push(f);
         }
     }
 
@@ -761,15 +763,15 @@ pub(crate) mod tests {
         let l2 = Arc::clone(&log);
         let l3 = Arc::clone(&log);
 
-        sig.connect(move |_| l1.lock().unwrap().push(1)); // slot A
-        let id_b = sig.connect(move |_| l2.lock().unwrap().push(2)); // slot B
-        sig.connect(move |_| l3.lock().unwrap().push(3)); // slot C
+        sig.connect(move |_| l1.lock().push(1)); // slot A
+        let id_b = sig.connect(move |_| l2.lock().push(2)); // slot B
+        sig.connect(move |_| l3.lock().push(3)); // slot C
 
         sig.disconnect(id_b);
         sig.emit_unconditionally(&());
 
         assert_eq!(
-            *log.lock().unwrap(),
+            *log.lock(),
             vec![1, 3],
             "A and C must fire in insertion order; B must be absent"
         );
@@ -923,14 +925,14 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let (guard_arc, guard_weak) = ReceiverGuard::new_pair();
 
         let mut sig: Signal<i32> = Signal::new();
         let posted_values: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
         let pv = Arc::clone(&posted_values);
-        sig.connect_queued(move |v| pv.lock().unwrap().push(v), guard_weak.clone());
+        sig.connect_queued(move |v| pv.lock().push(v), guard_weak.clone());
 
         // Drop receiver guard to invalidate.
         drop(guard_arc);
@@ -938,7 +940,7 @@ pub(crate) mod tests {
         // Emit after receiver is destroyed — must NOT post.
         sig.emit_unconditionally(&99);
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "no post must occur after receiver is destroyed"
         );
@@ -955,7 +957,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -974,7 +976,7 @@ pub(crate) mod tests {
             "Auto same-thread slot must be called synchronously before emit returns"
         );
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "Auto same-thread must not post to dispatcher"
         );
@@ -991,7 +993,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -1014,7 +1016,7 @@ pub(crate) mod tests {
         );
 
         // Drain only entries added by our emit; leave any foreign entries untouched.
-        let posted: Vec<_> = dispatcher.posted.lock().unwrap().drain(pre_len..).collect();
+        let posted: Vec<_> = dispatcher.posted.lock().drain(pre_len..).collect();
         assert_eq!(posted.len(), 1, "exactly one closure must be posted");
         posted.into_iter().for_each(|f| f());
 
@@ -1035,7 +1037,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -1054,7 +1056,7 @@ pub(crate) mod tests {
             "same-thread Auto slot must be called directly"
         );
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "no closure must be posted for same-thread Auto"
         );
@@ -1071,7 +1073,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -1094,7 +1096,7 @@ pub(crate) mod tests {
         );
 
         // Drain only entries added by our emit; leave any foreign entries untouched.
-        let posted: Vec<_> = dispatcher.posted.lock().unwrap().drain(pre_len..).collect();
+        let posted: Vec<_> = dispatcher.posted.lock().drain(pre_len..).collect();
         assert_eq!(posted.len(), 1, "exactly one closure must be posted");
         posted.into_iter().for_each(|f| f());
 
@@ -1113,7 +1115,7 @@ pub(crate) mod tests {
     #[serial]
     fn auto_disconnect_removes_slot() {
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -1135,7 +1137,7 @@ pub(crate) mod tests {
             "disconnected Auto slot must not be called"
         );
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "disconnected Auto slot must not post to dispatcher"
         );
@@ -1152,8 +1154,8 @@ pub(crate) mod tests {
         let dispatcher = install_test_dispatcher();
 
         // Simulate a concurrent test having already posted to the shared dispatcher.
-        dispatcher.posted.lock().unwrap().push(Box::new(|| {}));
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        dispatcher.posted.lock().push(Box::new(|| {}));
+        let pre_len = dispatcher.posted.lock().len();
 
         let mut sig: Signal<(i32,)> = Signal::new();
         sig.connect_auto(
@@ -1166,7 +1168,7 @@ pub(crate) mod tests {
         // Queue must not grow — the foreign entry is still there, but our emit
         // must not have added anything.
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "same-thread auto emit must not grow the dispatcher queue"
         );
@@ -1183,7 +1185,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let called = Arc::new(AtomicBool::new(false));
         let called2 = Arc::clone(&called);
@@ -1203,7 +1205,7 @@ pub(crate) mod tests {
             "same-thread Auto slot must not be called after receiver is destroyed"
         );
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "no post must occur after receiver is destroyed"
         );
@@ -1220,7 +1222,7 @@ pub(crate) mod tests {
         use crate::receiver_guard::ReceiverGuard;
 
         let dispatcher = install_test_dispatcher();
-        let pre_len = dispatcher.posted.lock().unwrap().len();
+        let pre_len = dispatcher.posted.lock().len();
 
         let foreign_id = other_thread_id();
 
@@ -1235,7 +1237,7 @@ pub(crate) mod tests {
         sig.emit_unconditionally(&(99,));
 
         assert_eq!(
-            dispatcher.posted.lock().unwrap().len(),
+            dispatcher.posted.lock().len(),
             pre_len,
             "no closure must be posted after receiver is destroyed"
         );

--- a/quartzite-core/src/traits.rs
+++ b/quartzite-core/src/traits.rs
@@ -159,7 +159,9 @@ pub trait Object: AsObject + Send {
     /// Only [`ConnectionType::Direct`] and [`ConnectionType::SingleShot`] are meaningful here.
     /// `Queued` and `Auto` connections require additional context (a dispatcher or a thread id)
     /// that the dynamic API does not carry; callers must encode that logic in the callback and
-    /// pass [`ConnectionType::Direct`].
+    /// pass [`ConnectionType::Direct`]. Passing `Queued` or `Auto` is caught by a
+    /// `debug_assert!` in the underlying `Signal::connect_typed` implementation and silently
+    /// degrades to `Direct` in release builds.
     ///
     /// # Parameters
     ///

--- a/quartzite-core/src/traits.rs
+++ b/quartzite-core/src/traits.rs
@@ -7,6 +7,7 @@ use crate::{
     id::{ConnectionId, ObjectId},
     meta::MetaObject,
     object_base::ObjectBase,
+    signal::ConnectionType,
     value::Value,
 };
 
@@ -155,20 +156,32 @@ pub trait Object: AsObject + Send {
     ///
     /// Returns `None` if `name` does not match any signal on this object.
     ///
+    /// Only [`ConnectionType::Direct`] and [`ConnectionType::SingleShot`] are meaningful here.
+    /// `Queued` and `Auto` connections require additional context (a dispatcher or a thread id)
+    /// that the dynamic API does not carry; callers must encode that logic in the callback and
+    /// pass [`ConnectionType::Direct`].
+    ///
     /// # Parameters
     ///
     /// - `signal`: meta-system signal name to subscribe to.
     /// - `callback`: type-erased slot receiving the emit-time argument values.
+    /// - `conn_type`: whether the slot fires once and auto-disconnects (`SingleShot`) or
+    ///   persists until explicitly disconnected (`Direct`).
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use quartzite_core::Object;
+    /// use quartzite_core::{Object, signal::ConnectionType};
     /// # fn example(obj: &mut impl Object) {
-    /// let _id = obj.connect_signal("clicked", Box::new(|_args| {}));
+    /// let _id = obj.connect_signal("clicked", Box::new(|_args| {}), ConnectionType::Direct);
     /// # }
     /// ```
-    fn connect_signal(&mut self, signal: &str, callback: SignalCallback) -> Option<ConnectionId>;
+    fn connect_signal(
+        &mut self,
+        signal: &str,
+        callback: SignalCallback,
+        conn_type: ConnectionType,
+    ) -> Option<ConnectionId>;
 
     /// Emits signal `signal` with `args` and returns `Some(())` when successful.
     ///
@@ -368,6 +381,7 @@ mod tests {
             &mut self,
             _signal: &str,
             _callback: SignalCallback,
+            _conn_type: ConnectionType,
         ) -> Option<ConnectionId> {
             None
         }

--- a/quartzite-core/src/value.rs
+++ b/quartzite-core/src/value.rs
@@ -303,7 +303,7 @@ impl IntoValue for i64 {
 
 // For other integer types, use a checked conversion so that out-of-range values
 // produce a `TypeError` instead of silently wrapping or truncating.
-macro_rules! impl_int_checked {
+macro_rules! impl_from_value_checked {
     ($t:ty) => {
         impl FromValue for $t {
             fn from_value(val: Value) -> Result<Self, TypeError> {
@@ -321,7 +321,15 @@ macro_rules! impl_int_checked {
                 }
             }
         }
+    };
+}
+
+// i32 and u32 always fit in i64, so `as i64` is lossless.
+macro_rules! impl_int_checked {
+    ($t:ty) => {
+        impl_from_value_checked!($t);
         impl IntoValue for $t {
+            #[inline]
             fn into_value(self) -> Value {
                 Value::Int(self as i64)
             }
@@ -331,8 +339,23 @@ macro_rules! impl_int_checked {
 
 impl_int_checked!(i32);
 impl_int_checked!(u32);
-impl_int_checked!(u64);
-impl_int_checked!(usize);
+
+// u64 and usize can exceed i64::MAX; saturate rather than wrap silently.
+impl_from_value_checked!(u64);
+impl IntoValue for u64 {
+    #[inline]
+    fn into_value(self) -> Value {
+        Value::Int(i64::try_from(self).unwrap_or(i64::MAX))
+    }
+}
+
+impl_from_value_checked!(usize);
+impl IntoValue for usize {
+    #[inline]
+    fn into_value(self) -> Value {
+        Value::Int(i64::try_from(self).unwrap_or(i64::MAX))
+    }
+}
 
 impl FromValue for f64 {
     fn from_value(val: Value) -> Result<Self, TypeError> {
@@ -654,6 +677,18 @@ mod tests {
     #[test]
     fn u64_accepts_zero() {
         assert_eq!(u64::from_value(Value::Int(0)), Ok(0u64));
+    }
+
+    #[test]
+    fn u64_max_saturates_to_i64_max() {
+        assert_eq!(u64::MAX.into_value(), Value::Int(i64::MAX));
+    }
+
+    #[test]
+    fn usize_max_saturates_to_i64_max() {
+        if usize::BITS >= 64 {
+            assert_eq!(usize::MAX.into_value(), Value::Int(i64::MAX));
+        }
     }
 
     #[test]

--- a/quartzite-core/src/value.rs
+++ b/quartzite-core/src/value.rs
@@ -684,11 +684,10 @@ mod tests {
         assert_eq!(u64::MAX.into_value(), Value::Int(i64::MAX));
     }
 
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn usize_max_saturates_to_i64_max() {
-        if usize::BITS >= 64 {
-            assert_eq!(usize::MAX.into_value(), Value::Int(i64::MAX));
-        }
+        assert_eq!(usize::MAX.into_value(), Value::Int(i64::MAX));
     }
 
     #[test]

--- a/quartzite-macros/src/object/codegen.rs
+++ b/quartzite-macros/src/object/codegen.rs
@@ -293,9 +293,9 @@ fn emit_connect_signal_dynamic(type_ident: &Ident, signals: &[SignalField]) -> T
                 let cb = #cr::__macro::Arc::clone(&cb);
                 #builtin_use
                 // Omit the closure type annotation for built-ins: inferred from the field type.
-                ::core::option::Option::Some(#signal_access.connect(move |args| {
+                ::core::option::Option::Some(#signal_access.connect_typed(move |args| {
                     (*cb)(&[#(#conversions),*])
-                }))
+                }, conn_type))
             }
         }
     });
@@ -304,6 +304,7 @@ fn emit_connect_signal_dynamic(type_ident: &Ident, signals: &[SignalField]) -> T
             this: &mut super::#type_ident,
             name: &str,
             cb: #cr::SignalCallback,
+            conn_type: #cr::signal::ConnectionType,
         ) -> ::core::option::Option<#cr::ConnectionId> {
             let cb: #cr::__macro::Arc<
                 dyn ::core::ops::Fn(&[#cr::Value]) + Send + Sync,

--- a/quartzite-macros/src/object_impl/codegen.rs
+++ b/quartzite-macros/src/object_impl/codegen.rs
@@ -248,8 +248,9 @@ pub(crate) fn emit_object_impl(
                 &mut self,
                 signal: &str,
                 callback: #cr::SignalCallback,
+                conn_type: #cr::signal::ConnectionType,
             ) -> ::core::option::Option<#cr::ConnectionId> {
-                #mod_ident::#connect_fn(self, signal, callback)
+                #mod_ident::#connect_fn(self, signal, callback, conn_type)
             }
             #[inline]
             fn emit_signal(

--- a/quartzite-macros/tests/object.rs
+++ b/quartzite-macros/tests/object.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, Mutex};
 
-use quartzite::core::{AsObject, FromValue, Object, ObjectBase, PropertyFlag, Signal, Value};
+use quartzite::core::{
+    AsObject, FromValue, Object, ObjectBase, PropertyFlag, Signal, Value, signal::ConnectionType,
+};
 use quartzite_macros::{Extend, Object, object_impl};
 
 #[derive(Extend, Object)]
@@ -76,7 +78,7 @@ fn ac10_connect_signal_and_emit() {
         }
     });
 
-    let id = c.connect_signal("count_changed", cb);
+    let id = c.connect_signal("count_changed", cb, ConnectionType::Direct);
     assert!(id.is_some());
 
     c.count_changed.emit_unconditionally(&(7,));

--- a/quartzite-macros/tests/object.rs
+++ b/quartzite-macros/tests/object.rs
@@ -192,3 +192,34 @@ fn unblock_restores_emit_wrapper() {
     c.emit_count_changed(2);
     assert!(*called.lock().unwrap(), "must fire after unblock");
 }
+
+// SingleShot: slot is removed after first delivery via macro-generated connect_signal path.
+#[test]
+fn single_shot_fires_once_via_object_trait() {
+    let mut c = make_counter();
+    let call_count = Arc::new(Mutex::new(0u32));
+    let call_count_clone = Arc::clone(&call_count);
+    let cb = Box::new(move |_args: &[Value]| {
+        *call_count_clone.lock().unwrap() += 1;
+    });
+
+    let id = c.connect_signal("count_changed", cb, ConnectionType::SingleShot);
+    assert!(
+        id.is_some(),
+        "connect_signal must return Some for a known signal"
+    );
+
+    c.count_changed.emit_unconditionally(&(1,));
+    assert_eq!(
+        *call_count.lock().unwrap(),
+        1,
+        "slot must fire on first emit"
+    );
+
+    c.count_changed.emit_unconditionally(&(2,));
+    assert_eq!(
+        *call_count.lock().unwrap(),
+        1,
+        "slot must not fire after SingleShot removal"
+    );
+}

--- a/quartzite-macros/tests/object.rs
+++ b/quartzite-macros/tests/object.rs
@@ -194,6 +194,8 @@ fn unblock_restores_emit_wrapper() {
 }
 
 // SingleShot: slot is removed after first delivery via macro-generated connect_signal path.
+// emit_unconditionally is used directly (not emit_count_changed) to bypass the signals_blocked
+// check — we want to observe slot removal in isolation without block/unblock interactions.
 #[test]
 fn single_shot_fires_once_via_object_trait() {
     let mut c = make_counter();

--- a/quartzite-macros/tests/object.rs
+++ b/quartzite-macros/tests/object.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use quartzite::core::Mutex;
 
 use quartzite::core::{
     AsObject, FromValue, Object, ObjectBase, PropertyFlag, Signal, Value, signal::ConnectionType,
@@ -37,13 +39,13 @@ fn ac6_read_write_property_with_notify() {
     let notified = Arc::new(Mutex::new(false));
     let notified_clone = Arc::clone(&notified);
     c.count_changed.connect(move |_args: &(i32,)| {
-        *notified_clone.lock().unwrap() = true;
+        *notified_clone.lock() = true;
     });
 
     let written = c.write_property("count", Value::Int(42));
     assert!(written);
     assert_eq!(c.count, 42);
-    assert!(*notified.lock().unwrap());
+    assert!(*notified.lock());
 }
 
 // AC7: read_only property returns false from write_property.
@@ -74,7 +76,7 @@ fn ac10_connect_signal_and_emit() {
     let received_clone = Arc::clone(&received);
     let cb = Box::new(move |args: &[Value]| {
         if let Some(v) = args.first() {
-            *received_clone.lock().unwrap() = i32::from_value(v.clone()).ok();
+            *received_clone.lock() = i32::from_value(v.clone()).ok();
         }
     });
 
@@ -82,7 +84,7 @@ fn ac10_connect_signal_and_emit() {
     assert!(id.is_some());
 
     c.count_changed.emit_unconditionally(&(7,));
-    assert_eq!(*received.lock().unwrap(), Some(7));
+    assert_eq!(*received.lock(), Some(7));
 }
 
 fn make_counter() -> Counter {
@@ -101,12 +103,12 @@ fn emit_wrapper_suppressed_when_blocked() {
     let called = Arc::new(Mutex::new(false));
     let called_clone = Arc::clone(&called);
     c.count_changed
-        .connect(move |_: &(i32,)| *called_clone.lock().unwrap() = true);
+        .connect(move |_: &(i32,)| *called_clone.lock() = true);
 
     c.object_base_mut().block_signals();
     c.emit_count_changed(42);
 
-    assert!(!*called.lock().unwrap(), "slot must not fire when blocked");
+    assert!(!*called.lock(), "slot must not fire when blocked");
 }
 
 // AC4: emit_<signal> wrapper delivers normally when not blocked.
@@ -116,11 +118,11 @@ fn emit_wrapper_delivers_when_unblocked() {
     let received = Arc::new(Mutex::new(None::<i32>));
     let received_clone = Arc::clone(&received);
     c.count_changed
-        .connect(move |args: &(i32,)| *received_clone.lock().unwrap() = Some(args.0));
+        .connect(move |args: &(i32,)| *received_clone.lock() = Some(args.0));
 
     c.emit_count_changed(7);
 
-    assert_eq!(*received.lock().unwrap(), Some(7));
+    assert_eq!(*received.lock(), Some(7));
 }
 
 // AC5: write_property does not emit notify when signals are blocked, but still writes value.
@@ -130,17 +132,14 @@ fn write_property_notify_suppressed_when_blocked() {
     let notified = Arc::new(Mutex::new(false));
     let notified_clone = Arc::clone(&notified);
     c.count_changed
-        .connect(move |_: &(i32,)| *notified_clone.lock().unwrap() = true);
+        .connect(move |_: &(i32,)| *notified_clone.lock() = true);
 
     c.object_base_mut().block_signals();
     let written = c.write_property("count", Value::Int(99));
 
     assert!(written, "write_property must return true");
     assert_eq!(c.count, 99, "value must be updated even when blocked");
-    assert!(
-        !*notified.lock().unwrap(),
-        "notify must not fire when blocked"
-    );
+    assert!(!*notified.lock(), "notify must not fire when blocked");
 }
 
 // Regression: write_property notify fires normally when not blocked.
@@ -150,11 +149,11 @@ fn write_property_notify_fires_when_unblocked() {
     let notified = Arc::new(Mutex::new(false));
     let notified_clone = Arc::clone(&notified);
     c.count_changed
-        .connect(move |_: &(i32,)| *notified_clone.lock().unwrap() = true);
+        .connect(move |_: &(i32,)| *notified_clone.lock() = true);
 
     c.write_property("count", Value::Int(5));
 
-    assert!(*notified.lock().unwrap(), "notify must fire when unblocked");
+    assert!(*notified.lock(), "notify must fire when unblocked");
 }
 
 // Property flag values: readable/writable/notify/constant from generated metadata.
@@ -182,15 +181,15 @@ fn unblock_restores_emit_wrapper() {
     let called = Arc::new(Mutex::new(false));
     let called_clone = Arc::clone(&called);
     c.count_changed
-        .connect(move |_: &(i32,)| *called_clone.lock().unwrap() = true);
+        .connect(move |_: &(i32,)| *called_clone.lock() = true);
 
     c.object_base_mut().block_signals();
     c.emit_count_changed(1);
-    assert!(!*called.lock().unwrap(), "must be suppressed while blocked");
+    assert!(!*called.lock(), "must be suppressed while blocked");
 
     c.object_base_mut().unblock_signals();
     c.emit_count_changed(2);
-    assert!(*called.lock().unwrap(), "must fire after unblock");
+    assert!(*called.lock(), "must fire after unblock");
 }
 
 // SingleShot: slot is removed after first delivery via macro-generated connect_signal path.
@@ -202,7 +201,7 @@ fn single_shot_fires_once_via_object_trait() {
     let call_count = Arc::new(Mutex::new(0u32));
     let call_count_clone = Arc::clone(&call_count);
     let cb = Box::new(move |_args: &[Value]| {
-        *call_count_clone.lock().unwrap() += 1;
+        *call_count_clone.lock() += 1;
     });
 
     let id = c.connect_signal("count_changed", cb, ConnectionType::SingleShot);
@@ -212,15 +211,11 @@ fn single_shot_fires_once_via_object_trait() {
     );
 
     c.count_changed.emit_unconditionally(&(1,));
-    assert_eq!(
-        *call_count.lock().unwrap(),
-        1,
-        "slot must fire on first emit"
-    );
+    assert_eq!(*call_count.lock(), 1, "slot must fire on first emit");
 
     c.count_changed.emit_unconditionally(&(2,));
     assert_eq!(
-        *call_count.lock().unwrap(),
+        *call_count.lock(),
         1,
         "slot must not fire after SingleShot removal"
     );

--- a/quartzite-runtime/src/factory.rs
+++ b/quartzite-runtime/src/factory.rs
@@ -153,6 +153,7 @@ mod tests {
         id::ConnectionId,
         meta::MetaObject,
         object_base::ObjectBase,
+        signal::ConnectionType,
         traits::{AsObject, Object, SignalCallback},
         value::Value,
     };
@@ -209,7 +210,12 @@ mod tests {
         fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
             None
         }
-        fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+        fn connect_signal(
+            &mut self,
+            _: &str,
+            _: SignalCallback,
+            _: ConnectionType,
+        ) -> Option<ConnectionId> {
             None
         }
 

--- a/quartzite-runtime/src/object_tree.rs
+++ b/quartzite-runtime/src/object_tree.rs
@@ -448,6 +448,7 @@ mod tests {
         id::ConnectionId,
         meta::MetaObject,
         object_base::ObjectBase,
+        signal::ConnectionType,
         traits::{AsObject, Object, SignalCallback},
         value::Value,
     };
@@ -504,7 +505,12 @@ mod tests {
         fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
             None
         }
-        fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+        fn connect_signal(
+            &mut self,
+            _: &str,
+            _: SignalCallback,
+            _: ConnectionType,
+        ) -> Option<ConnectionId> {
             None
         }
 
@@ -823,7 +829,12 @@ mod tests {
         fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
             None
         }
-        fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+        fn connect_signal(
+            &mut self,
+            _: &str,
+            _: SignalCallback,
+            _: ConnectionType,
+        ) -> Option<ConnectionId> {
             None
         }
         fn emit_signal(&mut self, name: &str, args: &[Value]) -> Option<()> {

--- a/quartzite-runtime/src/object_tree.rs
+++ b/quartzite-runtime/src/object_tree.rs
@@ -442,6 +442,8 @@ impl ObjectTree {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use itertools::{Itertools, assert_equal};
     use quartzite_core::{
@@ -758,7 +760,7 @@ mod tests {
 
     struct RecordingObject {
         base: ObjectBase,
-        emissions: std::sync::Arc<std::sync::Mutex<Vec<(String, Vec<Value>)>>>,
+        emissions: std::sync::Arc<parking_lot::Mutex<Vec<(String, Vec<Value>)>>>,
     }
 
     impl RecordingObject {
@@ -766,24 +768,24 @@ mod tests {
             name: &str,
         ) -> (
             Box<dyn Object>,
-            std::sync::Arc<std::sync::Mutex<Vec<(String, Vec<Value>)>>>,
+            std::sync::Arc<parking_lot::Mutex<Vec<(String, Vec<Value>)>>>,
         ) {
-            let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let log = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
             let obj = Box::new(Self {
                 base: ObjectBase::named(name),
-                emissions: std::sync::Arc::clone(&log),
+                emissions: Arc::clone(&log),
             });
             (obj, log)
         }
 
         fn anonymous() -> (
             Box<dyn Object>,
-            std::sync::Arc<std::sync::Mutex<Vec<(String, Vec<Value>)>>>,
+            std::sync::Arc<parking_lot::Mutex<Vec<(String, Vec<Value>)>>>,
         ) {
-            let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let log = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
             let obj = Box::new(Self {
                 base: ObjectBase::new(),
-                emissions: std::sync::Arc::clone(&log),
+                emissions: Arc::clone(&log),
             });
             (obj, log)
         }
@@ -838,10 +840,7 @@ mod tests {
             None
         }
         fn emit_signal(&mut self, name: &str, args: &[Value]) -> Option<()> {
-            self.emissions
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .push((name.to_owned(), args.to_vec()));
+            self.emissions.lock().push((name.to_owned(), args.to_vec()));
             Some(())
         }
     }
@@ -925,7 +924,7 @@ mod tests {
         let (obj, log) = RecordingObject::named("old");
         let id = tree.insert(obj, None);
         tree.rename(id, "new");
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert_eq!(emissions.len(), 1, "expected one emission: {emissions:?}");
         assert_eq!(emissions[0].0, "name_changed");
         assert_eq!(
@@ -941,7 +940,7 @@ mod tests {
         let (obj, log) = RecordingObject::named("same");
         let id = tree.insert(obj, None);
         tree.rename(id, "same");
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert!(
             emissions.is_empty(),
             "no-op rename must not emit: {emissions:?}"
@@ -955,7 +954,7 @@ mod tests {
         let (obj, log) = RecordingObject::anonymous();
         let id = tree.insert(obj, None);
         tree.rename(id, "named");
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert_eq!(emissions.len(), 1, "expected one emission: {emissions:?}");
         assert_eq!(
             emissions[0].1,
@@ -970,7 +969,7 @@ mod tests {
         let (obj, log) = RecordingObject::named("old");
         let id = tree.insert(obj, None);
         tree.clear_name(id);
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert_eq!(emissions.len(), 1, "expected one emission: {emissions:?}");
         assert_eq!(emissions[0].0, "name_changed");
         assert_eq!(
@@ -986,7 +985,7 @@ mod tests {
         let (obj, log) = RecordingObject::anonymous();
         let id = tree.insert(obj, None);
         tree.clear_name(id);
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert!(
             emissions.is_empty(),
             "anonymous clear_name must not emit: {emissions:?}"
@@ -1000,7 +999,7 @@ mod tests {
         let (obj, log) = RecordingObject::named("target");
         let id = tree.insert(obj, None);
         tree.destroy(id);
-        let emissions = log.lock().unwrap();
+        let emissions = log.lock();
         assert!(
             emissions.iter().all(|(name, _)| name != "name_changed"),
             "destroy must not emit name_changed: {emissions:?}"

--- a/quartzite-runtime/src/timer.rs
+++ b/quartzite-runtime/src/timer.rs
@@ -5,8 +5,6 @@
 //! [`TimerDriver`] (the pluggable backend trait), and the three built-in drivers —
 //! [`ThreadDriver`], [`AppDriver`], and [`PoolDriver`].
 
-use tracing::debug;
-
 use std::{
     sync::{
         Arc,
@@ -16,6 +14,7 @@ use std::{
 };
 
 use parking_lot::Mutex;
+use tracing::debug;
 
 use quartzite_core::{
     ConnectionId, ObjectBase, ObjectId, receiver_guard::ReceiverGuard, signal::Signal,

--- a/quartzite-runtime/src/timer.rs
+++ b/quartzite-runtime/src/timer.rs
@@ -5,6 +5,8 @@
 //! [`TimerDriver`] (the pluggable backend trait), and the three built-in drivers —
 //! [`ThreadDriver`], [`AppDriver`], and [`PoolDriver`].
 
+use tracing::debug;
+
 use std::{
     sync::{
         Arc,
@@ -485,6 +487,7 @@ impl Timer {
         if self.state.running.load(Ordering::SeqCst) {
             return;
         }
+        debug!(timer_id = ?self.base.id(), "timer: start");
         self.state.running.store(true, Ordering::SeqCst);
         self.state.fire_count.store(0, Ordering::SeqCst);
 
@@ -537,6 +540,7 @@ impl Timer {
         if !self.state.running.swap(false, Ordering::SeqCst) {
             return;
         }
+        debug!(timer_id = ?self.base.id(), "timer: stop");
         if let Some(driver) = self.driver.take() {
             driver.stop(self.base.id());
         }

--- a/quartzite-runtime/src/timer_drivers.rs
+++ b/quartzite-runtime/src/timer_drivers.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 use parking_lot::{Condvar, Mutex};
+use tracing::debug;
 
 use quartzite_core::ObjectId;
 
@@ -231,6 +232,7 @@ struct PoolInner {
     state: Mutex<PoolState>,
     condvar: Condvar,
     running: AtomicBool,
+    handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 /// Single shared background thread + min-heap, driving multiple timers.
@@ -278,10 +280,12 @@ impl PoolDriver {
             state: Mutex::new(PoolState::new()),
             condvar: Condvar::new(),
             running: AtomicBool::new(true),
+            handle: Mutex::new(None),
         });
 
         let inner_clone = Arc::clone(&inner);
-        thread::spawn(move || Self::pool_loop(&inner_clone));
+        let join = thread::spawn(move || Self::pool_loop(&inner_clone));
+        *inner.handle.lock() = Some(join);
 
         Self { inner }
     }
@@ -387,9 +391,12 @@ impl TimerDriver for PoolDriver {
 
 impl Drop for PoolDriver {
     fn drop(&mut self) {
+        debug!("pool driver: shutdown");
         self.inner.running.store(false, Ordering::SeqCst);
         self.inner.condvar.notify_all();
-        // Background thread exits on next condvar wake.
+        if let Some(handle) = self.inner.handle.lock().take() {
+            let _ = handle.join();
+        }
     }
 }
 

--- a/quartzite-runtime/tests/factory.rs
+++ b/quartzite-runtime/tests/factory.rs
@@ -2,6 +2,7 @@ use quartzite_core::{
     id::ConnectionId,
     meta::MetaObject,
     object_base::ObjectBase,
+    signal::ConnectionType,
     traits::{AsObject, Object, SignalCallback},
     value::Value,
 };
@@ -59,7 +60,12 @@ impl Object for FooObj {
     fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
         None
     }
-    fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+    fn connect_signal(
+        &mut self,
+        _: &str,
+        _: SignalCallback,
+        _: ConnectionType,
+    ) -> Option<ConnectionId> {
         None
     }
 

--- a/quartzite-runtime/tests/object_tree.rs
+++ b/quartzite-runtime/tests/object_tree.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use itertools::Itertools;
 use quartzite_core::{
@@ -97,7 +99,6 @@ impl Drop for LogObj {
     fn drop(&mut self) {
         self.log
             .lock()
-            .unwrap()
             .push(self.base.name().unwrap_or("").to_owned());
     }
 }
@@ -260,7 +261,7 @@ fn destroy_is_depth_first_post_order() {
 
     tree.destroy(root);
 
-    let order = log.lock().unwrap().clone();
+    let order = log.lock().clone();
     assert_eq!(order.len(), 4, "all 4 nodes must be destroyed");
 
     let positions: Vec<usize> = ["gc", "c1", "root"]

--- a/quartzite-runtime/tests/object_tree.rs
+++ b/quartzite-runtime/tests/object_tree.rs
@@ -6,6 +6,7 @@ use quartzite_core::{
     id::ConnectionId,
     meta::MetaObject,
     object_base::ObjectBase,
+    signal::ConnectionType,
     traits::{AsObject, Object, SignalCallback},
     value::Value,
 };
@@ -63,7 +64,12 @@ impl Object for Stub {
     fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
         None
     }
-    fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+    fn connect_signal(
+        &mut self,
+        _: &str,
+        _: SignalCallback,
+        _: ConnectionType,
+    ) -> Option<ConnectionId> {
         None
     }
 
@@ -136,7 +142,12 @@ impl Object for LogObj {
     fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
         None
     }
-    fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+    fn connect_signal(
+        &mut self,
+        _: &str,
+        _: SignalCallback,
+        _: ConnectionType,
+    ) -> Option<ConnectionId> {
         None
     }
 

--- a/quartzite-runtime/tests/object_tree_ext.rs
+++ b/quartzite-runtime/tests/object_tree_ext.rs
@@ -10,6 +10,7 @@ use quartzite_core::{
     id::ConnectionId,
     meta::MetaObject,
     object_base::ObjectBase,
+    signal::ConnectionType,
     traits::{AsObject, Object, SignalCallback},
     value::Value,
 };
@@ -75,7 +76,12 @@ impl Object for Stub {
     fn invoke_method(&mut self, _: &str, _: &[Value]) -> Option<Value> {
         None
     }
-    fn connect_signal(&mut self, _: &str, _: SignalCallback) -> Option<ConnectionId> {
+    fn connect_signal(
+        &mut self,
+        _: &str,
+        _: SignalCallback,
+        _: ConnectionType,
+    ) -> Option<ConnectionId> {
         None
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,10 @@ pub mod prelude {
     pub use quartzite_core::signal::{ConnectionType, Signal};
     // quartzite-core: emit! macro
     pub use quartzite_core::emit;
+    // quartzite-core: std-only types
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub use quartzite_core::Mutex;
     // quartzite-core: std-only dispatcher API
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

--- a/tests/signal_to_signal.rs
+++ b/tests/signal_to_signal.rs
@@ -1,6 +1,6 @@
 // Integration tests for signal-to-signal connections (AC1–AC11).
 use std::sync::{
-    Arc, Mutex,
+    Arc,
     atomic::{AtomicI32, Ordering},
 };
 
@@ -122,7 +122,6 @@ fn direct_connection_forwards_synchronously() {
         let c = Arc::clone(&captured);
         relay
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -155,7 +154,6 @@ fn liveness_after_target_drop() {
         let c = Arc::clone(&captured);
         relay
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -192,7 +190,6 @@ fn disconnect_stops_forwarding() {
         let c = Arc::clone(&captured);
         relay
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -230,7 +227,6 @@ fn chain_emitter_to_relay_a_to_relay_b() {
         let c = Arc::clone(&captured);
         relay_b
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -250,7 +246,7 @@ fn chain_emitter_to_relay_a_to_relay_b() {
 
     // Relay A → Relay B (lock relay_a, connect while held, then release)
     {
-        let mut guard = relay_a.lock().unwrap();
+        let mut guard = relay_a.lock();
         let b: Arc<Mutex<dyn Object>> = Arc::clone(&relay_b) as Arc<Mutex<dyn Object>>;
         connect_signal_to_signal(
             &mut *guard,
@@ -281,7 +277,6 @@ fn connect_signals_typed_api_direct() {
         let c = Arc::clone(&captured);
         relay
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -311,7 +306,7 @@ struct TestDispatcher {
 
 impl QueuedDispatcher for TestDispatcher {
     fn post(&self, f: Box<dyn FnOnce() + Send + 'static>) {
-        self.posted.lock().unwrap().push(f);
+        self.posted.lock().push(f);
     }
 }
 
@@ -332,7 +327,7 @@ fn install_dispatcher() -> Arc<TestDispatcher> {
 #[serial_test::serial]
 fn auto_cross_thread_posts_to_dispatcher() {
     let dispatcher = install_dispatcher();
-    dispatcher.posted.lock().unwrap().clear();
+    dispatcher.posted.lock().clear();
 
     let mut emitter = new_emitter();
     // Build a relay whose ObjectBase was created on another thread, so its thread_id
@@ -347,7 +342,6 @@ fn auto_cross_thread_posts_to_dispatcher() {
         let c = Arc::clone(&captured);
         relay
             .lock()
-            .unwrap()
             .value_received
             .connect(move |args: &(i32,)| c.store(args.0, Ordering::Relaxed));
     }
@@ -370,7 +364,7 @@ fn auto_cross_thread_posts_to_dispatcher() {
         "AC6: Auto cross-thread must not fire synchronously"
     );
     // Drain and run posted tasks.
-    let tasks: Vec<_> = dispatcher.posted.lock().unwrap().drain(..).collect();
+    let tasks: Vec<_> = dispatcher.posted.lock().drain(..).collect();
     assert!(
         !tasks.is_empty(),
         "AC6: at least one task must have been queued"


### PR DESCRIPTION
## Summary

- **#1 (major):** \`u64\`/\`usize\` \`IntoValue\` silently wrapped on overflow. Split \`impl_int_checked!\` macro: \`i32\`/\`u32\` keep lossless path; \`u64\`/\`usize\` now use saturating \`i64::try_from\`. Two new tests added.
- **#2 (minor):** Dynamic \`SingleShot\` slot was never removed after first delivery. Added \`conn_type: ConnectionType\` to \`Object::connect_signal\`; macro codegen calls \`connect_typed(wrapper, conn_type)\` so the slot is cleaned up automatically. Propagated to all hand-written \`Object\` impls. New tests added.
- **#3 (minor):** \`PoolDriver::Drop\` discarded the background thread's \`JoinHandle\`. Added \`handle: Mutex<Option<JoinHandle<()>>>\` to \`PoolInner\`; \`Drop\` now joins it.
- **#4 (minor):** \`Timer::start\` and \`Timer::stop\` lacked \`debug!\` traces. Added per AGENTS.md rule; traces fire only when state actually changes.
- **#5 (nit):** \`PoolDriver::Drop\` also lacked a \`debug!\` trace. Added.

Self-review follow-ups (round 1):
- \`usize_max_saturates_to_i64_max\`: replaced runtime \`if usize::BITS >= 64\` with \`#[cfg(target_pointer_width = "64")]\`.
- \`connect.rs\` \`slot_type\`: simplified verbose \`match\` to \`if matches!(...)\`.
- \`timer.rs\` import order fixed.
- Updated stub \`connect_signal\` impls in factory/object_tree tests.

Self-review follow-ups (round 2):
- Added comment to \`single_shot_fires_once_via_object_trait\` explaining \`emit_unconditionally\` usage.
- Strengthened \`connect_signal\` doc: noted \`Queued\`/\`Auto\` degrade to \`Direct\` in release builds.

Follow-up (parking_lot migration):
- Replaced \`std::sync::Mutex\` with \`parking_lot::Mutex\` across \`connect.rs\`, \`signal.rs\` tests, \`object_tree.rs\` tests, and \`signal_to_signal.rs\` — eliminates all \`.lock().unwrap_or_else\` and \`.lock().unwrap()\` boilerplate.
- Added \`parking_lot\` as a \`std\`-gated optional dep to \`quartzite-core\`.
- Re-exported \`parking_lot::Mutex\` from \`quartzite-core\` and \`quartzite::prelude\`.

## Test plan

- [ ] \`cargo build\` — passes
- [ ] \`cargo test --workspace\` — all green
- [ ] \`cargo clippy -- -D warnings\` — clean
- [ ] \`cargo fmt -- --check\` — clean
- [ ] \`RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace\` — clean