### PR TITLE
fix(docs): place document_features!() inline within crate docs and section verbose-tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ std = ["quartzite-core/std", "quartzite-geometry/std"]
 ## Enable proc-macro derive support (`Extend`, `Object`, `object_impl`, `MetaEnum`).
 ## Disable to reduce compile time in macro-free or `no_std` builds.
 derive = ["dep:quartzite-macros"]
+
+#! ### Diagnostic features
+#!
+#! Off by default. Enabling these is purely additive and only affects observability,
+#! never correctness or behaviour.
+
 ## Enable span instrumentation on high-frequency paths (e.g. signal emit, event loop post).
 ## Off by default to keep hot paths zero-cost.
 verbose-tracing = ["quartzite-core/verbose-tracing", "quartzite-runtime/verbose-tracing"]

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1,5 +1,58 @@
 # Learnings
 
+### 2026-05-07 — documentation — `document_features::document_features!()` invocation must sit inline within the `//!` crate doc, immediately after a `## Feature flags` heading; main vs diagnostic features must be sectioned in Cargo.toml
+
+**What happened:** Two related bugs in our `document_features` integration, both surfaced once `cargo doc` was published live to GitHub Pages (PR #148, #137):
+
+1. **Macro placement was wrong in two crate roots.**
+   - `src/lib.rs` invoked `#![doc = document_features::document_features!()]` on line 9, **before** the `//!` crate-doc block (lines 10-24). The rendered feature list appeared **first**, ahead of the overview.
+   - `quartzite-core/src/lib.rs` invoked it at the end of the attribute block (line 15) **with no preceding `## Feature flags` heading**. The features rendered as an unlabelled appendix with no TOC anchor.
+
+2. **`verbose-tracing` was mixed with main features.** In workspace `Cargo.toml` and `quartzite-core/Cargo.toml`, `verbose-tracing` was listed as a peer of `std` and `derive` — so the rendered feature list mixed a purely-diagnostic observability flag with the main feature-flag choices users actually evaluate (build-target, derive availability).
+
+PR #149 fixed both. Verified visually on `target/doc/*/index.html`: Examples → Feature flags (h2) → Diagnostic features (h4 subsection) — sidebar TOC correctly nests.
+
+**Rule:**
+
+- **Macro placement.** When a crate uses `document_features`, place the `#![doc = document_features::document_features!()]` invocation **inline within the `//!` crate doc**, immediately after a `## Feature flags` (or `# Feature flags` — whichever heading level matches sibling sections like `# Examples` already in that crate doc). The remaining inner attributes (lints, `cfg_attr`, etc.) follow afterwards. Never place the macro **before** the `//!` block (forces features-list to render first) or **after the entire attribute block with no preceding heading** (renders as an unlabelled appendix). Canonical shape:
+
+  ```rust
+  //! Crate overview…
+  //!
+  //! # Examples
+  //! …
+  //!
+  //! # Feature flags
+  #![doc = document_features::document_features!()]
+  #![other lint attributes…]
+  ```
+
+- **Cargo.toml feature sectioning.** Group features in `[features]` by audience using `#! ### <Section>` headings:
+  - **Main features** (default-on, commonly toggled, affects build target / API surface): listed first under no extra heading, just `## per-feature docstrings`.
+  - **Diagnostic features** (purely additive observability — tracing spans, debug instrumentation, profiling hooks): under `#! ### Diagnostic features` with a one-paragraph `#!` intro stating "Off by default. Enabling these is purely additive and only affects observability, never correctness or behaviour."
+  - Other categories (e.g. `#! ### Experimental features`, `#! ### Optional dependencies`) follow the canonical `document_features` example as needed.
+
+  Crates that **don't** invoke `document_features!()` (e.g. `quartzite-runtime` with only `verbose-tracing`) don't need section headings — the comments would be inert decoration.
+
+**Why:**
+
+- Reader priority: the human-curated overview is what readers want first. An auto-generated feature list before it inverts reading priority and forces every visitor to scroll past low-value content.
+- Anchorability: a section without an `## Feature flags` heading has no TOC anchor; readers can't link to it, can't search for it in the sidebar, can't deep-link from external docs.
+- Decision fatigue: mixing diagnostic features with main features makes every reader evaluate "do I need this?" on every line. Section headings communicate the "main features matter; diagnostic features are additive observability" distinction at a glance.
+
+**How to apply:**
+
+- When adding `document_features` to a new crate, write the source file in the canonical shape above before any other lint attributes are added — easier than retrofitting later.
+- When adding a feature to an existing `[features]` table:
+  1. Decide its audience: build-target/API-surface (main) vs observability-only (diagnostic) vs experimental/in-development.
+  2. If it's diagnostic and the table doesn't already have a `#! ### Diagnostic features` section, add one (with the standard intro paragraph) before adding the feature.
+  3. Place the `## per-feature docstring` immediately above the feature line.
+- When reviewing a PR that touches `document_features`-using crates, check both: (a) macro is inline within `//!` after a heading; (b) any new feature lands under the right `#! ###` section per its audience.
+
+**Escalated?** no
+
+> Candidate for escalation to `ai-docs/doc-convention.md` (heading placement + feature-section grouping is a documentation convention, parallel to the existing `_Simple._` tag rules). `/improve` should consider this when ≥3 unescalated entries accumulate; tagging `documentation` as the category to make the doc-convention escalation target obvious.
+
 ### 2026-05-07 — process — query the registry / release API for current versions before pinning a dependency or GitHub Action in any spec, issue body, design doc, or instruction file
 
 **What happened:** Twice in one session, issue bodies I authored cited stale dependency / action versions that the user had to correct:

--- a/quartzite-core/Cargo.toml
+++ b/quartzite-core/Cargo.toml
@@ -13,6 +13,12 @@ default = ["std"]
 ## Enable standard-library support (threading, queued dispatch, `is_on_current_thread`).
 ## Disable to build in `no_std + alloc` environments.
 std = ["indexmap/std", "tracing/log", "dep:parking_lot"]
+
+#! ### Diagnostic features
+#!
+#! Off by default. Enabling these is purely additive and only affects observability,
+#! never correctness or behaviour.
+
 ## Enable span instrumentation on high-frequency paths (e.g. signal emit).
 ## Off by default to keep hot paths zero-cost.
 verbose-tracing = []

--- a/quartzite-core/src/lib.rs
+++ b/quartzite-core/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate is `no_std`-compatible when the `std` feature is disabled (requires `alloc`).
 //! All runtime-specific functionality (event loops, timers, thread pools) lives in
 //! `quartzite-runtime`.
+//!
+//! # Feature flags
+#![doc = document_features::document_features!()]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
@@ -12,7 +15,6 @@
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![deny(missing_docs)]
-#![doc = document_features::document_features!()]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![deny(missing_docs)]
-#![doc = document_features::document_features!()]
-//!
 //! Provides a single facade crate that re-exports the workspace member crates
 //! ([`core`], [`events`], [`geometry`], [`macros`], [`runtime`]) plus a
 //! curated [`prelude`] for one-line imports.
@@ -22,6 +20,9 @@
 //!
 //! `MetaEnum` for enum reflection is available via [`macros::MetaEnum`] (requires the `derive`
 //! feature, enabled by default).
+//!
+//! # Feature flags
+#![doc = document_features::document_features!()]
 
 /// Re-exports the core object model, signals, and reflection types from [`quartzite_core`].
 ///


### PR DESCRIPTION
## Summary

Two related rendering bugs in our \`document_features\` integration, surfaced now that \`cargo doc\` is published live to GitHub Pages (#137 / PR #148).

## Bugs

### 1. Macro placement (2 files)

\`document_features::document_features!()\` was invoked outside the canonical inline-with-\`//!\` position:

| File | Before | Effect on rendered HTML |
|---|---|---|
| \`src/lib.rs\` | macro emitted on line 9, *before* the \`//!\` crate doc block (lines 10-24) | Feature list rendered **first**, ahead of the overview |
| \`quartzite-core/src/lib.rs\` | macro emitted on line 15, at the end of the attribute block, *with no preceding heading* | Features rendered as an unlabelled appendix |

The canonical pattern from the upstream crate's documentation is:

\`\`\`rust
//! Crate overview text…
//!
//! ## Feature flags
#![doc = document_features::document_features!()]
\`\`\`

### 2. \`verbose-tracing\` mixed with main features (2 Cargo.toml files)

\`verbose-tracing\` was listed as a peer of \`std\` and \`derive\` in workspace \`Cargo.toml\` and \`quartzite-core/Cargo.toml\`, so the rendered list mixed a **diagnostic** feature with the **main** feature-flag choices users actually evaluate. Moved it under a \`#! ### Diagnostic features\` section heading with a short prose intro.

\`quartzite-runtime/Cargo.toml\` has only \`verbose-tracing\` (no main features alongside) and does not invoke \`document_features!()\`, so left untouched.

## Changes

| File | Change |
|---|---|
| \`src/lib.rs\` | Move \`#![doc = document_features::document_features!()]\` from line 9 (before \`//!\`) to after the crate overview, immediately following a new \`//! # Feature flags\` heading |
| \`quartzite-core/src/lib.rs\` | Same — relocate macro invocation to inline after \`//! # Feature flags\` heading; remaining lint attributes follow |
| \`Cargo.toml\` | Add \`#! ### Diagnostic features\` section with prose intro before \`verbose-tracing\` |
| \`quartzite-core/Cargo.toml\` | Same |

4 files, +18 / −3 lines.

## Rendered output (verified locally)

\`target/doc/quartzite/index.html\` post-fix:

- \`<h2 id=\"examples\">Examples</h2>\` (kept first, with the example rust block)
- \`<h2 id=\"feature-flags\">Feature flags</h2>\` containing \`std\` + \`derive\` (rendered as h2)
- \`<h4 id=\"diagnostic-features\">Diagnostic features</h4>\` subsection with \`verbose-tracing\`
- Sidebar TOC nests Diagnostic features under Feature flags

\`target/doc/quartzite_core/index.html\` post-fix matches the same shape (no Examples section in this crate).

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo build -p quartzite --no-default-features\` clean
- [x] \`RUSTDOCFLAGS=\"-D warnings -D missing-docs\" cargo doc --no-deps --workspace\` clean
- [x] Visual sanity-check of \`target/doc/quartzite/index.html\` and \`target/doc/quartzite_core/index.html\` confirms section structure
- [ ] Reviewer sanity-check on the live \`https://maratik123.github.io/quartzite/\` after merge — the deploy workflow runs on push to master and the change should be visible within ~1 minute of merge
