### PR TITLE
chore(agents): escalate benches/ no-test exemption and writing-a-learning is not escalation

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -47,7 +47,7 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 - Naming (see AGENTS.md "API Naming"): is every `_unchecked` fn `unsafe` with a `# Safety` doc section? Is the unsuffixed name the safe/ergonomic default? Any safe fn carrying `_unchecked` (or `_checked` used for non-safety variants) → finding.
 
 ### 3. Test coverage
-- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exception: files under `examples/` are runnable demos — no test block required)
+- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exceptions: files under `examples/` are runnable demos — no test block required; files under `benches/` declared with `[[bench]] harness = false` are criterion bench binaries — `criterion_main!` replaces the test runner, so `#[cfg(test)]` items would never run — no test block required.)
 - Tests cover edge cases and error paths, not just the happy path?
 - Any test that would pass even if the production code were deleted (cosmetic test)?
 - Integration tests for public-facing macro output?

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -44,7 +44,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 
 ### 3. Test coverage
 - Every non-trivial function / branch has a test?
-- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exception: files under `examples/` are runnable demos — no test block required)
+- Every file with ~50+ lines of non-trivial code has a `#[cfg(test)] mod tests` block? (Exceptions: files under `examples/` are runnable demos — no test block required; files under `benches/` declared with `[[bench]] harness = false` are criterion bench binaries — `criterion_main!` replaces the test runner, so `#[cfg(test)]` items would never run — no test block required.)
 - Tests verify invariants, not cosmetics?
   - Mental test: comment out the production fix → does the test fail? If not → cosmetic → **REJECT**
 - No `unwrap()` in tests without justification?

--- a/.claude/skills/ai-audit/SKILL.md
+++ b/.claude/skills/ai-audit/SKILL.md
@@ -127,7 +127,7 @@ Per the official docs:
 #### G. AGENTS.md "Propagation Rule" coherence
 - Every "sync group" listed in AGENTS.md still has all listed members present and cross-referenced.
 - Behaviors described in AGENTS.md and replicated in agent checklists agree (e.g., file-size hard/soft limits in `review-findings.md` match AGENTS.md).
-- Exemptions in AGENTS.md (e.g., `examples/` no-test exemption, trait-impl doc-convention exemption) appear in every enforcement file.
+- Exemptions in AGENTS.md (e.g., `examples/` and `benches/` no-test exemptions, trait-impl doc-convention exemption) appear in every enforcement file.
 
 #### H. Documentation conformance pointers
 - `ai-docs/doc-convention.md` is referenced by `review-findings.md` and `self-review.md`. Confirm the relative paths resolve.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,9 @@ Per source:
   - `git cherry-pick` — moves specific commits to another branch
   - Backup branch — `git checkout -b backup/...` before any destructive operation
 - Plan first. Tests before prod code (TDD). Lint changed files.
-- Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files. **Exception:** files under `examples/` are runnable demos, not library code — no `#[cfg(test)]` block required.
+- Any file with substantial logic (~50+ lines of non-trivial code) must have a `#[cfg(test)] mod tests` block. No exceptions for generator, codegen, or utility files. **Exceptions:**
+  - Files under `examples/` are runnable demos, not library code — no `#[cfg(test)]` block required.
+  - Files under `benches/` declared with `[[bench]] harness = false` (criterion bench binaries) — `criterion_main!` replaces the test runner, so `#[cfg(test)]` items would never be invoked. No `#[cfg(test)]` block required.
 - `.gitignore` (not `.arcignore`).
 - After generating or moving any markdown file with relative links to siblings (`../`, `../../`), trace at least one link by hand or with `realpath` before committing. From `ai-docs/deferred/file.md`: `..` reaches `ai-docs/`, `../..` reaches the repo root.
 - **PR review comment resolution:** After pushing fixes, resolve only the comments that were addressed by a code change. Comments where you posted an objection (explaining why no change was made) must **not** be resolved — leave them for the reviewer to accept or push back on. **Mechanics (GitHub stores review threads, not just comments — REST `/pulls/{N}/comments` does not expose `isResolved`; use GraphQL):**
@@ -174,6 +176,8 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 Categories: `code-style` | `process` | `architecture` | `testing` | `documentation` | `tooling` | `search` | `other`
 
 Run `/improve` when ≥3 unescalated entries accumulate.
