### PR TITLE
chore(agents): pin design and design-review to opus model

### DIFF
--- a/.claude/agents/design-review.md
+++ b/.claude/agents/design-review.md
@@ -2,6 +2,7 @@
 name: design-review
 description: "Critically reviews a Design Document against a quality checklist and issues GO / ITERATE / STOP. Invoked by /task in an Evaluator-Optimizer loop with the design agent until GO is reached or the iteration cap is hit."
 tools: Read, Grep, Glob, Bash
+model: opus
 ---
 
 # Design Review Agent

--- a/.claude/agents/design.md
+++ b/.claude/agents/design.md
@@ -1,6 +1,7 @@
 ---
 name: design
 description: "Produces a structured Design Document with decomposition for an implementation task. Investigates the codebase, evaluates alternatives, breaks work into atomic tasks. Invoked by /task between spec and implementation, or to revise the design after design-review feedback."
+model: opus
 ---
 
 # Design Agent


### PR DESCRIPTION
## Summary

Add \`model: opus\` to the frontmatter of both \`.claude/agents/design.md\` and \`.claude/agents/design-review.md\`. Two-line change.

## Rationale

Both agents make high-stakes meta-decisions that calcify into implementation downstream:

- **\`design\`** produces the Design Document that drives the implementation step. Mistakes (wrong API, wrong decomposition, missing risks) propagate as code that has to be reverted or rewritten — exactly the kind of thing better reasoning helps avoid.
- **\`design-review\`** gates the Design Document with **GO / ITERATE / STOP**. Quality of the verdict depends on careful judgment against the checklist, not pattern-matching against surface forms.

Both join the existing instruction-modifying agents already pinned to opus per the same reasoning (escalation in PR #128 / earlier session):

| Agent | Pinned to opus before this PR | After this PR |
|---|---|---|
| \`self-improve\` | ✅ | ✅ |
| \`learnings-escalation-audit\` | ✅ | ✅ |
| \`design\` | ❌ (inherited) | ✅ |
| \`design-review\` | ❌ (inherited) | ✅ |

Together these four are the agents whose output **sets the bar for everything downstream** — sonnet for execution, opus for the decisions that bound that execution.

## Out of scope

Other agents (\`self-review\`, \`review-findings\`) inherit the session model intentionally — they review code (already calcified work) rather than gate decisions, and the inherit-from-session pattern keeps the verification step predictable when the user runs it under different model contexts.

## Test plan

- [x] \`cargo build\` clean (no Rust changes; runs only to refresh \`Cargo.lock\` per AGENTS.md)
- [x] \`grep -rn 'model: opus' .claude/agents/\` shows all four agents (\`design\`, \`design-review\`, \`learnings-escalation-audit\`, \`self-improve\`)
- [x] No documentation references the opus-pinning as an explicit policy list — propagation is just the two agent files themselves
- [ ] Reviewer sanity-check: do you want \`self-review\` or \`review-findings\` also bumped, or is the inherit-from-session pattern correct for those?