### PR TITLE
fix(renderer): inline WindowedApplication::new() body; remove spurious inner()

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -807,6 +807,14 @@ For each hit, add an entry to `ai-docs/panic-index.md` (location, trigger, invar
 
 **Escalated?** skill:task
 
+### 2026-05-08 — code-style — generic-fn split (`fn inner`) requires a conversion-style generic param; don't apply it to parameter-less fns
+
+**What happened:** `WindowedApplication::new()` in `quartzite-renderer/src/application.rs` wrapped its entire body in a nested `fn inner()` and called it, despite having no parameters at all. The generic-fn split pattern (AGENTS.md "Generic-fn split for binary size") exists solely to avoid monomorphization bloat from `impl Into<T>` / `impl AsRef<T>` / `impl ToString` generics. With no generic param, the indirection is dead weight — the body lands in one copy regardless, and the extra wrapper just adds noise.
+
+**Rule:** Only apply the nested `fn inner()` split when the outer function has a conversion-style generic parameter (`impl Into<T>`, `impl AsRef<T>`, `impl ToString`) **and** the body is >3 lines. For non-generic fns (no params, concrete types only), write the body directly in the outer fn. Additionally, re-evaluate `#[inline]` after inlining: if the body now has >1 non-simple call, the fn no longer qualifies and `#[inline]` must be removed.
+
+**Escalated?** no
+
 ### 2026-05-07 — process — do not escalate learnings inline during `/task`; leave `Escalated? no` for `/improve`
 
 **What happened:** During `/task 143`, I wrote a learnings entry and immediately escalated it by editing `AGENTS.md`, `.claude/agents/self-review.md`, and `.claude/agents/review-findings.md` in the same commit. The user corrected: escalation is `/improve`'s job.

--- a/quartzite-renderer/src/application.rs
+++ b/quartzite-renderer/src/application.rs
@@ -31,17 +31,13 @@ impl WindowedApplication {
     ///
     /// Returns [`RendererError::EventLoop`] if the winit event loop cannot be
     /// created (e.g. no display server available).
-    #[inline]
     pub fn new() -> Result<Self, RendererError> {
-        fn inner() -> Result<WindowedApplication, RendererError> {
-            let app = Application::new()?;
-            let event_loop = EventLoop::new()?;
-            Ok(WindowedApplication {
-                _app: app,
-                event_loop,
-            })
-        }
-        inner()
+        let app = Application::new()?;
+        let event_loop = EventLoop::new()?;
+        Ok(Self {
+            _app: app,
+            event_loop,
+        })
     }
 
     /// Runs the winit event loop, handing control to `handler`.


### PR DESCRIPTION
## Summary

- Removes the nested `fn inner()` from `WindowedApplication::new()` — the generic-fn split pattern is only valid for fns with conversion-style generic params (`impl Into<T>` / `impl AsRef<T>` / `impl ToString`); `new()` has none
- Inlines the body directly and removes `#[inline]` (two non-simple calls disqualify it)
- Adds a learnings entry documenting the rule

## Test plan

- [x] All existing tests pass (`cargo test -p quartzite-renderer`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt -- --check` clean