### PR TITLE
chore(rules): escalate three /improve patterns into instruction files

### DIFF
--- a/.claude/agents/review-findings.md
+++ b/.claude/agents/review-findings.md
@@ -29,6 +29,7 @@ Every suspicion — investigate via Read/grep, don't guess. Don't invent problem
 
 ### 1. Safety and correctness
 - `unsafe` blocks: each justified with a comment explaining the invariant?
+- **Panic-index sync.** For every public fn / method with a `# Panics` doc section, **and** every production `.unwrap()` / `.expect(…)` / `panic!` outside `#[cfg(test)]`, verify there is a corresponding entry in `ai-docs/panic-index.md` (location, trigger, invariant, why not `Result`, preferred fix). Production panic site missing from the index → `major`. The `# Panics` doc-section signal is the primary trigger; the grep below is the secondary catch-net.
 - **`unwrap()` / `expect()` / `panic!()` audit:** grep changed files for these outside `#[cfg(test)]` modules. A reason string does NOT make a panicking call acceptable — ask "is there a non-panicking form?" Mandatory substitutions:
   - `Mutex::lock().expect(...)` → `.lock().unwrap_or_else(|e| e.into_inner())`
   - `Condvar::wait*().expect(...)` → `.wait*(...).unwrap_or_else(|e| e.into_inner())`

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -52,6 +52,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 
 ### 4. Safety and correctness
 - `unsafe` blocks: each one justified with a comment?
+- **Panic-index sync.** For every new production `.unwrap()` / `.expect(…)` / `panic!` hit outside `#[cfg(test)]`, **and** for every new public fn / method that documents a `# Panics` doc section, verify `ai-docs/panic-index.md` was updated in this diff with a row covering the new panic site (location, trigger, invariant, why not `Result`, preferred fix). New production panic site without a corresponding panic-index entry → REJECT (`major`). The doc-section signal (`# Panics`) is the primary trigger; the grep below is the secondary catch-net.
 - **`unwrap()` / `expect()` / `panic!()` audit (run this grep first):**
   ```bash
   grep -n '\.unwrap()\|\.expect(\|panic!' <changed-files> | grep -v '#\[cfg(test)\]' | grep -v '^\s*//'

--- a/.claude/skills/bugfix/SKILL.md
+++ b/.claude/skills/bugfix/SKILL.md
@@ -134,7 +134,7 @@ Now open Edit.
 
 1. Run the failing test from Step 3: `cargo test test_name` — must turn green
 2. Run the full suite: `cargo test` — confirm nothing else broke
-3. Run `cargo clippy -- -D warnings` for changed files
+3. Run `cargo clippy --workspace -- -D warnings` for changed files
 4. Run `cargo fmt`
 5. **Delete the trace artifact:** `git rm ai-docs/bugfix/trace-*.md 2>/dev/null || rm -f ai-docs/bugfix/trace-*.md` (handles both tracked and untracked traces)
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -58,7 +58,7 @@ For each `⬜ Open` finding in the `## AC Status` table (top-to-bottom):
 After every 3 fixes (or when all findings in a subtask are resolved):
 1. `cargo build` — must compile
 2. `cargo test` — all green
-3. `cargo clippy -- -D warnings` — clean
+3. `cargo clippy --workspace -- -D warnings` — clean
 4. `cargo fmt`
 5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — clean
 6. Update `## Files touched` and mark subtask `[x]` in progress file
@@ -69,7 +69,7 @@ After every 3 fixes (or when all findings in a subtask are resolved):
 
 1. `cargo build` — PASS
 2. `cargo test` — all green
-3. `cargo clippy -- -D warnings` — clean
+3. `cargo clippy --workspace -- -D warnings` — clean
 4. `cargo fmt -- --check` — clean
 5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — clean (matches CI)
 6. **Doc convention conformance.** For every changed `pub` item, verify it conforms to [`ai-docs/doc-convention.md`](../../../ai-docs/doc-convention.md) (summary tense, `# Parameters` on fns with ≥1 non-receiver arg, strict section order, `# Errors` / `# Panics` / `# Safety` where applicable). Methods inside `impl Trait for Type {}` blocks are exempt; the trait *definition* is not. Mechanical heading scan on changed files: `rg '^\s*///\s*#\s*(Parameters|Returns|Type parameters|Lifetimes|Errors|Panics|Safety|Examples|See also)\b' <file>`.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -151,7 +151,7 @@ finding (Step 11) requires a design change rather than a code fix:
 - After each subtask:
   1. `cargo build` — must compile
   2. `cargo test test_name` — if subtask adds tests
