### PR TITLE
docs(agents): drop `memory` from `Escalated?` taxonomy — user-local persistence is not project escalation

### DIFF
--- a/.claude/agents/learnings-escalation-audit.md
+++ b/.claude/agents/learnings-escalation-audit.md
@@ -24,14 +24,14 @@ Per AGENTS.md "Corrections Log":
 
 | Value | Means | Verification |
 |---|---|---|
-| `no` | Not yet acted on. | Nothing to verify — but flag if the same mistake repeats ≥2 times unescalated. |
-| `memory` | Saved to global cross-project memory only. | Treated as `no` for project-level audit. |
+| `no` | Not yet acted on (no project-level rule). May also have been saved to user-local persistence (`~/.claude/.../MEMORY.md`, `settings.local.json`) — those are private to one developer and DO NOT count as project-level escalation. | Nothing to verify — but flag if the same mistake repeats ≥2 times unescalated. |
 | `AGENTS.md` | Rule lives in `AGENTS.md`. | Find a section/sentence in `AGENTS.md` that addresses the mistake. |
 | `skill:[name]` | Rule lives in `.claude/skills/<name>/SKILL.md`. | File exists; rule is there. |
 | `agent:[name]` | Rule lives in `.claude/agents/<name>.md`. | File exists; rule is there. |
 | `hook` | Rule is a hook in `.claude/settings.json`. | A hook with a matcher + command that addresses the mistake exists. |
 | `settings` | Rule is a non-hook setting (permission allow/deny, env). | Listed in `.claude/settings.json` `permissions.*` or `env`. |
 | `doc-convention` | Rule lives in `ai-docs/doc-convention.md`. | File exists; rule is there. Use only for documentation-style rules that genuinely belong in the workspace doc-convention reference. |
+| `code-style` | Rule lives in `ai-docs/code-style.md`. | File exists; rule is there. Use only for code-style rules that genuinely belong in the workspace code-style reference. |
 
 Multiple values are comma-separated (`AGENTS.md, hook`). Each must independently verify.
 
@@ -52,7 +52,7 @@ Extract `(date, category, description, rule, escalated)` for each entry.
 
 ### Step 2: Verify each escalation target
 
-For each entry where `Escalated?` is **not** `no` / `memory`:
+For each entry where `Escalated?` is **not** `no`:
 
 - For each target in the comma-separated list:
   - **`AGENTS.md`** — `rg -n "<keyword from rule>" AGENTS.md`. The rule keyword should be a distinctive phrase from the `Rule:` field, not generic (avoid "test", "commit"). If no match → mismatch.
@@ -61,6 +61,7 @@ For each entry where `Escalated?` is **not** `no` / `memory`:
   - **`hook`** — read `.claude/settings.json`, scan `hooks.*[].hooks[].command` for the keyword. If no hook references the relevant tool/behavior → mismatch.
   - **`settings`** — scan `.claude/settings.json` `permissions.allow`, `permissions.deny`, `env`. Mismatch if absent.
   - **`doc-convention`** — verify `ai-docs/doc-convention.md` exists, then grep for keyword. If file missing → blocker. If keyword absent → mismatch.
+  - **`code-style`** — verify `ai-docs/code-style.md` exists, then grep for keyword. If file missing → blocker. If keyword absent → mismatch.
 
 Record each entry's status:
 

--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -24,15 +24,15 @@ Go through `ai-docs/learnings.md` and group entries:
 - By category (`code-style`, `process`, `architecture`, `testing`, `search`, `other`)
 - By recurrence (how many times the same mistake)
 - By escalation status:
-  - **Unescalated** (`no`, `memory`): `memory` is global cross-project only — not a project-level fix
-  - **Escalated** (`AGENTS.md`, `skill:[name]`, `hook`, `settings`, `agent:[name]`, `doc-convention`, `code-style`): rule is in project instructions; `settings.local` does NOT count (user-local, not project)
+  - **Unescalated** (`no`): no project-level rule was added. The entry may also have been saved to user-local persistence (`~/.claude/.../MEMORY.md`, `settings.local.json`), but neither counts as project-level escalation — those are private to one developer.
+  - **Escalated** (`AGENTS.md`, `skill:[name]`, `hook`, `settings`, `agent:[name]`, `doc-convention`, `code-style`): rule is in project instructions visible to every contributor.
 
 ### Step 2: Determine actions
 
 | Occurrences | Current status | Action |
 |---|---|---|
