### PR TITLE
ci: publish cargo doc to GitHub Pages on push to master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Build docs
+        run: cargo doc --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: "-D warnings -D missing-docs"
+      - name: Create redirect index
+        run: printf '<meta http-equiv="refresh" content="0; url=quartzite/index.html">\n' > target/doc/index.html
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # quartzite
 
 [![codecov](https://codecov.io/gh/maratik123/quartzite/branch/master/graph/badge.svg)](https://codecov.io/gh/maratik123/quartzite)
+[![docs](https://img.shields.io/badge/docs-master-blue)](https://maratik123.github.io/quartzite/)
 
 A GUI and object framework for Rust built around signals/slots,
 a rich object model, and a declarative UI layer — implemented as idiomatic Rust with no native

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -627,6 +627,16 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Escalated?** AGENTS.md, agent:self-review, agent:review-findings
 
+### 2026-05-07 — process — actionlint skipped again on docs.yml despite existing learnings entry
+
+**What happened:** `.github/workflows/docs.yml` was created, committed, and pushed without running `actionlint`. The user had to ask explicitly — same pattern as the previous entry (2026-05-07, line ~26). The existing learning is `Escalated? no` and has not been enforced.
+
+**Rule:** Run `actionlint <file>` on every GitHub Actions workflow file created or modified, before staging. This is a required gate, same as `cargo build` and `cargo clippy`.
+
+**Why:** Two occurrences in the same session with the rule already written confirms the rule needs to live in AGENTS.md and the task skill, not just in learnings.
+
+**Escalated?** no
+
 ### 2026-05-07 — process — do not skip design/design-review for "simple" tasks
 
 **What happened:** `/task 116` was a pure annotation task (replace `#[inline]` with `/// _Simple._` at 12 sites). I skipped Steps 6–7 (design agent + design review) on the grounds that no design decision existed. The user called out the omission.

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -9,6 +9,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 | [generic-simple-tags](done/2026-05-07-generic-simple-tags.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; annotation-only) | — |
 | [coverage-ci](done/2026-05-07-coverage-ci.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only) | — |
 | [criterion-benchmarks](done/2026-05-07-criterion-benchmarks.spec.md) | `quartzite-core` `quartzite-runtime` CI | ✅ implemented (0 new tests; 10 benches, 3 CI workflows) | — |
+| [cargo-doc-pages](done/2026-05-07-cargo-doc-pages.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only) | — |
 | [graphics-stack](2026-05-03-graphics-stack.spec.md) | `quartzite-paint-api` `quartzite-renderer` | 🟢 ready | — |
 | [code-style-extraction](done/2026-05-07-code-style-extraction.spec.md) | (docs only) | ✅ implemented (0 new tests; docs only) | — |
 | [generic-fn-split](done/2026-05-07-generic-fn-split.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; refactoring) | — |

--- a/ai-docs/plans/done/2026-05-07-cargo-doc-pages.design.md
+++ b/ai-docs/plans/done/2026-05-07-cargo-doc-pages.design.md
@@ -1,0 +1,76 @@
+# Design: cargo doc publishing to GitHub Pages
+
+**Issue:** #137
+**Date:** 2026-05-07
+
+## Approach
+
+Add a single GitHub Actions workflow file `.github/workflows/docs.yml` that, on every push to
+`master`, builds `cargo doc` with the same flags used in the AGENTS.md doc gate, injects a
+top-level redirect page into `target/doc/`, and deploys the artifact to GitHub Pages via the
+official Pages action trio (configure → upload → deploy). A docs badge is added to `README.md`
+under the existing codecov badge.
+
+**Why this approach:**
+- Artifact-based Pages deployment (no `gh-pages` branch) is the current GitHub-recommended
+  approach; it avoids branch-management noise and works cleanly with the existing workflow
+  structure.
+- Reusing the exact `RUSTDOCFLAGS` and `cargo doc` flags from `ci.yml`'s `docs` job keeps the
+  doc gate consistent between CI and deployment.
+- A single `run:` step to write the redirect HTML keeps the workflow minimal — no extra actions
+  or scripts needed.
+
+**Rejected alternatives:**
+- `peaceiris/actions-gh-pages`: third-party action, requires a `gh-pages` branch, more moving
+  parts than the official trio.
+- Running `cargo doc` in an existing workflow job and uploading from there: couples doc build to
+  unrelated CI concerns; the Pages deployment must be its own job to hold the `pages: write` and
+  `id-token: write` permissions without granting them to all CI jobs.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Create `.github/workflows/docs.yml` with trigger, permissions, concurrency, build job (checkout + toolchain + cache + `cargo doc` + inject redirect + upload artifact), and deploy job | `.github/workflows/docs.yml` | — |
+| 2 | Insert docs badge in `README.md` under the codecov badge line | `README.md` | — |
+
+## Risks
+
+- **`gh-pages` source vs. artifact source misconfiguration:** GitHub Pages must be configured in
+  Settings → Pages to use "GitHub Actions" as the source, not a branch. This is a one-time manual
+  step by the repo owner after the first run. The workflow will succeed but the site will 404
+  until this is done. Mitigation: document in the spec's Out of scope section (already done).
+- **Stale action major versions:** The spec pins `configure-pages@v6`, `upload-pages-artifact@v5`,
+  `deploy-pages@v5` as verified on 2026-05-07. If GitHub releases a new major, the workflow
+  continues to work on the pinned major. Mitigation: major-only pins per project convention.
+- **`target/doc/` path assumption:** The redirect step writes to `target/doc/index.html`. If
+  `cargo doc` ever changes its output path this step silently produces a bad artifact. Mitigation:
+  the step runs immediately after `cargo doc` and the workflow would fail at the upload step if
+  the path were wrong.
+- **Concurrency with rapid pushes:** `cancel-in-progress: false` means a second push queues
+  rather than kills the in-flight deploy. This is the correct choice for Pages (avoids deploying
+  a partial build), but a burst of pushes could queue several deploys. Mitigation: this matches
+  the spec decision and is acceptable given the low push frequency on `master`.
+
+## Test Design
+
+This task involves no Rust code — there are no `#[cfg(test)]` modules or integration tests to
+write. Correctness is verified by the workflow running successfully on GitHub Actions after the
+PR is merged to `master`. The following manual checks serve as acceptance verification:
+
+- AC1: Workflow file has `on: push: branches: [master]` and no `pull_request` trigger.
+- AC2: `cargo doc` step sets `RUSTDOCFLAGS: "-D warnings -D missing-docs"` and uses
+  `--no-deps --workspace`; a deliberate missing-doc warning in a test branch would fail the job.
+- AC3: A `run:` step writes `<meta http-equiv="refresh" ...>` HTML to `target/doc/index.html`
+  pointing at `quartzite/index.html` before the upload step.
+- AC4: The deploy job uses exactly `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`,
+  `actions/deploy-pages@v5` and no `gh-pages` branch reference appears anywhere.
+- AC5: Top-level `permissions:` block lists only `contents: read`, `pages: write`,
+  `id-token: write`.
+- AC6: Top-level `concurrency:` block sets `group: "pages"` and `cancel-in-progress: false`.
+- AC7: `README.md` line 3 (after codecov badge) contains the shield badge linking to
+  `https://maratik123.github.io/quartzite/`.
+
+## Open questions
+
+_None._

--- a/ai-docs/plans/done/2026-05-07-cargo-doc-pages.spec.md
+++ b/ai-docs/plans/done/2026-05-07-cargo-doc-pages.spec.md
@@ -1,0 +1,60 @@
+# cargo doc publishing to GitHub Pages
+
+**Source:** issue #137
+**Date:** 2026-05-07
+**Tracked in:** #137
+
+## Scope
+
+1. New `.github/workflows/docs.yml` — triggers on `push` to `master`
+2. Runs `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace`; fails the build on any doc warning
+3. Injects a top-level `index.html` redirect pointing at `quartzite/index.html` (facade crate)
+4. Deploys via the official Pages trio: `actions/configure-pages@v6` + `actions/upload-pages-artifact@v5` + `actions/deploy-pages@v5`; no `gh-pages` branch (artifact-based source)
+5. Workflow-level permissions: `contents: read`, `pages: write`, `id-token: write`
+6. Concurrency group: `group: "pages"`, `cancel-in-progress: false`
+7. README docs badge inserted under the existing `codecov` badge: `[![docs](https://img.shields.io/badge/docs-master-blue)](https://maratik123.github.io/quartzite/)`
+
+## Out of scope
+
+- Enabling GitHub Pages in Settings → Pages (user action — must be done by the repo owner after the first workflow run)
+- Per-PR docs preview
+- `--document-private-items`
+- Versioned/multi-version docs
+
+## Deferred
+
+- Multi-version docs (post first `cargo publish`) | After docs.rs takes over for releases | No separate issue needed yet
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Trigger | `push` to `master` only — no PR preview |
+| Doc flags | `RUSTDOCFLAGS="-D warnings -D missing-docs"` + `--no-deps --workspace` — matches AGENTS.md doc-gate |
+| Redirect target | Facade crate (`quartzite/index.html`) |
+| Pages source | GitHub Actions artifact (no `gh-pages` branch) |
+| Action versions | `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5` — verified 2026-05-07 |
+| Concurrency | `group: "pages"`, `cancel-in-progress: false` — prevents overlapping deploys on rapid pushes |
+
+## Technical constraints
+
+- Action versions must match project convention (major-only pins, e.g. `@v5`).
+- `actions/checkout` must match existing workflows (`@v6`).
+- `upload-pages-artifact` is composite (no Node runtime); `deploy-pages` requires Node 24.
+- The redirect `index.html` must be injected into `target/doc/` before the artifact upload step.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `.github/workflows/docs.yml` triggers on `push` to `master` (and only on push to master) |
+| AC2 | Workflow runs `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace`; a doc warning causes the workflow to fail |
+| AC3 | A `target/doc/index.html` is created that redirects the browser to `quartzite/index.html` |
+| AC4 | Deploys via `actions/configure-pages@v6` + `actions/upload-pages-artifact@v5` + `actions/deploy-pages@v5`; no `gh-pages` branch used |
+| AC5 | Workflow permissions are scoped to `contents: read`, `pages: write`, `id-token: write` |
+| AC6 | Workflow has `concurrency: group: "pages"`, `cancel-in-progress: false` |
+| AC7 | README contains a docs badge linking to `https://maratik123.github.io/quartzite/`, inserted under the codecov badge |
+
+## Open questions
+
+_None._


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docs.yml`: triggers on push to `master`, builds workspace docs with `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace`, injects a top-level `index.html` redirect to the `quartzite` facade crate, and deploys via the official Pages artifact trio (`configure-pages@v6` + `upload-pages-artifact@v5` + `deploy-pages@v5`)
- Workflow uses scoped permissions (`contents: read`, `pages: write`, `id-token: write`) and a `concurrency` group (`"pages"`, `cancel-in-progress: false`) to prevent overlapping deploys
- Adds docs badge to `README.md` linking to `https://maratik123.github.io/quartzite/`

> **One-time repo owner action required after merge:** Settings → Pages → Build and deployment → Source: **GitHub Actions**. The workflow will succeed on the first push but the site returns 404 until this is configured.

## Tracking

Closes #137

## Test plan

- [x] AC1: `on: push: branches: [master]` only — no `pull_request` trigger
- [x] AC2: `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — doc warnings fail the build
- [x] AC3: `printf '<meta http-equiv="refresh"...>' > target/doc/index.html` injects redirect before artifact upload
- [x] AC4: All three Pages actions used; no `gh-pages` branch reference
- [x] AC5: Workflow-level permissions scoped to `contents: read`, `pages: write`, `id-token: write`
- [x] AC6: `concurrency: group: "pages"`, `cancel-in-progress: false`
- [x] AC7: Docs badge on README line 4 under codecov badge
- [x] `cargo build` clean
- [x] `cargo test` green
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` clean