-  3. `cargo fmt`; `cargo clippy -- -D warnings`
+  3. `cargo fmt`; `cargo clippy --workspace -- -D warnings`
   4. Update `.progress.md`
   5. If N=3 of M≥5 → handoff via Agent (see `/context-reset`)
 - Unknown API → read sources → grep codebase → ask user. Don't guess.
@@ -163,11 +163,15 @@ finding (Step 11) requires a design change rather than a code fix:
 1. `cargo build` — compiles clean
 2. `cargo test` — all green
 3. `cargo fmt -- --check` — no formatting drift
-4. `cargo clippy -- -D warnings` — clean
+4. `cargo clippy --workspace -- -D warnings` — clean (`--workspace` is required so leaf crates outside the default dep tree, e.g. `quartzite-renderer`, are linted; the bare form misses them)
 5. `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace` — no doc errors or warnings (matches CI)
 6. **actionlint gate** — if this task created or modified any `.github/workflows/*.yml` file, run `actionlint <file>` (or pass every changed workflow file in one invocation) and require a clean pass. Skip the gate only when no workflow file was touched. See AGENTS.md *Build & Test → Workflow files*.
-7. For each AC — confirm covered by test or manual verification
-8. Show summary table:
+7. **Panic-index sync.** Scan new/modified production sources for documented or direct panic sites and update `ai-docs/panic-index.md` if any are introduced:
+   - `rg '^\s*///\s*#\s*Panics' <changed-files>` — documented panic behaviour (primary signal; always present when a panic exists)
+   - `rg '\.expect\(|\.unwrap\(|panic!' <changed-files>` filtered to lines outside `#[cfg(test)]` modules — direct panic call sites
+   For each new hit, add an entry to `ai-docs/panic-index.md` (location, trigger, invariant, why not `Result`, preferred fix). Stage `panic-index.md` with the implementation commit. Skip when this task added no new production panics.
+8. For each AC — confirm covered by test or manual verification
+9. Show summary table:
 
 ```
 | # | Criterion | Test / Verification | Status |
@@ -175,7 +179,7 @@ finding (Step 11) requires a design change rather than a code fix:
 | AC1 | ... | tests::name | ✅ PASS |
 ```
 
-9. On ALL PASS → proceed to Step 9.5
+10. On ALL PASS → proceed to Step 9.5
 
 ### Step 9.5: Update documentation
 
@@ -223,7 +227,7 @@ For each `⬜ Open` finding in the latest `## Self-Review (Round N)` section of 
 After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
 1. `cargo build` — must compile
 2. `cargo test` — all green