+
+**Writing a learning entry is not authorisation to escalate.** Writing to `ai-docs/learnings.md` and editing project instruction files (`AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `.claude/settings.json`, `ai-docs/code-style.md`, `ai-docs/doc-convention.md`) are two distinct actions with different triggers. Writing a learning is automatic on any non-obvious correction; escalation happens only when the user runs `/improve` (or explicitly asks). After writing a learning entry, mark `Escalated? no` and stop. Do not edit instruction files in the same turn as a follow-up to the entry. The Propagation Rule fires only when you are *already* editing an instruction file for an independent reason — it does not authorise pre-emptive escalation triggered by a fresh learnings entry.
 
 ## Rust Test Conventions
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -94,7 +94,7 @@ If a body needs a long-lived stable reference (e.g., a doc that won't be revisit
 
 **How to apply:** After writing a learning entry, mark `Escalated? no` and stop. Do not touch AGENTS.md, skill files, or agent files as a follow-up to writing the entry. Wait for `/improve`.
 
-**Escalated?** no
+**Escalated?** AGENTS.md
 
 ### 2026-05-07 — code-style — criterion bench files (`harness = false`) are exempt from `#[cfg(test)]` requirement
 
@@ -106,7 +106,7 @@ If a body needs a long-lived stable reference (e.g., a doc that won't be revisit
 
 **How to apply:** When writing a criterion bench file (`harness = false`), do not add a `#[cfg(test)] mod tests` block. The AGENTS.md test-coverage rule applies to library and application source (`src/`), not to criterion bench binaries.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, agent:self-review, agent:review-findings
 
 ### 2026-05-07 — code-style — concrete trait-impl methods take `#[inline]`, not `// _Simple._` (PR #129 follow-up)
 
@@ -632,7 +632,7 @@ Concrete substitutions:
 
 **How to apply:** When the user says "add to learnings" (or "note this", "remember this"), write the entry and stop. If the learnings entry merits escalation to project instructions, mark `Escalated? no` and let the user trigger `/improve` when ready. Never escalate to agents/skills on the same turn as a learnings-only request.
 
-**Escalated?** no
+**Escalated?** AGENTS.md
 
 ### 2026-05-06 — process — `/next` skill cannot see "Blocked by:" in issue bodies; use a GitHub label instead
 
@@ -704,7 +704,7 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Rule:** Files under `benches/` are criterion bench binaries, not library code. Like `examples/`, they are runnable binaries and do not require a `#[cfg(test)] mod tests` block regardless of line count. Both existing workspace bench files (`quartzite-core/benches/signal_property.rs`, `quartzite-runtime/benches/object_tree.rs`) follow this pattern.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, agent:self-review, agent:review-findings
 
 ### 2026-05-07 — process — do not escalate learnings inline during `/task`; leave `Escalated? no` for `/improve`
 
@@ -712,4 +712,4 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Rule:** When writing to `ai-docs/learnings.md` during `/task` (or any non-`/improve` skill), always set `Escalated? no`. Do not touch `AGENTS.md`, `.claude/agents/**`, or `.claude/skills/**` on the basis of a new learnings entry. The Propagation Rule only triggers when you are *already* editing an instruction file for a separate reason — it does not authorize pre-emptive escalation. Run `/improve` when ≥3 unescalated entries accumulate.
 
-**Escalated?** no
+**Escalated?** AGENTS.md


### PR DESCRIPTION
## Summary
- /improve pass landing two recurring rules from `ai-docs/learnings.md`.
- **benches/ exemption** (3 occurrences across two PRs in one session): adds `benches/` files declared with `[[bench]] harness = false` (criterion binaries) to the AGENTS.md `#[cfg(test)] mod tests` exemption list, propagated to `.claude/agents/self-review.md`, `.claude/agents/review-findings.md`, and the `.claude/skills/ai-audit/SKILL.md` exemption-example list.
- **Writing a learning is not authorisation to escalate** (3 occurrences, 2026-05-06 + 2026-05-07 ×2): adds an explicit paragraph to AGENTS.md "## Corrections Log" right after the /improve trigger sentence — writing to `ai-docs/learnings.md` and editing project instruction files are two distinct actions; the Propagation Rule does not authorise pre-emptive escalation triggered by a fresh learnings entry.
- Bumps `Escalated?` on the five processed entries to reflect the new project-level rules.

## Test plan
- [x] `cargo build` clean (Cargo.lock unchanged — instruction-file-only edits).
- [x] Propagation grep across `.claude/agents/`, `.claude/skills/`, `AGENTS.md` — all four enforcement loci aligned (`AGENTS.md:103`, `self-review.md:47`, `review-findings.md:50`, `ai-audit/SKILL.md:130`).
- [ ] Eval A: hypothetical `quartzite-runtime/benches/object_tree.rs`-style file is no longer flagged for missing `#[cfg(test)]` by the agent checklists.
- [ ] Eval B: when user says "add to learnings: X", the agent reads AGENTS.md "## Corrections Log" and answers "no, writing is not escalation; mark `Escalated? no` and stop."