### PR TITLE
docs(learnings): query registry for current versions before pinning in any spec/issue/doc

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1,5 +1,28 @@
 # Learnings
 
+### 2026-05-07 — process — query the registry / release API for current versions before pinning a dependency or GitHub Action in any spec, issue body, design doc, or instruction file
+
+**What happened:** Twice in one session, issue bodies I authored cited stale dependency / action versions that the user had to correct:
+
+1. **#135** (Bencher CI) initially said `criterion = "0.5"`. The actual current is `0.8.2`. The user paste-corrected it after observing crates.io.
+2. **#137** (cargo doc publishing) said `actions/deploy-pages@v4` (and offered `peaceiris/actions-gh-pages@v3` as a fallback). The actual current is `@v5.0.0`; `@v4` is **node20** and would have re-introduced the exact Node-20 deprecation we'd just spent PR #146 fixing across the bench workflows. The user caught it before any `/task` session picked the issue up.
+
+The pattern is the same in both cases: I named a specific version from training-data knowledge, and the named version was several majors behind real-world current.
+
+**Rule:** When authoring an issue body, design doc, spec, or AGENTS.md / `ai-docs/**` addition that names a **specific** dependency or GitHub Action version, query the live source first:
+
+- **Cargo crates:** `curl -sS "https://crates.io/api/v1/crates/<name>" | jq -r '.crate.max_stable_version'`
+- **GitHub Actions:** `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` — and also fetch `action.yml` to confirm the Node runtime is current (`gh api /repos/<owner>/<repo>/contents/action.yml --jq '.content' | base64 -d | grep -E 'using:|node'`)
+- **Project crate convention** (AGENTS.md `## Dependency Versions`): use `0.x` for `0.x.y`, `x` for `x.y.z`. Apply that pinning *to the version actually observed in the registry*, not to a remembered version.
+
+If a body needs a long-lived stable reference (e.g., a doc that won't be revisited for months), include a comment `(verified current YYYY-MM-DD)` so future readers can spot drift before a `/task` session pins the stale value into a Cargo.toml or workflow file.
+
+**Why:** Stated versions become **load-bearing** the moment a `/task` session picks the issue up. The Sonnet 4.6 implementer follows the spec literally — `criterion = "0.5"` lands in `Cargo.toml` even though `"0.8"` is current; `actions/deploy-pages@v4` lands in a workflow file even though `@v4` is the Node-20 version we'd just deprecated workspace-wide. The cost of the mistake is asymmetric: 30 seconds of registry query at authoring time vs. a corrective PR + reviewer time vs. (worst case) a reverted regression.
+
+**How to apply:** Before writing any version-pinning string in any document the user might act on, run the registry query. The training cutoff is months behind live releases — treat training-data version knowledge as untrustworthy by default, especially for fast-moving projects (criterion bumped 0.5 → 0.8 between training and now; `actions/deploy-pages` bumped v4 → v5; `actions/upload-artifact` bumped v4 → v7).
+
+**Escalated?** no
+
 ### 2026-05-07 — process — run actionlint on every new or modified GitHub Actions workflow file
 
 **What happened:** Three new workflow files were created for Bencher CI integration and committed without running actionlint. The user had to ask explicitly. actionlint caught `actions/github-script@v6` being too old for the current GitHub Actions runner; fixing it required an extra commit.


### PR DESCRIPTION
## Summary

Logs a recurring process slip: issue bodies I authored cited stale dependency / action versions twice in one session.

| Issue | Stale value I wrote | Actual current | Caught by |
|---|---|---|---|
| #135 (Bencher CI) | \`criterion = "0.5"\` | \`0.8.2\` | user paste-correction |
| #137 (cargo doc publishing) | \`actions/deploy-pages@v4\` | \`@v5.0.0\` (\`@v4\` is **node20**, the very deprecation PR #146 just fixed) | user re-asked for freshness check |

Stated versions become **load-bearing** the moment a \`/task\` session picks the issue up — Sonnet 4.6 follows the spec literally — so the asymmetric cost (30s of registry query vs. a corrective PR) deserves a logged rule.

## Changes

- \`ai-docs/learnings.md\` — new entry under date 2026-05-07 with concrete query commands for both crates.io and GitHub Action releases (incl. the action.yml Node-version probe used in the Pages-trio sweep above).

## Test plan

- [x] \`cargo build\` clean (no Rust changes; runs only to refresh \`Cargo.lock\` per AGENTS.md)
- [x] Diff is one file, +23 lines, learnings-only
- [ ] Reviewer sanity-check: the rule's specifics (commands, project-convention pinning rule) match AGENTS.md \`## Dependency Versions\`

## Out of scope

- **No escalation in this PR.** Marked \`Escalated? no\` per the standing rule that "add to learnings" requests don't authorize propagation. If \`/improve\` later decides this rule warrants AGENTS.md / skill-level escalation, that lands separately.