-| 1 | no / memory | Nothing — wait for recurrence |
-| ≥2 | no / memory | Update `AGENTS.md` or skill/agent/settings file — add/strengthen rule |
+| 1 | no | Nothing — wait for recurrence |
+| ≥2 | no | Update `AGENTS.md` or skill/agent/settings file — add/strengthen rule |
 | ≥2 | AGENTS.md / skill / agent / settings | Rule exists but isn't working → move closer to the point of execution |
 | ≥3 | rule in place | Propose a hook in `.claude/settings.json` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,9 +153,9 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 ### YYYY-MM-DD — [category] — [short description]
 **What happened:** [quote or paraphrase]
 **Rule:** [what to do instead, or what to keep doing]
-**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | doc-convention | code-style | memory (comma-separate multiple)
+**Escalated?** no | AGENTS.md | skill:[name] | hook | settings | agent:[name] | doc-convention | code-style (comma-separate multiple)
 
-> `memory` = saved to global memory only. `/improve` treats it as unescalated — the entry remains a candidate for project-level escalation (AGENTS.md / skill / agent / hook / settings / doc-convention / code-style). `settings.local` does NOT count as project-level.
+> `Escalated?` records **project-level** persistence only — instruction files visible to every contributor (`AGENTS.md`, skills, agents, hooks, project `settings.json`, `ai-docs/doc-convention.md`, `ai-docs/code-style.md`). **User-local persistence does NOT count and is NOT a value of this field** — that includes the auto-memory store (`~/.claude/.../MEMORY.md`) and `settings.local.json`, both of which are private to one developer and don't help future readers. If a correction was saved only to user-local memory, mark `Escalated? no`; the entry remains a candidate for project-level escalation by `/improve`.
 > `doc-convention` = the rule landed in `ai-docs/doc-convention.md`. Use only for documentation-style rules that genuinely belong in the workspace doc-convention reference rather than in AGENTS.md or a skill.
 > `code-style` = the rule landed in `ai-docs/code-style.md`. Use only for code-style rules that genuinely belong in the workspace code-style reference rather than in AGENTS.md or a skill.
 ```

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1,5 +1,17 @@
 # Learnings
 
+### 2026-05-07 — process — `memory` is user-local, not a project-level escalation target
+
+**What happened:** The `Escalated?` enum in AGENTS.md `## Corrections Log` listed `memory` alongside `AGENTS.md`, `skill:[name]`, `hook`, etc. as a valid value. `/improve` and the escalation-audit agent both said "memory counts as unescalated for project-level audit purposes" — i.e., the system was treating it as `no` while still presenting it as a legitimate-looking enum option. Five existing learnings entries said `Escalated? AGENTS.md, memory` where the `, memory` was load-bearing-looking but actually carried no project-level signal.
+
+**Rule:** `Escalated?` records **project-level** persistence only — instruction files visible to every contributor (AGENTS.md, skills, agents, hooks, project `settings.json`, `ai-docs/doc-convention.md`, `ai-docs/code-style.md`). User-local persistence (`~/.claude/.../MEMORY.md`, `settings.local.json`) is structurally identical: private to one developer, not visible to future readers. **Neither is a valid value of `Escalated?`.** If a correction was saved only to user-local persistence, mark `Escalated? no`. Saving to memory is independent of escalation; it's worth doing for personal context but doesn't substitute for landing the rule in a project file.
+
+**Why:** Listing `memory` as an enum option created the false impression it counted as escalation. Audit agents had to special-case it (`treat as no`), and reviewers of correction-log diffs couldn't tell at a glance whether `, memory` was load-bearing. Dropping the value and unifying the explanatory note around "user-local persistence does NOT count" eliminates the mental footnote and aligns the enum with what `/improve` already does.
+
+**How to apply:** When recording a correction, ignore whatever was saved to global memory or `settings.local.json` for the purposes of `Escalated?`. Mark `no` if no project-level rule was added; mark with the appropriate target (or comma-separated list) if it was. The `learnings-escalation-audit` agent now skips entries with `Escalated? no` (was: `no` or `memory`); the `self-improve` agent's classification table no longer mentions `memory`.
+
+**Escalated?** AGENTS.md, agent:self-improve, agent:learnings-escalation-audit
+
 ### 2026-05-07 — code-style — if the `fn inner` of a generic-fn split is simple, unwrap it (don't `#[inline]` it)
 
 **What happened:** Applied the "Generic-fn split for binary size" pattern to four fns. Two of the four inner fns (`ObjectFactory::register`'s inner — single `HashMap::insert`; `ObjectBase::named`'s inner — single `ObjectBase::new()` call + struct literal) are concrete and simple by the recursive definition. The first reaction was to add `#[inline]` to those two simple inners, matching the concrete-row marker rule. User then pointed out that `#[inline]` on a simple inner causes the compiler to inline it back into the (per-`T`-monomorphized) outer fn, which **defeats the split entirely** — the body ends up duplicated per concrete `T` anyway, just with extra source indirection. The right answer is to unwrap a simple inner, not to mark it.
