### PR TITLE
docs(panic-index): add WindowedApplication::run panic entry and update learnings

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -790,11 +790,14 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 ### 2026-05-08 — process — update ai-docs/panic-index.md when introducing production panic sites
 
-**What happened:** Graphics-stack (#73) introduced three new crates (`quartzite-paint-api`, `quartzite-paint`, `quartzite-renderer`). The panic-index was not checked or updated during implementation or design. The new crates happen to have zero production panic sites, so no entry is needed this time — but the omission was only discovered after the fact.
+**What happened:** Graphics-stack (#73) introduced `WindowedApplication::run` which documents a platform-level panic (macOS main-thread requirement from `winit::run_app`) in its `# Panics` section. The panic-index was not checked or updated during implementation or at Step 9 (Verify). The omission was caught only after the PR merged.
 
-**Rule:** At Step 9 (Verify), grep production sources of all new/modified crates for `.expect(`, `.unwrap(`, and `panic!` outside `#[cfg(test)]` blocks. For each hit, add an entry to `ai-docs/panic-index.md` (location, invariant, why Result was not used, preferred fix). Stage and commit `panic-index.md` with the implementation commit if entries were added.
+**Rule:** At Step 9 (Verify), scan all new/modified production sources for two signals:
+1. `grep "# Panics" src/**/*.rs` — documented panic behaviour (primary signal; always present when a panic exists).
+2. `grep -n "\.expect\b\|\.unwrap\b\|panic!" src/**/*.rs` outside `#[cfg(test)]` — direct panic call sites.
+For each hit, add an entry to `ai-docs/panic-index.md` (location, trigger, invariant, why not `Result`, preferred fix). Stage and commit `panic-index.md` with the implementation commit.
 
-**Why not in design or as an AC:** The design phase cannot enumerate `.expect()` sites that don't exist yet, and adding "no panics" as a generic AC would be vacuous boilerplate. The right checkpoint is Step 9 (Verify), after the code exists and can actually be grepped.
+**Why not in design or as an AC:** The design phase cannot enumerate panic sites that don't exist yet. `# Panics` sections are the canonical indicator — they are written at implementation time, so the check belongs at Step 9 after the code exists.
 
 **Escalated?** no
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -788,6 +788,16 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Escalated?** no
 
+### 2026-05-08 — process — update ai-docs/panic-index.md when introducing production panic sites
+
+**What happened:** Graphics-stack (#73) introduced three new crates (`quartzite-paint-api`, `quartzite-paint`, `quartzite-renderer`). The panic-index was not checked or updated during implementation or design. The new crates happen to have zero production panic sites, so no entry is needed this time — but the omission was only discovered after the fact.
+
+**Rule:** At Step 9 (Verify), grep production sources of all new/modified crates for `.expect(`, `.unwrap(`, and `panic!` outside `#[cfg(test)]` blocks. For each hit, add an entry to `ai-docs/panic-index.md` (location, invariant, why Result was not used, preferred fix). Stage and commit `panic-index.md` with the implementation commit if entries were added.
+
+**Why not in design or as an AC:** The design phase cannot enumerate `.expect()` sites that don't exist yet, and adding "no panics" as a generic AC would be vacuous boilerplate. The right checkpoint is Step 9 (Verify), after the code exists and can actually be grepped.
+
+**Escalated?** no
+
 ### 2026-05-08 — process — regenerate ROADMAP.md after every INDEX.md change
 
 **What happened:** Updated `ai-docs/plans/INDEX.md` (marking graphics-stack ✅, unblocking widgets/paint-style) without re-running `scripts/gen-roadmap.sh`. The ROADMAP sync CI gate re-ran the generator, found a diff, and failed on PR #159.

--- a/ai-docs/panic-index.md
+++ b/ai-docs/panic-index.md
@@ -9,7 +9,15 @@ was not used at the time, and the preferred fix when this is eventually hardened
 
 ## Active entries
 
-_None._
+### `quartzite-renderer` — `WindowedApplication::run`
+
+| Field | Value |
+|---|---|
+| **Location** | `quartzite-renderer/src/application.rs` — `WindowedApplication::run` |
+| **Trigger** | Called from a non-main thread on platforms that require it (notably macOS). Enforced internally by `winit::event_loop::EventLoop::run_app`. |
+| **Invariant** | winit's event loop must own the main thread on some platforms. |
+| **Why not `Result`** | `run_app` panics at the platform level; the panic is not catchable or convertible to an error without a thread-spawn wrapper. Returning a `Result` for this case would require spawning a dedicated main thread, which is a larger architectural decision. |
+| **Preferred fix** | Provide a `run_on_main_thread` helper (or document `#[cfg(target_os = "macos")]` guard) once multi-window / multi-platform support is added. Tracked implicitly under #53 (multi-window). |
 
 ---
 


### PR DESCRIPTION
## Summary

- **`ai-docs/panic-index.md`** — adds entry for `WindowedApplication::run`: platform panic (macOS main-thread requirement) enforced by `winit::run_app`; not convertible to `Result` without a thread-spawn wrapper; tracked for hardening under #53.
- **`ai-docs/learnings.md`** — updates the Step 9 panic-index rule: primary signal is `grep "# Panics"` in production sources (not just `.expect`/`.unwrap`/`panic!` call sites), since documented `# Panics` sections are the canonical indicator of panic behaviour.

## Tracking

Follow-up to #159 (graphics-stack).