### PR TITLE
chore(instructions): /ai-audit — sync stale Escalated? line + clean Phase 2 verdict

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -686,7 +686,7 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Why:** Two occurrences in the same session with the rule already written confirms the rule needs to live in AGENTS.md and the task skill, not just in learnings.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, skill:task
 
 ### 2026-05-07 — process — do not skip design/design-review for "simple" tasks
 


### PR DESCRIPTION
## Summary

Routine `/ai-audit` run. **Phase 1** (learnings-escalation-audit subagent) caught one drifted \`Escalated?\` line; **Phase 2** (10-section instruction audit) found nothing requiring action.

## Phase 1 — auto-fix

The second 2026-05-07 actionlint entry in \`ai-docs/learnings.md\` was still tagged \`Escalated? no\` despite PR #150 landing the rule in \`AGENTS.md\` (\`## Build & Test\` + Workflow files paragraph) and \`.claude/skills/task/SKILL.md\` (Step 9 verify). Re-tagged to \`AGENTS.md, skill:task\` to match.

| | |
|---|---|
| Entries audited | 56 |
| Drifted | 1 |
| Auto-fixed | 1 |
| User judgment needed | 0 |

## Phase 2 — clean verdict

10-section checklist, 0 findings:

| Section | Result |
|---|---|
| A. Cross-reference integrity | ✅ 42 links resolve; 1 false-positive (audit-prose example) |
| B. Conflicting / duplicated rules | ✅ AGENTS.md ↔ code-style.md follows index/canonical pattern |
| C. Dead references | ✅ \`skill:\`/\`agent:\` resolves; \`task ↔ task-issue\` mentions intentional |
| D. Skill frontmatter (×10) | ✅ all valid; \`disable-model-invocation\` correctly applied |
| E. Agent frontmatter (×6) | ✅ all valid; \`learnings-escalation-audit\` + \`self-improve\` pinned to opus |
| F. Hooks (\`.claude/settings.json\`) | ✅ JSON valid; events/matchers/exit-codes/quoting all correct |
| G. AGENTS.md propagation rule | ✅ Review sync group intact; PR #150 propagation verified |
| H. Doc-convention pointers | ✅ all anchors resolve incl. new \`#feature-flags-rendering-document_features\` |
| I. File size & structure | ✅ largest instruction file 277 lines, well under 500-line guideline |
| J. Allow-list consistency | ✅ skill-level \`allowed-tools\` correctly extend project allow |

**Findings:** 0 blocker / 0 major / 0 minor / 0 nit.

## Soft observations for future \`/improve\` (not audit fixes)

- actionlint rule could propagate to \`review-findings\`/\`self-review\` if a future omission slips past \`/task\` Step-9.
- registry-query rule could propagate to \`/interview\` if stale-version citations recur despite \`AGENTS.md ## Dependency Versions\` placement.

Both are defensible as-is: enforcement points are at the right layer.

## Test plan

- [x] \`jq . .claude/settings.json\` — JSON valid
- [x] All 16 skill+agent files parse with valid frontmatter
- [x] \`cargo build\` clean (no Rust changes)
- [x] Diff is one line in \`ai-docs/learnings.md\` (the \`Escalated?\` re-tag)