### PR TITLE
chore(agents): escalate actionlint, document_features, registry-query rules

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -88,6 +88,7 @@ Flag each of the following:
 - **Missing `# Panics`** on a fn that calls `unwrap()` / `expect(…)`, indexes / slices a collection, asserts an invariant, or performs arithmetic that can overflow on plausible inputs (also flagged by `clippy::missing_panics_doc`).
 - **Missing `# Safety`** on every `unsafe fn` (also flagged by `clippy::missing_safety_doc`).
 - **Ad-hoc sections** (e.g. stray `# Notes`) — only the canonical headings above are allowed.
+- **`document_features` rendering** ([`ai-docs/doc-convention.md`](../../ai-docs/doc-convention.md#feature-flags-rendering-document_features))**:** any crate that invokes `document_features::document_features!()` must place the macro inline within the `//!` block immediately after a `## Feature flags` heading (not before the `//!` block, not as a trailing attribute with no heading) → `major`. Any entry in that crate's `[features]` table that lands in the wrong `#! ### <Section>` per audience (main vs. `#! ### Diagnostic features` vs. `#! ### Experimental features` …) → `minor`.
 
 ## What you do NOT check
 

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -107,6 +107,7 @@ REJECT on any of:
 - **Missing `# Panics`** on a fn that calls `unwrap()` / `expect(…)`, indexes / slices a collection, asserts an invariant, or performs arithmetic that can overflow on plausible inputs (also flagged by `clippy::missing_panics_doc`).
 - **Missing `# Safety`** on every `unsafe fn` (also flagged by `clippy::missing_safety_doc`).
 - **Ad-hoc sections** (e.g. stray `# Notes`) — only the canonical headings above are allowed.
+- **`document_features` rendering** ([`ai-docs/doc-convention.md`](../../ai-docs/doc-convention.md#feature-flags-rendering-document_features))**:** any crate this diff adds or modifies that invokes `document_features::document_features!()` must place the macro inline within the `//!` block immediately after a `## Feature flags` heading (not before the `//!` block, not as a trailing attribute with no heading); and any new entry in that crate's `[features]` table must land under the correct `#! ### <Section>` heading per audience (main features unsectioned; observability-only flags under `#! ### Diagnostic features`). Misplaced macro or new feature listed in the wrong section → REJECT.
 
 ### 7. Objection quality (round > 1 only)
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -167,7 +167,7 @@ finding (Step 11) requires a design change rather than a code fix:
 5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — no doc errors or warnings (matches CI)
 6. **actionlint gate** — if this task created or modified any `.github/workflows/*.yml` file, run `actionlint <file>` (or pass every changed workflow file in one invocation) and require a clean pass. Skip the gate only when no workflow file was touched. See AGENTS.md *Build & Test → Workflow files*.
 7. For each AC — confirm covered by test or manual verification
-7. Show summary table:
+8. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -165,7 +165,8 @@ finding (Step 11) requires a design change rather than a code fix:
 3. `cargo fmt -- --check` — no formatting drift
 4. `cargo clippy -- -D warnings` — clean
 5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — no doc errors or warnings (matches CI)
-6. For each AC — confirm covered by test or manual verification
+6. **actionlint gate** — if this task created or modified any `.github/workflows/*.yml` file, run `actionlint <file>` (or pass every changed workflow file in one invocation) and require a clean pass. Skip the gate only when no workflow file was touched. See AGENTS.md *Build & Test → Workflow files*.
+7. For each AC — confirm covered by test or manual verification
 7. Show summary table:
 
 ```
@@ -174,7 +175,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-8. On ALL PASS → proceed to Step 9.5
+9. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -268,7 +269,7 @@ After the PR is created, the unconditional PR-body re-read rule (AGENTS.md *Work
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps --workspace` clean? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps --workspace` clean? `actionlint` clean on every changed `.github/workflows/*.yml` (skip if none changed)? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? `gh pr view <N>` re-read after every push (unconditional) — `gh pr edit` only if body contradicts new commits? |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,10 @@ cargo fmt                             # fix formatting
 cargo fmt -- --check                  # check only
 RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace   # doc gate (matches CI)
 cargo build -p quartzite --no-default-features   # verify derive-free / no_std path compiles
+actionlint .github/workflows/<file>.yml   # required gate for any new/modified workflow file
 ```
+
+**Workflow files.** Any new or modified `.github/workflows/*.yml` is a required `actionlint` gate before staging — same status as `cargo build` / `cargo clippy`. Run `actionlint <file>` (or pass every changed file in one invocation) and fix all errors before `git add`. actionlint catches runner-version mismatches, deprecated action versions, expression syntax errors, and shell quoting issues that `cargo` checks cannot see.
 
 Search: `rg <pattern> --type rust [-l | -C 3]`
 
@@ -72,6 +75,14 @@ When adding or editing dependencies in `Cargo.toml`:
 - Use `x` for `x.y.z` versions — never pin minor or patch.
 - No `~` prefix — Cargo's default `^` semantics are sufficient.
 - After changing version constraints, run `cargo update` to pull latest compatible versions, then `cargo build` to verify.
+
+**Query the registry before pinning.** Whenever you write a *specific* version string for a dependency or GitHub Action — in `Cargo.toml`, a workflow file, an issue body, a spec, a design doc, a learning, or any `ai-docs/**` page — query the live source first. Training-data version knowledge is months stale by default and treating it as authoritative has, in this repo, twice put the wrong major into a spec the user then had to correct (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`). The cost is asymmetric: 30 seconds at authoring time vs. a corrective PR + reviewer time vs. a reverted regression worst-case.
+
+Per source:
+
+- **Cargo crates:** `curl -sS "https://crates.io/api/v1/crates/<name>" | jq -r '.crate.max_stable_version'` — then apply the `0.x` / `x` pinning rule above to the *observed* version, not a remembered one.
+- **GitHub Actions:** `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` for the current major; also fetch `action.yml` to confirm the Node runtime is current — `gh api /repos/<owner>/<repo>/contents/action.yml --jq '.content' | base64 -d | grep -E 'using:|node'`. (Skipping the runtime check is how stale Node-20 majors slipped in repeatedly.)
+- **Long-lived references** (a doc that won't be revisited for months): annotate `(verified current YYYY-MM-DD)` next to the version so the next reader can spot drift before a `/task` session pins the stale value.
 
 ## Workflow
 

--- a/ai-docs/doc-convention.md
+++ b/ai-docs/doc-convention.md
@@ -195,6 +195,92 @@ is **not** fine: agents and reviewers check this mechanically.
   }
   ```
 
+## Feature flags rendering (`document_features`)
+
+Crates that invoke [`document_features`](https://crates.io/crates/document_features)
+to render their `Cargo.toml` `[features]` table into rustdoc must obey two
+conventions — one in the source file, one in `Cargo.toml`. Both are
+load-bearing for the public docs.html that ships to GitHub Pages.
+
+### Macro placement
+
+Place the `#![doc = document_features::document_features!()]` invocation
+**inline within the `//!` crate doc**, immediately after a
+`## Feature flags` heading (or `# Feature flags` — pick the heading level
+that matches sibling sections like `# Examples` already used in the same
+crate doc). The remaining inner attributes (lints, `cfg_attr`, etc.) follow
+the macro line. Canonical shape:
+
+```rust
+//! Crate overview…
+//!
+//! # Examples
+//! …
+//!
+//! # Feature flags
+#![doc = document_features::document_features!()]
+#![other lint attributes…]
+```
+
+**Forbidden positions:**
+
+- **Before** the `//!` block — the rendered feature list appears first,
+  ahead of the human-curated overview (inverts reading priority).
+- **After** the entire attribute block with no preceding `## Feature flags`
+  heading — the features render as an unlabelled appendix with no TOC anchor
+  (no deep-link target, no sidebar entry, no search match).
+
+### Cargo.toml feature sectioning
+
+Group entries in `[features]` by audience using `#! ### <Section>`
+section headings. `document_features` parses these into rustdoc subsections.
+
+- **Main features** (default-on, commonly toggled, affects build target /
+  API surface): listed first under no extra heading, just `## per-feature`
+  doc strings.
+- **Diagnostic features** (purely additive observability — tracing spans,
+  debug instrumentation, profiling hooks): under `#! ### Diagnostic features`
+  with a one-paragraph `#!` intro stating "Off by default. Enabling these is
+  purely additive and only affects observability, never correctness or
+  behaviour."
+- Other categories (`#! ### Experimental features`,
+  `#! ### Optional dependencies`, …) follow the canonical
+  `document_features` example as needed.
+
+Crates that **don't** invoke `document_features!()` (e.g. a crate with only
+a `verbose-tracing` flag) don't need section headings — the comments would
+be inert decoration.
+
+### Why
+
+- Reader priority: the human-curated overview is what readers want first.
+  An auto-generated feature list before it forces every visitor to scroll
+  past low-value content.
+- Anchorability: a section without an `## Feature flags` heading has no TOC
+  anchor; readers can't link to it, can't search for it in the sidebar,
+  can't deep-link from external docs.
+- Decision fatigue: mixing diagnostic features with main features makes
+  every reader evaluate "do I need this?" on every line. Section headings
+  communicate "main features matter; diagnostic features are additive
+  observability" at a glance.
+
+### How to apply
+
+- When adding `document_features` to a new crate, write the source file in
+  the canonical shape above before any other lint attributes are added —
+  easier than retrofitting later.
+- When adding a feature to an existing `[features]` table:
+  1. Decide its audience: build-target / API-surface (main) vs.
+     observability-only (diagnostic) vs. experimental / in-development.
+  2. If it's diagnostic and the table doesn't already have a
+     `#! ### Diagnostic features` section, add one (with the standard
+     intro paragraph) before adding the feature.
+  3. Place the `## per-feature` docstring immediately above the feature
+     line.
+- When reviewing a PR that touches `document_features`-using crates, check
+  both: (a) macro is inline within `//!` after a heading; (b) any new
+  feature lands under the right `#! ###` section per its audience.
+
 ## Linking and code references
 
 - **Backtick every Rust identifier in prose.** Type names, function names,

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -49,9 +49,7 @@ PR #149 fixed both. Verified visually on `target/doc/*/index.html`: Examples →
   3. Place the `## per-feature docstring` immediately above the feature line.
 - When reviewing a PR that touches `document_features`-using crates, check both: (a) macro is inline within `//!` after a heading; (b) any new feature lands under the right `#! ###` section per its audience.
 
-**Escalated?** no
-
-> Candidate for escalation to `ai-docs/doc-convention.md` (heading placement + feature-section grouping is a documentation convention, parallel to the existing `_Simple._` tag rules). `/improve` should consider this when ≥3 unescalated entries accumulate; tagging `documentation` as the category to make the doc-convention escalation target obvious.
+**Escalated?** doc-convention, agent:self-review, agent:review-findings
 
 ### 2026-05-07 — process — query the registry / release API for current versions before pinning a dependency or GitHub Action in any spec, issue body, design doc, or instruction file
 
@@ -74,7 +72,7 @@ If a body needs a long-lived stable reference (e.g., a doc that won't be revisit
 
 **How to apply:** Before writing any version-pinning string in any document the user might act on, run the registry query. The training cutoff is months behind live releases — treat training-data version knowledge as untrustworthy by default, especially for fast-moving projects (criterion bumped 0.5 → 0.8 between training and now; `actions/deploy-pages` bumped v4 → v5; `actions/upload-artifact` bumped v4 → v7).
 
-**Escalated?** no
+**Escalated?** AGENTS.md
 
 ### 2026-05-07 — process — run actionlint on every new or modified GitHub Actions workflow file
 
@@ -86,7 +84,7 @@ If a body needs a long-lived stable reference (e.g., a doc that won't be revisit
 
 **How to apply:** After writing or editing any `.github/workflows/*.yml` file, run `actionlint <file>` before staging. If multiple files changed, pass all of them in one invocation. Fix all errors before committing.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, skill:task
 
 ### 2026-05-07 — process — do not escalate learnings without being asked; escalation is triggered only by /improve
 


### PR DESCRIPTION
## Summary

`/improve` run on three recurring learnings (≥2 occurrences each, all unescalated) — moves them from `ai-docs/learnings.md` into project-level instructions so the rules become visible to every contributor.

- **actionlint gate.** AGENTS.md *Build & Test* lists `actionlint` alongside the cargo gates + adds a *Workflow files* paragraph. `/task` Step 9 (Verify) gains an explicit actionlint sub-step (gate 6) and a matching entry in the Step 9 row of the gate checklist; gate fires only when the task touches `.github/workflows/*.yml`.
- **`document_features` rendering convention.** `ai-docs/doc-convention.md` gains a *Feature flags rendering* section covering macro placement (inline within `//!` immediately after a `## Feature flags` heading — not before the `//!` block, not as an unlabelled trailing attribute) and `Cargo.toml` feature sectioning (main vs. `#! ### Diagnostic features`). Per the AGENTS.md *Propagation Rule*, both review agents (`self-review.md` §6, `review-findings.md` §6) now flag misplaced macro / mis-sectioned features.
- **Query the registry before pinning.** AGENTS.md *Dependency Versions* extends with per-source commands — `curl … crates.io/api/v1/crates/<name> … max_stable_version` for crates, `gh api /repos/<owner>/<repo>/releases` + `action.yml` runtime check for GitHub Actions — and the `(verified current YYYY-MM-DD)` annotation for long-lived references. Closes the loop on the two version-stale issue bodies (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`) the user had to correct in one session.

`Escalated?` lines updated in `ai-docs/learnings.md` for the three entries (`AGENTS.md`, `skill:task`, `doc-convention`, `agent:self-review`, `agent:review-findings`).

A follow-up commit (c1fb56d) fixes a Step 9 list numbering off-by-one introduced by the actionlint insertion — the trailing item was bumped 8→9 but the intermediate item missed the 7→8 bump. Caught by the /improve eval before merge; list now renders contiguous 1–9.

## Test plan

- [x] AGENTS.md *Build & Test* lists `actionlint` and the *Workflow files* paragraph reads cleanly
- [x] `/task` Step 9 numbering is contiguous (1–9; new actionlint sits at gate 6) and the gate-checklist row mentions actionlint
- [x] `ai-docs/doc-convention.md` *Feature flags rendering* section anchors as `#feature-flags-rendering-document_features` (the link from both agents)
- [x] Both review agents' §6 Documentation include the `document_features` bullet
- [x] AGENTS.md *Dependency Versions* registry-query commands are runnable as-is
- [x] Eval — reproduce the three original failure modes and confirm the new rules surface the right gate