### PR TITLE
chore(agents): pin instruction-modifying agents to opus model

### DIFF
--- a/.claude/agents/learnings-escalation-audit.md
+++ b/.claude/agents/learnings-escalation-audit.md
@@ -1,6 +1,7 @@
 ---
 name: learnings-escalation-audit
 description: "Verifies that every entry in ai-docs/learnings.md has an accurate `Escalated?` field — the named target (AGENTS.md / skill / agent / hook / settings) actually contains the rule. Fixes drift in-place. Invoked by /ai-audit Phase 1. Does not write project code."
+model: opus
 ---
 
 # Learnings Escalation Audit

--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -1,6 +1,7 @@
 ---
 name: self-improve
 description: "Analyzes ai-docs/learnings.md for repeating correction patterns and proposes diffs to AGENTS.md, ai-docs/code-style.md, ai-docs/doc-convention.md, skill files, agent files, or settings.json (escalating to hooks at ≥3 occurrences). Invoked by /improve. Does not write code."
+model: opus
 ---
 
 # Self-Improve Agent


### PR DESCRIPTION
## Summary

Per [the sub-agents docs](https://code.claude.com/docs/en/sub-agents) → "Choose a model", the `model:` frontmatter field on a subagent definition accepts `sonnet`, `opus`, `haiku`, a full model ID (e.g. `claude-opus-4-7`), or `inherit` (default). When omitted, the subagent uses the parent session's model.

Two agents in this workspace mutate instruction files (long-lived guidance read by every contributor):

| Agent | Write surface |
|---|---|
| `.claude/agents/self-improve.md` | AGENTS.md, ai-docs/code-style.md, ai-docs/doc-convention.md, `.claude/skills/**`, `.claude/agents/**`, `.claude/settings.json` |
| `.claude/agents/learnings-escalation-audit.md` | ai-docs/learnings.md (`Escalated?` field drift fixes) |

Both involve cross-file reasoning, taxonomy decisions, and edits to documents that every future Claude session will load. Pin them to `opus` explicitly so the choice doesn't depend on whatever model the parent session happens to be running.

The four read-only / design agents (`design`, `design-review`, `review-findings`, `self-review`) keep the default `inherit` — their judgement-vs-cost tradeoff is fine on the inherited model, and they don't mutate instruction files.

## Diff

```diff
 # .claude/agents/self-improve.md
 ---
 name: self-improve
 description: "Analyzes ai-docs/learnings.md ..."
+model: opus
 ---

 # .claude/agents/learnings-escalation-audit.md
 ---
 name: learnings-escalation-audit
 description: "Verifies that every entry in ai-docs/learnings.md ..."
+model: opus
 ---
```

## Note for the reader

Per the sub-agents docs: *"Subagents are loaded at session start. If you add or edit a subagent file directly on disk, restart your session to load it."* This change applies to future sessions.

## Test plan

- [x] Frontmatter `model: opus` lines added to exactly the two named agents; no other agent gained a `model:` field.
- [x] No `.rs` / `Cargo.toml` files touched — pure agent-config change.