### PR TITLE
chore(ci): bump JS actions to Node-24 majors (upload-artifact, download-artifact, github-script)

### DIFF
--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -21,12 +21,12 @@ jobs:
           set -o pipefail
           cargo bench --workspace | tee benchmark_results.txt
       - name: Upload Benchmark Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark_results.txt
           path: ./benchmark_results.txt
       - name: Upload GitHub Pull Request Event
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: event.json
           path: ${{ github.event_path }}

--- a/.github/workflows/fork_pr_benchmarks_track.yml
+++ b/.github/workflows/fork_pr_benchmarks_track.yml
@@ -16,17 +16,17 @@ jobs:
       PR_EVENT: event.json
     steps:
       - name: Download Benchmark Results
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: ${{ env.BENCHMARK_RESULTS }}
           run_id: ${{ github.event.workflow_run.id }}
       - name: Download PR Event
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: ${{ env.PR_EVENT }}
           run_id: ${{ github.event.workflow_run.id }}
       - name: Export PR Event Data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let fs = require('fs');


### PR DESCRIPTION
## Summary

Three JavaScript actions in the bench CI pipeline are still on Node-20 majors. GitHub's [Node-20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) forces Node 24 as default on 2026-06-02 and removes Node 20 from runners on 2026-09-16. The notice surfaced today on the Run Fork PR Benchmarks job for \`actions/upload-artifact@v4\`; the other two would surface on the next \`workflow_run\` track-job firing.

## Changes

| Action | Before | After | Source |
|---|---|---|---|
| \`actions/upload-artifact\` | \`@v4\` (node20) | \`@v7\` (node24) | \`fork_pr_benchmarks_run.yml\` ×2 |
| \`dawidd6/action-download-artifact\` | \`@v6\` (node20) | \`@v21\` (node24) | \`fork_pr_benchmarks_track.yml\` ×2 |
| \`actions/github-script\` | \`@v7\` (node20) | \`@v8\` (node24) | \`fork_pr_benchmarks_track.yml\` ×1 |

## Why \`github-script@v8\`, not \`@v9\`

\`@v9\` adds an \`@actions/github\` v9 ESM upgrade with two breaking changes (\`require('@actions/github')\` removed; \`getOctokit\` injected as a script parameter, blocking \`const getOctokit = …\` redeclarations). Audit of our only script (the *Export PR Event Data* step in \`fork_pr_benchmarks_track.yml\`) confirms it uses neither \`@actions/github\` imports nor \`getOctokit\`, so it would survive \`@v9\` unchanged — but \`@v8\` is the **minimum-risk** pin: Node-runtime bump only, no \`@actions/github\` API churn.

## Out of scope

Other actions in the workspace are already current or unaffected:

- \`actions/checkout@v6\` — current major (v6.0.2), node24
- \`actions/cache@v5\` — current major (v5.0.5), node24
- \`bencherdev/bencher@main\` — rolling tag, node24
- \`dtolnay/rust-toolchain@stable\` — rolling tag, composite (no Node)
- \`taiki-e/install-action@v2\` — current major, composite (no Node)
- \`codecov/codecov-action@v6\` — current major, composite (no Node)

## Test plan

- [x] \`cargo build\` clean (no Rust changes; runs only to refresh \`Cargo.lock\` per AGENTS.md)
- [x] Local \`actionlint\` clean on both edited workflows
- [x] \`git diff --stat\` matches the table above (5 line changes across 2 files)
- [ ] Reviewer sanity-check: post-merge, the next CI run on master + the next PR confirm the Node-20 deprecation notices no longer appear