@@ -150,7 +162,7 @@ Markers are mutually exclusive by shape. Codegen mirrors the rule: emit `#[inlin
 
 **Rule:** Never add, remove, modify, or `.gitignore` IDE files (`.idea/`, `*.iml`, `.vscode/`, etc.) unless the user explicitly asks. Treat them as the user's domain.
 
-**Escalated?** AGENTS.md, memory
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — process — "submit to PR" means push to remote, not merge
 
@@ -158,7 +170,7 @@ Markers are mutually exclusive by shape. Codegen mirrors the rule: emit `#[inlin
 
 **Rule:** "Submit to PR" (and similar: "push to PR", "add to PR") means `git push` the branch to remote. It does not mean merging. Only merge when the user explicitly says "merge" or "merge the PR".
 
-**Escalated?** AGENTS.md, memory
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — process — "wtf" signals that the previous action was wrong
 
@@ -166,7 +178,7 @@ Markers are mutually exclusive by shape. Codegen mirrors the rule: emit `#[inlin
 
 **Rule:** "wtf" (and similar expressions of surprise/frustration) means the last action was the opposite of what the user wanted. Stop immediately, ask what went wrong, and do not proceed until the intent is clarified.
 
-**Escalated?** AGENTS.md, memory
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — process — never use git reset --hard; use soft reset, stash, cherry-pick, or backup branch
 
@@ -178,7 +190,7 @@ Markers are mutually exclusive by shape. Codegen mirrors the rule: emit `#[inlin
 - `git cherry-pick` — moves specific commits to another branch
 - Backup branch — `git checkout -b backup/...` before any destructive operation
 
-**Escalated?** AGENTS.md, memory
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — process — always create a feature branch before committing; never commit directly to master
 
@@ -225,7 +237,7 @@ If "submit PR" is requested and commits are already pushed to origin/master: sto
 
 Note: `code-review` is a **skill** (user-facing workflow); `review-findings` and `self-review` are **agents** spawned by it. Do not refer to any of these as "code-review agent" — that conflates the skill with an agent. (A `diff-review` agent existed historically but was removed as orphan; do not reintroduce it without wiring it into a skill.)
 
-**Escalated?** AGENTS.md, memory
+**Escalated?** AGENTS.md
 
 ### 2026-05-02 — process — self-review must not re-run cargo fmt or cargo clippy
 


### PR DESCRIPTION
## Summary

`memory` (the auto-memory store at `~/.claude/.../MEMORY.md`) is structurally identical to `settings.local.json`: private to one developer, invisible to future contributors. Both already failed to qualify as project-level escalation per the explanatory notes, but `memory` was still listed as a valid value of `Escalated?` — creating the false impression it counted, and forcing audit agents to special-case "treat as `no`".

This PR drops `memory` from the enum and unifies around the rule that **user-local persistence is not a value of `Escalated?` at all**. If a correction was saved only to memory or `settings.local.json`, mark `Escalated? no`.

## Changes

- **`AGENTS.md` `## Corrections Log`** — `memory` removed from the `Escalated?` enum; explanatory note rewritten to lump `~/.claude/.../MEMORY.md` and `settings.local.json` together as user-local persistence that doesn't count. The `doc-convention` and `code-style` notes are unchanged.
- **`.claude/agents/self-improve.md`** — "Unescalated" set is now just `no`; the explanatory line clarifies that user-local persistence may exist but doesn't qualify. Step-2 routing table cells `no / memory` → `no`.
- **`.claude/agents/learnings-escalation-audit.md`** — `memory` row removed from the values table; **`code-style` row added** (parallel to existing `doc-convention` row, closing a pre-existing gap from PR #125); audit-skip condition `not no / memory` → `not no`; per-target verification bullet for `code-style` added under Step 2.
- **`ai-docs/learnings.md`** — 5 existing entries `Escalated? AGENTS.md, memory` → `Escalated? AGENTS.md` (semantics unchanged — `memory` was already not project-level). New 2026-05-07 entry documenting the taxonomy refinement, escalated to `AGENTS.md, agent:self-improve, agent:learnings-escalation-audit`.

## Test plan

- [x] `rg -i 'memory' AGENTS.md .claude/agents/ .claude/skills/ ai-docs/learnings.md | grep -i 'escalat\|MEMORY\.md'` returns only the new explanatory text in the three updated files (which intentionally mention `MEMORY.md` to document why it doesn't count).
- [x] `rg ', memory' ai-docs/learnings.md` returns zero hits.
- [x] `cargo build` clean (sanity — doc-only PR).
- [x] `cargo fmt -- --check` clean.
- [x] `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` clean.
- [x] Reviewer sanity-check: the `code-style` row addition in `learnings-escalation-audit.md` closes a real pre-existing gap (the agent had no audit logic for `code-style` despite that being a valid escalation target since PR #125).