### PR TITLE
docs(deferred): point CI rows at #133-#137 after splitting umbrella #59

### DIFF
--- a/ai-docs/deferred/ci-docs-workflow.md
+++ b/ai-docs/deferred/ci-docs-workflow.md
@@ -14,15 +14,17 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #59 |
+| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #133 |
 | Auto-merge | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | — |
-| Code coverage, benchmarks, release workflow | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #59 |
+| Code coverage (`cargo-llvm-cov` + Codecov) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #134 |
+| Benchmarks (`criterion` + PR regression comments) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #135 |
+| Release workflow (cargo publish on tagged versions) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #136 |
 | Removing `rstest` from `quartzite-core` — it is genuinely used in `quartzite-core/src/value.rs` | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | | — |
 | Any other code-quality changes not listed above | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | | — |
 | `std` feature on `quartzite-runtime` (would gate nothing today) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
 | Full wildcard re-exports beyond `prelude` | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
 | Future features (`extension`, `8k_pages`, etc.) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
-| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #59 |
+| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #137 |
 | Unit tests inside example files | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | — |
 | Private/internal items | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | — |
 | Separate EXAMPLES.md or README additions beyond existing content | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | — |


### PR DESCRIPTION
## Summary

Update `ai-docs/deferred/ci-docs-workflow.md` Tracked column to reference the five per-item issues created when umbrella #59 was split:

- "Windows / macOS CI runners" → #133
- "Code coverage (`cargo-llvm-cov` + Codecov)" → #134 *(split out from bundled row)*
- "Benchmarks (`criterion` + PR regression comments)" → #135 *(split out)*
- "Release workflow (cargo publish on tagged versions)" → #136 *(split out)*
- "`cargo doc` publishing / CI integration" → #137

The previously bundled "Code coverage, benchmarks, release workflow" row is expanded into three separate rows so each tracked sub-item maps 1:1 to a live issue, matching the granularity of #133-#137.

## Test plan

- [x] `grep -n '#59' ai-docs/deferred/ci-docs-workflow.md` returns no matches
- [x] All five new issue numbers (#133, #134, #135, #136, #137) appear in the Tracked column
- [x] `cargo build` clean (refresh `Cargo.lock` per AGENTS.md; no Rust changes)
- [ ] Reviewer sanity-check: each row's source-spec link still points at the right plan file