### PR TITLE
ci: add code coverage reporting via cargo-llvm-cov + Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # quartzite
 
+[![codecov](https://codecov.io/gh/maratik123/quartzite/branch/master/graph/badge.svg)](https://codecov.io/gh/maratik123/quartzite)
+
 A GUI and object framework for Rust built around signals/slots,
 a rich object model, and a declarative UI layer — implemented as idiomatic Rust with no native
 dependencies, no foreign ABI, and no code generation outside of proc macros.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -570,6 +570,16 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Escalated?** AGENTS.md, agent:self-review, agent:review-findings
 
+### 2026-05-07 — tooling — run actionlint on new/modified GitHub Actions workflow files
+
+**What happened:** `coverage.yml` was written and committed without running `actionlint`. The user asked after the fact whether it had been run.
+
+**Rule:** Run `actionlint <workflow-file>` on every new or modified `.github/workflows/*.yml` file as part of Step 9 (Verify), before the self-review agent.
+
+**How to apply:** Add `actionlint .github/workflows/<changed>.yml` to the Step 9 checklist whenever a task touches workflow files. `actionlint` is available in `$PATH`. Must produce no output (exit 0) before proceeding.
+
+**Escalated?** no
+
 ### 2026-05-07 — process — do not skip design/design-review for "simple" tasks
 
 **What happened:** `/task 116` was a pure annotation task (replace `#[inline]` with `/// _Simple._` at 12 sites). I skipped Steps 6–7 (design agent + design review) on the grounds that no design decision existed. The user called out the omission.

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -576,7 +576,7 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Rule:** Run `actionlint <workflow-file>` on every new or modified `.github/workflows/*.yml` file as part of Step 9 (Verify), before the self-review agent.
 
-**How to apply:** Add `actionlint .github/workflows/<changed>.yml` to the Step 9 checklist whenever a task touches workflow files. `actionlint` is available in `$PATH`. Must produce no output (exit 0) before proceeding.
+**How to apply:** Add `actionlint .github/workflows/<changed>.yml` to the Step 9 checklist whenever a task touches workflow files. `actionlint` is installed locally and available in `$PATH`. Must produce no output (exit 0) before proceeding.
 
 **Escalated?** no
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -7,6 +7,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
 | [generic-simple-tags](done/2026-05-07-generic-simple-tags.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; annotation-only) | — |
+| [coverage-ci](done/2026-05-07-coverage-ci.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only) | — |
 | [graphics-stack](2026-05-03-graphics-stack.spec.md) | `quartzite-paint-api` `quartzite-renderer` | 🟢 ready | — |
 | [code-style-extraction](done/2026-05-07-code-style-extraction.spec.md) | (docs only) | ✅ implemented (0 new tests; docs only) | — |
 | [generic-fn-split](done/2026-05-07-generic-fn-split.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; refactoring) | — |

--- a/ai-docs/plans/done/2026-05-07-coverage-ci.design.md
+++ b/ai-docs/plans/done/2026-05-07-coverage-ci.design.md
@@ -1,0 +1,100 @@
+# Design: CI — Code Coverage via cargo-llvm-cov + Codecov
+
+**Issue:** #134
+**Date:** 2026-05-07
+
+## Approach
+
+Add a separate `.github/workflows/coverage.yml` that runs `cargo-llvm-cov` on
+`ubuntu-latest`, produces an LCOV report, and uploads it to Codecov via
+`codecov/codecov-action@v5`. A companion `codecov.yml` at the repository root
+configures informational-only status checks (no auto-fail). A Codecov badge is
+appended to `README.md` alongside the implicit CI badge block.
+
+### Why a separate file
+
+`ci.yml` runs a multi-OS matrix and is gated by branch protection. Coverage is a
+single-platform concern (LLVM instrumentation is platform-independent; measuring
+on Ubuntu is sufficient) and must not block merges. Keeping it in a separate file
+avoids polluting the CI matrix and makes the informational boundary obvious.
+
+### `--exclude` flag — examples are not a workspace member
+
+The spec says `--exclude quartzite-examples`, but that package does not exist as a
+workspace member. The workspace has exactly these members: `quartzite` (root),
+`quartzite-core`, `quartzite-macros`, `quartzite-runtime`, `quartzite-geometry`,
+`quartzite-events`, `quartzite-event-types`. Examples are `[[example]]` targets
+inside the root `quartzite` package. Passing `--exclude quartzite-examples` to
+`cargo llvm-cov` would produce an error ("package ID specification ... did not
+match any packages"). Omit the flag; example binaries have no `#[test]` items and
+produce no coverage data in the LCOV report unless explicitly run with
+`--examples`. Since `--examples` is not passed, examples are naturally excluded.
+
+### Tool installation
+
+`taiki-e/install-action@v2` with `tool: cargo-llvm-cov` installs the pre-built
+binary in seconds. This action also installs `llvm-tools-preview` for the active
+Rust toolchain automatically, so no separate `rustup component add` step is needed.
+
+### Doctests
+
+`--doctests` is included per the spec. `cargo-llvm-cov` v0.5+ supports doctest
+coverage out of the box (it spawns a separate instrumented doctest binary).
+
+### Codecov configuration
+
+`codecov.yml` at the repo root controls Codecov behaviour independently of the
+workflow file. Setting `informational: true` on the project status check prevents
+Codecov from posting a failing GitHub check when coverage drops, while still
+posting a PR comment with the delta.
+
+### Rejected alternatives
+
+- **Add to ci.yml**: rejected — mixes concerns and could create confusion if
+  coverage is slow or flaky relative to the primary gate jobs.
+- **Coveralls**: rejected — spec mandates Codecov; Codecov has better Rust/LCOV
+  integration and free OSS tier.
+- **Multi-OS coverage**: rejected per spec; out of scope.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Create `coverage.yml` workflow | `.github/workflows/coverage.yml` | — |
+| 2 | Create `codecov.yml` configuration | `codecov.yml` | — |
+| 3 | Add Codecov badge to README | `README.md` | 1 |
+
+## Risks
+
+- **`cargo-llvm-cov` not available on stable**: mitigation — `taiki-e/install-action` downloads
+  a pre-built binary from GitHub Releases; it does not require nightly. No additional
+  toolchain configuration is needed beyond stable.
+- **Doctest coverage requires `llvm-tools-preview` component**: mitigation — `taiki-e/install-action`
+  installs it automatically as a side-effect of installing `cargo-llvm-cov`.
+- **`CODECOV_TOKEN` not set**: the upload step will fail with a 401 until the
+  secret is added in repo Settings → Secrets. The job itself is informational and
+  not branch-protected, so this only affects the coverage upload, not merges.
+  Mitigation: document the prerequisite in the PR description.
+- **Badge URL wrong before first upload**: the Codecov badge URL embeds the repo
+  slug (`maratik123/quartzite`) and branch (`master`). It will show "unknown"
+  until the first successful upload. This is cosmetic and self-resolves.
+- **`--exclude quartzite-examples` flag**: as analysed above, passing this flag
+  would cause `cargo llvm-cov` to error. The flag must not be used.
+
+## Test Design
+
+This task produces only CI workflow YAML files and a README edit — no Rust source
+changes. There is no `#[cfg(test)]` module to write.
+
+**Manual verification steps (post-merge):**
+- Push to `master` triggers the `coverage` job; GitHub Actions log shows
+  `cargo llvm-cov ... --doctests` completing and `lcov.info` being uploaded.
+- A PR against `master` triggers the same job; Codecov posts a PR comment with
+  coverage delta.
+- Codecov project page at `https://codecov.io/gh/maratik123/quartzite` shows
+  a coverage percentage.
+- The badge in `README.md` resolves and displays a percentage after the first upload.
+
+## Open questions
+
+_(none)_

--- a/ai-docs/plans/done/2026-05-07-coverage-ci.spec.md
+++ b/ai-docs/plans/done/2026-05-07-coverage-ci.spec.md
@@ -1,0 +1,60 @@
+# CI: Code coverage reporting via cargo-llvm-cov + Codecov
+
+**Source:** issue #134
+**Date:** 2026-05-07
+**Tracked in:** #134
+
+## Scope
+
+- New `.github/workflows/coverage.yml` with a single `coverage` job
+- Runs on push to `master` and on PRs targeting `master`
+- Platform: `ubuntu-latest` only (coverage instrumentation is platform-independent)
+- Install `cargo-llvm-cov` via `taiki-e/install-action`
+- Run `cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests`
+- Exclude `examples/` from coverage (no test logic there)
+- Upload via `codecov/codecov-action@v5` with `token: ${{ secrets.CODECOV_TOKEN }}`
+- New `codecov.yml`: `coverage.status.project.target: auto`, `threshold: 1%`, `informational: true` (no auto-fail), comment-only mode
+- Codecov badge added to `README.md` under existing badges
+
+## Out of scope
+
+- Multi-OS coverage (Windows/macOS) — duplicate work, ubuntu-only is sufficient
+- Auto-fail on coverage drop — comment-only, informational only
+- Special proc-macro crate handling — `cargo-llvm-cov` v0.5+ handles proc-macros automatically
+- Benchmarks, release workflow (tracked separately in #135, #136)
+
+## Deferred
+
+- Threshold tightening (below 1%) | after project matures | no new issue needed
+- Per-crate coverage targets | not needed until more crates land | no new issue needed
+
+## Key decisions
+
+| Question | Decision |
+|----------|----------|
+| Separate file vs. add to ci.yml? | Separate `coverage.yml` — coverage is a distinct concern |
+| Codecov or Coveralls? | Codecov — better Rust support, GitHub-native PR comments, free OSS tier |
+| Run on push + PRs? | Both — push-to-master provides baseline; PRs need baseline for delta |
+| Include doctests? | Yes (`--doctests`) — skipping under-counts public-API coverage |
+| Include examples? | No (`--exclude quartzite-examples`) — runnable demos, no test logic |
+
+## Technical constraints
+
+- Requires `CODECOV_TOKEN` secret to be added to the repo settings before the job can upload
+- `codecov/codecov-action@v5` is the current major version; pin to `v5` (floating tag, not a SHA)
+- `cargo-llvm-cov` needs a nightly or stable compiler with llvm-tools; `taiki-e/install-action` handles this
+- `coverage.yml` must not block merges (no branch protection rule depending on it); it is informational
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `coverage.yml` exists and defines a `coverage` job triggered on push to `master` and on `pull_request` targeting `master` |
+| AC2 | Job installs `cargo-llvm-cov`, runs `cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests`, and uploads `lcov.info` via `codecov/codecov-action@v5` |
+| AC3 | `codecov.yml` exists with `coverage.status.project.target: auto`, `threshold: 1%`, and `informational: true` (no auto-fail on drop) |
+| AC4 | `README.md` contains a Codecov badge linking to the project's Codecov page |
+| AC5 | `ci.yml` is unchanged (coverage logic lives entirely in `coverage.yml`) |
+
+## Open questions
+
+_(none)_

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary

- New `.github/workflows/coverage.yml`: single `coverage` job on `ubuntu-latest`, triggered on push to `master` and PRs targeting `master`
- Uses **nightly** toolchain (required for `--doctests` support in `cargo-llvm-cov`)
- Installs `cargo-llvm-cov` via `taiki-e/install-action@v2`, runs `cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests`, uploads via `codecov/codecov-action@v5`
- New `codecov.yml`: `target: auto`, `threshold: 1%`, `informational: true` (no auto-fail on coverage drop)
- Codecov badge added to `README.md`
- `ci.yml` is unchanged

**Prerequisite:** add `CODECOV_TOKEN` secret to repo Settings → Secrets and variables → Actions before the upload step will succeed. The job is informational-only and not branch-protected, so missing the secret does not block merges.

> Note: `--exclude quartzite-examples` is intentionally omitted — `quartzite-examples` is not a workspace member. Examples are `[[example]]` binaries inside the root `quartzite` package and produce no LCOV data unless `--examples` is passed (which it is not).

## Tracking

Closes #134

## Test plan

- [ ] AC1: `coverage.yml` triggers on push to `master` and PRs targeting `master`
- [ ] AC2: Job installs `cargo-llvm-cov` (nightly), runs with `--workspace --lcov --output-path lcov.info --doctests`, uploads via `codecov/codecov-action@v5`
- [ ] AC3: `codecov.yml` has `target: auto`, `threshold: 1%`, `informational: true`
- [ ] AC4: Codecov badge visible in `README.md`
- [ ] AC5: `ci.yml` unchanged
- [ ] `cargo build` clean
- [ ] `cargo clippy -- -D warnings` clean