-3. `cargo clippy -- -D warnings` — clean
+3. `cargo clippy --workspace -- -D warnings` — clean
 4. Update `.progress.md`
 5. **PR body sync (unconditional).** Run `gh pr view <N> --json title,body` and re-read the body. Decide *after* reading whether `gh pr edit` is needed: edit if the body contradicts the new commits (renames, scope drift, AC status flips, cited counts that drifted), skip if it's still accurate. Never skip the read. Applies to every push during this step — not just review-fix commits that change public API. See AGENTS.md *Workflow*.
 6. **Resolve fixed review threads (unconditional).** For every PR review comment addressed by a `✅ Fixed` finding in this round, follow the GraphQL recipe in AGENTS.md *Workflow* → "PR review comment resolution" verbatim — reply via REST, query unresolved thread IDs via `reviewThreads`, then `resolveReviewThread` each fixed thread and verify `isResolved: true`. Threads behind `⚠️ Objected` findings stay open. Skipping this sub-step has caused the same correction twice (`ai-docs/learnings.md` entries #33 and #44) — the recipe is already in AGENTS.md; this sub-step exists so it is actually consulted.
@@ -237,24 +241,32 @@ After all findings are resolved (`✅ Fixed` or `⚠️ Objected`):
    - Change the plan row status to `✅ implemented (N tests)`
    - Move spec/design files to `ai-docs/plans/done/`
    - Update dependency tree and **Suggested next steps**
-4. `cargo build` — ensures `Cargo.lock` is refreshed and included if changed.
-5. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, `ai-docs/learnings.md` (if modified), updated `INDEX.md`, and spec/design now in `done/`.
-6. Commit:
+4. **Regenerate dependent artefacts.** If any source for an auto-generated file
+   was touched in this commit, regenerate now and stage the artefact in the same
+   commit so the CI sync-gate runs green on first push:
+   - `ai-docs/plans/INDEX.md` or `ai-docs/plans/done/**` changed → run
+     `bash scripts/gen-roadmap.sh` and stage `ROADMAP.md`.
+   - When new generators land, append the source→artefact relationship to
+     `ai-docs/context.md` (the auto-derived-artefact registry) and add a bullet
+     here.
+5. `cargo build` — ensures `Cargo.lock` is refreshed and included if changed.
+6. Stage all changed files: implementation files from `## Files touched`, `context.md`, `README.md`, `ai-docs/learnings.md` (if modified), updated `INDEX.md`, regenerated artefacts (e.g. `ROADMAP.md`), and spec/design now in `done/`.
+7. Commit:
    ```
    feat(<crate>): <short imperative description>
 
    <1-3 lines: what changed and why; key ACs covered>
    N new tests; all M tests green.
    ```
-7. `git push -u origin <branch>`
-8. `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"` — body must include:
+8. `git push -u origin <branch>`
+9. `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"` — body must include:
    - **Summary** (bullet list of what changed)
    - **Tracking** — reference the issue captured in the spec's `**Tracked in:**` field:
      - PR fully resolves the issue → `Closes #<N>` (auto-closes on merge)
      - PR partially addresses or is related (multi-PR effort, shared umbrella issue) → `Refs #<N>` (no `Closes`)
      - Spec was written with `Tracked in: none` → omit this section
    - **Test plan** (checklist: one line per AC, plus clippy/build)
-9. Post the PR URL to the user.
+10. Post the PR URL to the user.
 
 After the PR is created, the unconditional PR-body re-read rule (AGENTS.md *Workflow*) applies to any subsequent push on this branch: `gh pr view <N>` first, then `gh pr edit` only if the body now contradicts the diff.
 
@@ -269,9 +281,9 @@ After the PR is created, the unconditional PR-body re-read rule (AGENTS.md *Work
 | Step 8 | Design doc with GO? Test Design section present? |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
-| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy -- -D warnings` clean? `cargo doc --no-deps --workspace` clean? `actionlint` clean on every changed `.github/workflows/*.yml` (skip if none changed)? All ACs covered? |
+| Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy --workspace -- -D warnings` clean (note: `--workspace`, not bare)? `cargo doc --no-deps --workspace` clean? `actionlint` clean on every changed `.github/workflows/*.yml` (skip if none changed)? Any new `# Panics` doc section / `.unwrap()` / `.expect()` / `panic!` outside `#[cfg(test)]` → `ai-docs/panic-index.md` updated and staged (skip when no new production panics)? All ACs covered? |
 | Step 9.5 | context.md + README.md updated? (spec/design NOT moved yet — happens at Step 12) |
 | Step 10 | Self-review APPROVE before deleting progress file? |
 | Step 11 | `major`/`blocker` objections confirmed by user? Design change → Design Amendment triggered? `gh pr view <N>` re-read after every push (unconditional) — `gh pr edit` only if body contradicts new commits? |
 | Design Amendment | User approved the amendment? Design review returned GO before resuming? |
-| Step 12 | Branch ≠ master? INDEX.md ✅? spec/design moved to done/? `Cargo.lock` refreshed? PR body references the tracking issue (`Closes #N` or `Refs #N`)? PR created and URL posted? |
+| Step 12 | Branch ≠ master? INDEX.md ✅? spec/design moved to done/? Auto-derived artefacts regenerated and staged (e.g. `ROADMAP.md` from `INDEX.md`)? `Cargo.lock` refreshed? PR body references the tracking issue (`Closes #N` or `Refs #N`)? PR created and URL posted? |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ cargo build
 cargo test                            # all tests
 cargo test test_name                  # filter by substring
 cargo test -- --nocapture             # show stdout
-cargo clippy -- -D warnings           # lint (strict)
+cargo clippy --workspace -- -D warnings   # lint (strict; --workspace catches leaf crates outside the default dep tree)
 cargo fmt                             # fix formatting
 cargo fmt -- --check                  # check only
 RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace   # doc gate (matches CI)

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -54,9 +54,7 @@ The workspace may grow more such relationships (e.g., a future tool that generat
 
 **How to apply:** in the `/task` Step 12 checklist (or its skill prose), add a *Regenerate dependent artefacts* sub-step that lists the known auto-generation triggers. Today: "if `ai-docs/plans/INDEX.md` or `ai-docs/plans/done/**` changed in this commit, run `./scripts/gen-roadmap.sh` and stage `ROADMAP.md`". When new generators land, append to the list.
 
-**Escalated?** no
-
-> Candidate for escalation to `.claude/skills/task/SKILL.md` Step 12 — adding a "Regenerate dependent artefacts" bullet between "update INDEX.md" and "stage all changed files". `/improve` should consider when ≥ 2 occurrences accumulate; the sync-gate caught this one, so the cost was bounded.
+**Escalated?** skill:task
 
 ### 2026-05-07 — documentation — `document_features::document_features!()` invocation must sit inline within the `//!` crate doc, immediately after a `## Feature flags` heading; main vs diagnostic features must be sectioned in Cargo.toml
 
@@ -786,7 +784,7 @@ When a GraphQL mutation fails with NOT_FOUND, do not silently move on — invest
 
 **Rule:** Always run `cargo clippy --workspace -- -D warnings` (not just `cargo clippy -- -D warnings`) to catch lints in leaf crates. The default-dep-tree clippy run is a subset, not a full check.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, skill:task, skill:bugfix, skill:code-review
 
 ### 2026-05-08 — process — update ai-docs/panic-index.md when introducing production panic sites
 
@@ -799,7 +797,7 @@ For each hit, add an entry to `ai-docs/panic-index.md` (location, trigger, invar
 
 **Why not in design or as an AC:** The design phase cannot enumerate panic sites that don't exist yet. `# Panics` sections are the canonical indicator — they are written at implementation time, so the check belongs at Step 9 after the code exists.
 
-**Escalated?** no
+**Escalated?** skill:task, agent:self-review, agent:review-findings
 
 ### 2026-05-08 — process — regenerate ROADMAP.md after every INDEX.md change
 
@@ -807,7 +805,7 @@ For each hit, add an entry to `ai-docs/panic-index.md` (location, trigger, invar
 
 **Rule:** Whenever `ai-docs/plans/INDEX.md` is modified, run `bash scripts/gen-roadmap.sh` and stage `ROADMAP.md` in the same commit. The CI gate enforces this — ROADMAP.md must always be in sync with INDEX.md at commit time.
 
-**Escalated?** no
+**Escalated?** skill:task
 
 ### 2026-05-07 — process — do not escalate learnings inline during `/task`; leave `Escalated? no` for `/improve`
 


### PR DESCRIPTION
## Summary

`/improve` round of 2026-05-08. Three patterns escalated from `ai-docs/learnings.md` into instruction files; six single-occurrence learnings deliberately left for recurrence.

**Pattern A — Regenerate auto-derived artefacts (2 occurrences: L57, L810).** `/task` Step 12 gains a *Regenerate dependent artefacts* sub-step (between "Finalise INDEX.md" and "cargo build"); the only relationship today is `INDEX.md` → `ROADMAP.md` via `scripts/gen-roadmap.sh`, but the slot is reusable for future generators. Step 12 gate row updated to match.

**Pattern D — `cargo clippy --workspace` (1 occurrence: L789).** Bare `cargo clippy -- -D warnings` was missing leaf crates outside the default dep tree (`quartzite-renderer`). Upgraded the canonical command across:

- `AGENTS.md` § Build & Test
- `.claude/skills/task/SKILL.md` (Step 8 per-subtask, Step 9 verify, Step 11 fix-loop, Step 9 gate row)
- `.claude/skills/bugfix/SKILL.md` Step 6
- `.claude/skills/code-review/SKILL.md` (Step 3 mid-loop verify + Step 4 final verify)

Borderline single-occurrence call: the fix is a one-token addition that aligns instructions with what CI actually does.

**Pattern E — Panic-index sync (1 occurrence: L802).** `ai-docs/panic-index.md` exists but was never referenced by any instruction file — implementers had no signal to update it. `/task` Step 9 gains a panic-index sync sub-step (skipped when no new production panics); `self-review` and `review-findings` agents both gain the matching check (REJECT / `major` on a new panic site without a panic-index row).

`Escalated?` flipped on L57, L789, L802, L810 to the routed targets. Six other unescalated learnings remain `no` per the don't-rule-on-one-offs anti-pattern.

## Verification

- \`cargo build\` clean
- \`cargo clippy --workspace -- -D warnings\` clean (the new mandated form works as documented; same form catches lints in `quartzite-renderer` that the bare form misses)
- No code changes — instruction-file-only PR

## Test plan

- [x] AGENTS.md Build & Test command list shows `cargo clippy --workspace -- -D warnings`
- [x] /task Step 9 sub-step 7 (panic-index sync) present, with skip-when-empty escape hatch
- [x] /task Step 12 sub-step 4 (regenerate dependent artefacts) present, with ROADMAP example
- [x] /task Step 9 + Step 12 gate-checklist rows updated
- [x] self-review §4 + review-findings §1 panic-index check propagated
- [x] /bugfix + /code-review clippy lines upgraded (Propagation Rule)
- [x] L57, L789, L802, L810 `Escalated?` fields routed; six single-occurrence learnings stay `no`
- [x] \`cargo build\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean