### PR TITLE
docs(agent-writing-style): Phase 0 dual-model style spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ Interpret user phrasing literally and conservatively. When uncertain — ask, do
 |------|---------|
 | `ai-docs/context.md` | Project context — read on demand |
 | `ai-docs/code-style.md` | Workspace code-style reference — read on demand |
+| `ai-docs/agent-writing-style.md` | Style for binary rules in instruction files (dual-model readability) — read on demand and when editing any of `AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `ai-docs/code-style.md`, `ai-docs/doc-convention.md` |
 | `ai-docs/plans/INDEX.md` | Plan index — statuses and dependency order |
 | `ai-docs/plans/*.spec.md` | Active task spec + acceptance criteria |
 | `ai-docs/plans/*.design.md` | Active task design documents |

--- a/ai-docs/agent-writing-style.md
+++ b/ai-docs/agent-writing-style.md
@@ -1,0 +1,156 @@
+# Agent Writing Style
+
+**Audience:** anyone editing instruction files (`AGENTS.md`,
+`.claude/skills/**`, `.claude/agents/**`, `ai-docs/code-style.md`,
+`ai-docs/doc-convention.md`).
+
+**Goal:** write binary rules so that both Opus 4.7 and Sonnet 4.6 reading the
+same paragraph land on the same interpretation.
+
+> **AXIOM — Apply this style only to binary rules.**
+> Visual fail-loud emphasis is a tool for unambiguous rules where misreads
+> have caused real failures. Applying it to ordinary prose devalues every
+> emphasis token in the file — readers tune out the YELLED RULES because
+> they're everywhere.
+>
+> | If a paragraph is... | Style |
+> |---|---|
+> | A binary rule (do X / never do Y / exactly one of A or B) | Fail-loud (patterns below) |
+> | A documented misread spot (`Escalated?` target in `learnings.md`) | Fail-loud |
+> | A multi-axis decision tree | Fail-loud + action table |
+> | Rationale, context, examples, links | Ordinary prose |
+
+## Patterns
+
+### 1. AXIOM blockquote (top-of-section)
+
+For sections governed by one binary rule:
+
+> **AXIOM — \<name\>.**
+> \<single-sentence rule.\> \<optional why-it-matters sentence.\>
+>
+> | If you see... | Action |
+> |---|---|
+> | \<condition\> | \<action\> |
+
+Place immediately after the `## heading`, before any nuanced rules. The
+action table is what makes the rule mechanical.
+
+Example: `ai-docs/code-style.md § #[inline] and _Simple._`.
+
+### 2. Fail-loud verbs (bold uppercase)
+
+| Use... | For |
+|---|---|
+| **NEVER** / **MUST NOT** / **FORBIDDEN** | Prohibitions |
+| **ALWAYS** / **MUST** | Required actions |
+| **STOP** | Halt-the-workflow signals |
+| **REJECT** | Code-review verdicts |
+| **REMOVE** / **REPLACE** / **DELETE** | Corrective actions |
+
+At most one bold-uppercase verb per paragraph. If a paragraph carries three,
+it is no longer a rule — it is noise.
+
+### 3. Action tables ("if you see X → do Y")
+
+For mechanical decisions:
+
+| If you see... | Action |
+|---|---|
+| `#[inline]` AND `_Simple._` on the same fn | **REMOVE** `_Simple._`, keep `#[inline]` |
+
+Left column lists conditions an editor or reviewer would recognise (visible
+markers, file paths, error messages). Right column lists the action verbatim.
+Do not bury the action in prose around the table.
+
+### 4. Explicit file lists, never globs
+
+In fail-loud blocks, enumerate each path:
+
+> When writing to `ai-docs/learnings.md`, you **MUST NOT** also edit any of
+> these files in the same turn:
+>
+> - `AGENTS.md`
+> - `CLAUDE.md`
+> - `.claude/skills/**` (any file under this directory)
+> - `.claude/agents/**` (any file under this directory)
+> - `.claude/settings.json`
+> - `ai-docs/code-style.md`
+> - `ai-docs/doc-convention.md`
+
+A glob inside one bullet (with parenthetical "any file under this directory")
+is fine. A glob *as the entire list* is not — readers expand globs
+differently.
+
+### 5. Numbered enumeration of triggers
+
+For "this fires when..." or "this is authorised by...":
+
+> Project-level escalation happens only when:
+>
+> 1. The user runs `/improve`, OR
+> 2. The user explicitly asks ("escalate this", "update AGENTS.md", etc.).
+
+State the OR/AND connector at the end of each item, consistently. Consistent
+placement defeats nesting ambiguity.
+
+### 6. Concrete do/not examples
+
+For non-trivial rules, show both shapes:
+
+> **Do this:**
+> ```rust
+> let g = mutex.lock().unwrap_or_else(|e| e.into_inner());
+> ```
+>
+> **NOT this:**
+> ```rust
+> let g = mutex.lock().expect("mutex poisoned");  // .expect() panics on poison
+> ```
+
+Examples remove ambiguity faster than prose.
+
+## Writing checklist
+
+Before submitting a rule paragraph, check:
+
+- [ ] Single declarative sentence? (Three nested clauses → split.)
+- [ ] Verb at the start? ("Append to..." beats "It is the case that...")
+- [ ] Every condition explicit? (No "usually" / "the obvious case".)
+- [ ] File paths spelled out? (Not "the usual file".)
+- [ ] Says what to DO, not only what NOT to do?
+- [ ] Action verb present? (Not just "this is forbidden".)
+
+## Anti-patterns
+
+| Anti-pattern | Why bad | Fix |
+|---|---|---|
+| Every paragraph in caps | Emphasis devalued | Reserve fail-loud for binary rules |
+| AXIOM blockquote without action table | States rule but not application | Always include "if X → do Y" table |
+| Implicit conditions ("usually") | Models infer differently | State explicitly |
+| Globs as the entire fail-loud list | Reader expansion varies | Enumerate files |
+| Rule + rationale + example + edge case in one paragraph | Rule lost in prose | Split: rule (fail-loud), rationale (prose), example (do/not), edge case (sub-bullet) |
+| Negative-only rules ("don't X") | Reader doesn't know correct action | Pair with "do Y instead" |
+
+## Citation in PRs
+
+When a PR adds or modifies a fail-loud section, cite this doc in the body:
+
+> Per `ai-docs/agent-writing-style.md` § Pattern 1, this PR adds an AXIOM
+> blockquote to `<file> § <section>`.
+
+Citing this doc grounds the stylistic choice in the agreed convention rather
+than per-PR taste.
+
+## Out of scope
+
+This file does not govern:
+
+- Files for Opus-only readers: agents with `model: opus` frontmatter
+  (`design`, `design-review`, `learnings-escalation-audit`, `self-improve`)
+  and Opus-mode skills (`/ai-audit`, `/improve`)
+- Rust source code documentation (covered by `ai-docs/doc-convention.md`)
+- Project context (covered by `ai-docs/context.md`)
+
+For those readers, AXIOM/fail-loud styling is optional — the reader has the
+context to disambiguate without it.

--- a/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
+++ b/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
@@ -1,9 +1,9 @@
 # Instruction-File Rewrite Plan (v4)
 
-**Status:** in progress (Phase 0 lands in PR #166)
+**Status:** in progress (Phase 0 in PR #166; Phase 1 tracked in issues #167–#171)
 **Started:** 2026-05-08
 **Style reference:** [`ai-docs/agent-writing-style.md`](../agent-writing-style.md)
-**Tracked in:** none (multi-PR workflow plan, no single GitHub issue)
+**Tracked in:** none (this meta-plan has no single GitHub issue; each Phase 1 file has its own — see table below)
 
 ## Goal
 
@@ -69,17 +69,41 @@ PRs cite this doc as the standard.
 
 ---
 
-## Phase 1 — Rewrite cycle (5 PRs, sequential)
+## Phase 1 — Rewrite cycle (5 PRs, independent)
 
-### File order
+Each Phase 1 file has its own GitHub tracking issue and proceeds independently
+of the other four — work can be parallelised across sessions without
+inter-file sequencing. The numbered "order" below is a **recommended priority**
+(highest leverage first), not a sequencing requirement.
 
-| # | File | Why this order |
-|---|---|---|
-| 1 | `AGENTS.md` | Central reference; everything else cites it |
-| 2 | `ai-docs/code-style.md` | Most rule-dense; multiple decision trees |
-| 3 | `ai-docs/doc-convention.md` | Similar density to code-style |
-| 4 | `.claude/agents/self-review.md` | Reads (1) and (2) — verifies they're effective |
-| 5 | `.claude/agents/review-findings.md` | Same shape as (4) |
+### File order — recommended priority
+
+| # | File | Issue | Recommended priority rationale |
+|---|---|---|---|
+| 1 | `AGENTS.md` | [#167](https://github.com/maratik123/quartzite/issues/167) | Central reference; everything else cites it |
+| 2 | `ai-docs/code-style.md` | [#168](https://github.com/maratik123/quartzite/issues/168) | Most rule-dense; multiple decision trees; section-share-aware override expected |
+| 3 | `ai-docs/doc-convention.md` | [#169](https://github.com/maratik123/quartzite/issues/169) | Similar density to code-style |
+| 4 | `.claude/agents/self-review.md` | [#170](https://github.com/maratik123/quartzite/issues/170) | Reads (1)–(3) — verifies upstream rewrites are effective at agent-checklist depth |
+| 5 | `.claude/agents/review-findings.md` | [#171](https://github.com/maratik123/quartzite/issues/171) | Mirrors (4); often updated in lockstep per Propagation Rule |
+
+All five issues are labeled `blocked` until PR #166 (this Phase 0 PR) merges,
+since the rewrite cites `ai-docs/agent-writing-style.md` (the style spec) and
+this plan doc.
+
+### Cross-reference link sanity (per file)
+
+When a Phase 1 rewrite changes a section anchor, sibling files that link to
+the changed anchor break. **Each per-file workflow includes a cross-reference
+audit step**:
+
+- Pre-rewrite: `grep -rn "<file>#" ai-docs/ .claude/skills/ .claude/agents/`
+  to enumerate every link into this file's anchors
+- Post-rewrite: re-grep, verify every old anchor still resolves OR update the
+  linker file in the same PR (Propagation Rule applies)
+
+If two files cross-link heavily, the rewrite PRs may opt to bundle a small
+follow-up commit updating sibling anchors. That bundling is per-PR judgment;
+no plan-level rule forces it.
 
 ### Per-file workflow
 
@@ -125,8 +149,10 @@ PRs cite this doc as the standard.
     with diagnosis + proposed revision.
 16. Semantic-preservation self-review (every old rule still in new file)
 17. cargo build (sanity)
-18. Stage explicit files, commit, push -u, gh pr create
-19. Wait for user merge before next file
+18. Stage explicit files, commit, push -u, gh pr create — link the file's
+    GitHub issue (`Closes #N`)
+19. (No inter-file sequencing — other Phase 1 files can be picked up in
+    parallel by the same or different sessions)
 ```
 
 ---
@@ -469,7 +495,13 @@ template:
 - v3 — test-driven (probes BEFORE rewrite); 2 approval gates per file;
   iteration cap = 3; random ordering. Rejected on anti-clustering rule:
   flat 40% cap doesn't work for files with one rule-dominant section.
-- v4 — current. Adds section-share-aware anti-clustering (mechanical
-  override > 50% by lines, judgment-call override for rule-dominant
-  sections); adds probe-surface coverage requirement (≥ 60% sections
-  targeted) and Class B/C placement constraints.
+- v4 — adds section-share-aware anti-clustering (mechanical override > 50%
+  by lines, judgment-call override for rule-dominant sections); adds
+  probe-surface coverage requirement (≥ 60% sections targeted) and Class B/C
+  placement constraints.
+- v4.1 — current. Each Phase 1 file gets its own GitHub tracking issue
+  (#167–#171). Phase 1 PRs are now independent rather than sequential —
+  the file order in the table is a recommended priority, not a sequencing
+  requirement. Adds per-file cross-reference link-sanity audit step
+  (pre-rewrite grep + post-rewrite re-grep) so anchor breakages are caught
+  in the same PR that introduces them.

--- a/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
+++ b/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
@@ -1,0 +1,475 @@
+# Instruction-File Rewrite Plan (v4)
+
+**Status:** in progress (Phase 0 lands in PR #166)
+**Started:** 2026-05-08
+**Style reference:** [`ai-docs/agent-writing-style.md`](../agent-writing-style.md)
+**Tracked in:** none (multi-PR workflow plan, no single GitHub issue)
+
+## Goal
+
+Rewrite the workspace's instruction files so that both Opus 4.7 and Sonnet 4.6
+reading the same paragraph land on the same interpretation. Test the result
+empirically with a dual-model comprehension probe per file.
+
+Reusable: this plan is intended as a template for future dual-model rewrites
+(e.g., Phase 2 procedural skills, or any new instruction-file family). Cite
+sections of this doc when a future PR follows the same workflow.
+
+## Scope
+
+### In scope (Sonnet + Opus dual-readability)
+
+| File | Lines |
+|---|---|
+| `AGENTS.md` | 220 |
+| `ai-docs/code-style.md` | 409 |
+| `ai-docs/doc-convention.md` | 429 |
+| `.claude/agents/self-review.md` | 161 |
+| `.claude/agents/review-findings.md` | 152 |
+
+Total: ~1,371 lines across 5 files (Phase 1).
+
+### Out of scope (Opus-only readers)
+
+- Agents with `model: opus` frontmatter:
+  - `.claude/agents/design.md`
+  - `.claude/agents/design-review.md`
+  - `.claude/agents/learnings-escalation-audit.md`
+  - `.claude/agents/self-improve.md`
+- Skills that run in Opus mode:
+  - `.claude/skills/ai-audit/SKILL.md`
+  - `.claude/skills/improve/SKILL.md`
+
+For these readers, AXIOM/fail-loud styling is optional — the reader has the
+context to disambiguate without it.
+
+### Deferred (Phase 2, not committed)
+
+Procedural skills with workflow steps but low binary-rule density:
+
+- `.claude/skills/bugfix/SKILL.md`
+- `.claude/skills/code-review/SKILL.md`
+- `.claude/skills/task/SKILL.md`
+- `.claude/skills/interview/SKILL.md`
+- `.claude/skills/next/SKILL.md`
+- `.claude/skills/pr-merged/SKILL.md`
+- `.claude/skills/context-reset/SKILL.md`
+- `.claude/skills/verify/SKILL.md`
+
+No commitment to revisit after Phase 1 unless Phase 1 produces a specific
+reason to.
+
+---
+
+## Phase 0 — Style spec (1 PR, complete in PR #166)
+
+Land [`ai-docs/agent-writing-style.md`](../agent-writing-style.md) as the
+citable reference for binary-rule writing style. After merge, all subsequent
+PRs cite this doc as the standard.
+
+---
+
+## Phase 1 — Rewrite cycle (5 PRs, sequential)
+
+### File order
+
+| # | File | Why this order |
+|---|---|---|
+| 1 | `AGENTS.md` | Central reference; everything else cites it |
+| 2 | `ai-docs/code-style.md` | Most rule-dense; multiple decision trees |
+| 3 | `ai-docs/doc-convention.md` | Similar density to code-style |
+| 4 | `.claude/agents/self-review.md` | Reads (1) and (2) — verifies they're effective |
+| 5 | `.claude/agents/review-findings.md` | Same shape as (4) |
+
+### Per-file workflow
+
+```
+1.  Branch off master:                  chore/<date>-rewrite-<filename>
+2.  Read file end-to-end
+3.  Build the SECTION INVENTORY:
+      - list every top-level (##) heading
+      - record line ranges and per-section share of total file lines
+4.  Cross-reference ai-docs/learnings.md → list every misread event
+    traceable to this file (quoted offending paragraph + line range)
+5.  Identify failure-likely hot spots (nested conditionals, decision
+    trees, carve-outs, cross-references) with line ranges
+6.  Draft probes:
+      - Class A (failure-targeted)  : 4-6 probes, drawn from step 4
+      - Class B (failure-likely)    : 1-3 probes, drawn from step 5
+    For each probe: question, full rubric, target section(s).
+7.  Build the COVERAGE MAP — table showing which top-level section
+    each probe targets. Verify the coverage rules (below) hold;
+    if not, draft additional Class B probes until they do.
+8.  ===> APPROVAL GATE 1:
+        - probe set (A + B)
+        - rubrics
+        - coverage map (with section-share-aware override declarations
+          where applicable)
+      User accepts / amends / rejects BEFORE rewrite. <===
+9.  Rewrite with the approved probe set + rubrics open in view.
+    Each fail-loud edit is justified by which probe(s) it makes pass.
+    A section with NO probe is OUT OF SCOPE — do not rewrite.
+    Cross-reference touch-ups (link fixes, heading anchors) are allowed
+    but no fail-loud restyling of unprobed sections.
+10. Draft Class C probe — single literal-token control, anchored on a
+    stable section of the rewritten file
+11. ===> APPROVAL GATE 2: Class C probe (small gate) <===
+12. Randomize all probes (A+B+C), spawn dual-model parallel test:
+      - Subagent A: model="opus",   prompt="Read file. Answer probes 1..N."
+      - Subagent B: model="sonnet", same prompt
+13. Evaluate per the rubric (mechanical, per-probe CORRECT/WRONG)
+14. If all probes CONVERGE on CORRECT → step 16
+    Else → step 15
+15. Revise the failing-probe sections, re-randomize order, re-run.
+    Cap: 3 rounds. After round 3 if still failing → surface to user
+    with diagnosis + proposed revision.
+16. Semantic-preservation self-review (every old rule still in new file)
+17. cargo build (sanity)
+18. Stage explicit files, commit, push -u, gh pr create
+19. Wait for user merge before next file
+```
+
+---
+
+## Probe composition (per file)
+
+Each comprehension test contains three classes of probe, randomly interleaved:
+
+### Class A — Failure-targeted (4–6 probes)
+
+Questions derived from documented misread events in `ai-docs/learnings.md`.
+One probe per learnings entry that traces back to the file under rewrite.
+These are the rules where ambiguity has *already* cost a session.
+
+**Example (AGENTS.md):**
+
+> The user says "add this to learnings: \<some rule\>". You write the entry.
+> Are you authorised to also update AGENTS.md in the same turn? Yes / No, and
+> why?
+
+(Targets entry L13 — "on corrections, write to learnings only".)
+
+### Class B — Failure-likely (1–3 probes)
+
+Questions targeting complex/non-trivial logic in the file that *hasn't* failed
+yet but has the structural shape that produces dual-model divergence: nested
+conditionals, multi-axis decision trees, carve-out exemptions, cross-references
+requiring synthesis.
+
+**Example (code-style.md decision tree):**
+
+> A method `fn foo(&self) -> u32 { self.field }` lives inside `impl<T> Trait
+> for Foo<T>`. The body has no branches, no loops, and one trivial field
+> access. Which marker does it carry, and which form (`/// _Simple._` /
+> `// _Simple._` / `#[inline]`)? Why?
+
+(Targets the carve-out boundary that's structurally tricky but hasn't failed
+yet.)
+
+### Class C — Control / A-B sanity (1 probe)
+
+A read-the-file-literally question whose answer is a single explicit token
+from the rewritten file. Serves as a control: both models should always
+answer this identically. If they diverge on the control, the test setup
+itself is broken (model didn't read, model misread the prompt) — not the
+file.
+
+**Example (AGENTS.md):**
+
+> Per AGENTS.md § *Project*, what file should you read on demand for project
+> purpose, entities, architecture, and design decisions? Quote the path
+> verbatim.
+
+(Answer: literally `ai-docs/context.md`. If models give different answers,
+throw out the test run and re-spawn — file isn't to blame.)
+
+### Random ordering
+
+Each iteration shuffles probe order. Detects order-dependence (where a
+model's answer to probe N is biased by what it saw in probe N-1). If round 2
+with reshuffled order produces a *different* outcome than round 1 with the
+same probes, that's diagnostic information about ordering effects in the
+file's logical flow.
+
+### Total per file
+
+| Class | Count |
+|---|---|
+| A — Failure-targeted | 4–6 |
+| B — Failure-likely | 1–3 |
+| C — Control | 1 |
+| **Total** | **6–10** |
+
+---
+
+## Probe-surface coverage rules
+
+Probes must demonstrate the file is comprehensible end-to-end, not just at
+known-bad spots.
+
+### Hard requirements (checked at Gate 1)
+
+| Rule | Threshold |
+|---|---|
+| Section coverage | At least **60% of top-level (`##`) sections** are targeted by at least one probe |
+| Anti-clustering (default) | No more than **40% of probes** target a single section |
+| Anti-clustering (heavy-section override) | If a section's line range is > 50% of the file (mechanical) OR is judged rule-dominant at Gate 1 (judgment-call), the per-section cap relaxes to `min(section_share + 10%, 70%)` |
+| Class B placement | At least **one Class B probe** targets a section that has zero Class A probes |
+| Class C placement | The control probe's anchor section must NOT be a section targeted by any Class A or B probe |
+
+### Section-share-aware anti-clustering — two qualifying paths
+
+**(a) Mechanical override** — section line range / total file line range > 50%.
+Auto-detected during Section Inventory (step 3 above).
+
+**(b) Judgment-call override** — section is ≤ 50% by lines but rule-dense to
+the point that its share of the rules worth probing exceeds 50%. Invoking (b)
+requires an explicit one-line justification at Gate 1 (e.g., "section is 30%
+by lines but contains 4 of 5 candidate rules with documented misreads + 2 of
+3 candidate failure-likely hot spots — declaring rule-dominant").
+
+### Worked examples
+
+**Example 1 — small variation (mechanical override)**
+
+```
+File: hypothetical-rule-doc.md (300 lines)
+Section X: lines 100-280 = 180 lines = 60% of file → mechanical override
+
+Cap on Section X:           min(60% + 10%, 70%) = 70%
+Cap on every other section: 40%
+
+If 8 probes total: up to 5 in Section X (62.5%), at least 3 spread elsewhere.
+```
+
+**Example 2 — code-style.md (judgment-call override)**
+
+```
+File: ai-docs/code-style.md (~409 lines)
+Section "#[inline] and the _Simple._ doc tag": lines 116-238 = 30% by lines
+
+NOT > 50% by lines → no mechanical override.
+
+Justification at Gate 1: "Section is 30% by lines but contains the entire
+marker-form decision tree (5 rows), the trait-method carve-out, the codegen
+mirroring rule, and the marker-maintenance cascade. Of 5 candidate Class A
+probes from learnings.md, 4 trace here. Of 3 candidate Class B hot spots,
+2 are inside this section. Declaring rule-dominant."
+
+Cap on this section (judgment-call):  60% (declared share)
+If 8 probes total: up to 5 in this section, at least 3 spread elsewhere.
+```
+
+**Example 3 — flat file, no override**
+
+```
+File: hypothetical-flat.md (200 lines, 5 ## sections, ~40 lines each)
+No section qualifies → default 40% cap applies.
+If 8 probes total: max 3 per section.
+```
+
+### Coverage map deliverable at Gate 1
+
+Surfaced as a table:
+
+```
+Section                               | Share | A probes  | B probes | C  | Cap | OK?
+--------------------------------------|-------|-----------|----------|----|-----|----
+Scope                                 | 3%    | -         | -        | -  | 40% | ✓
+Source files                          | 2%    | -         | -        | -  | 40% | ✓
+...
+#[inline] and _Simple._ doc tag       | 30%   | A1,A2,A3,A4 | B1,B2  | -  | 60% | ✓ (judgment override)
+...
+
+Coverage:                7 / 11 sections targeted (64%) → PASS (≥ 60%)
+Heaviest single section: 6/10 = 60% in #[inline] section → PASS (cap 60%)
+Coverage rule:           PASS
+```
+
+The override declaration is part of Gate 1 — user sees the justification
+text, agrees or pushes back.
+
+---
+
+## Rubric-based evaluation
+
+Comparison is rubric-based, not prose-vs-prose. Each model's answer is
+graded independently against the probe's pre-defined answer key. Wording
+deviation between two correct answers is irrelevant.
+
+### Probe answer key (per probe)
+
+#### Class C (control) — exact-token match
+
+```
+Type: literal-token
+Required value: <verbatim string from the file>
+
+Comparison: case-sensitive substring search for the literal value
+in each model's answer.
+```
+
+#### Class A and B — required-present / required-absent rubric
+
+```
+Type: prose-with-rubric
+
+Required-present (each must appear in some form):
+  1. <key concept 1>
+  2. <key concept 2>
+
+Required-absent (none of these may appear):
+  1. <forbidden concept 1>
+  2. <forbidden concept 2>
+
+Verdict logic:
+  - All required-present matched AND no required-absent matched → CORRECT
+  - Anything else → WRONG
+```
+
+### Convergence verdict (across both models)
+
+After both models produce answers and each is independently graded:
+
+| Opus | Sonnet | Verdict |
+|---|---|---|
+| CORRECT | CORRECT | **CONVERGE** — file is clear on this rule |
+| WRONG | WRONG | **DIVERGE** — rule is unclear to both models |
+| CORRECT | WRONG | **DIVERGE** — rule reads differently to Sonnet |
+| WRONG | CORRECT | **DIVERGE** — rule reads differently to Opus |
+
+Both-CORRECT counts as CONVERGE *regardless of how their wording differs.*
+
+### Reporting format
+
+For each probe, after the round completes:
+
+```
+Probe N (Class A, derived from L13)
+
+Question: <verbatim>
+
+Opus answer: "<verbatim>"
+  Rubric check:
+    required-present 1: ✓ matched
+    required-present 2: ✓ matched
+    required-absent  1: ✓ none
+    required-absent  2: ✓ none
+  Verdict: CORRECT
+
+Sonnet answer: "<verbatim>"
+  Rubric check:
+    required-present 1: ✓ matched
+    required-present 2: ✓ matched
+    required-absent  1: ✓ none
+    required-absent  2: ✗ <forbidden concept> present
+  Verdict: WRONG
+
+Convergence: DIVERGE — Sonnet read the rule as admitting a carve-out
+that does not exist. Source paragraph: <file>:<line range>.
+Diagnosis: <text>. Proposed revision: <text>.
+```
+
+### Edge cases
+
+| Case | Handling |
+|---|---|
+| Model gives correct answer + adds a wrong qualifier | Required-absent hit → WRONG |
+| Both correct but verbose vs terse | Both CORRECT → CONVERGE |
+| Model answers in list, other in prose | Format irrelevant — rubric scans concepts |
+| Model partially answers (1/2 required-present) | WRONG — partial credit isn't enough |
+| Model adds extra correct context not asked for | No required-absent hit → CORRECT |
+| Rubric itself too lenient (catches false-CORRECT) | Caught at PR review or future learnings; tighten rubric next round |
+| Rubric itself too strict (false-WRONG) | Caught when clearly-equivalent answer judged WRONG; amend rubric on the spot, re-evaluate |
+
+### What is NOT used
+
+- **No third LLM judge.** A judge subagent would itself have model-shape
+  bias (an Opus judge would prefer Opus-shaped answers, vice versa) —
+  defeating the dual-model neutrality. The driver evaluates against the
+  rubric mechanically; the user signs off on the rubric.
+- **No semantic-similarity scoring** (cosine/embedding distance). Too noisy
+  at the granularity needed; would obscure substantive divergences.
+- **No partial-credit grading.** Probes are binary CORRECT/WRONG.
+
+---
+
+## Approval gates
+
+| Gate | When | Deliverables |
+|---|---|---|
+| Phase 0 PR | After style-spec draft | Approve / amend / reject `agent-writing-style.md` content |
+| **Gate 1** (per file, before rewrite) | After step 7 of per-file workflow | Probes A+B, rubrics, coverage map (with override declarations) |
+| **Gate 2** (per file, after rewrite) | After step 10 of per-file workflow | Class C probe + answer |
+| Iteration-cap escalation (per file) | After round 3 of comprehension test fails | Diagnosis, divergent answers, proposed revision |
+| Per-file PR | After self-review passes | Standard GitHub PR review |
+
+---
+
+## Iteration cap = 3
+
+Per file, max 3 comprehension rounds. After round 3 if still diverging on
+Class A or B, surface to user with:
+
+- All three rounds' answers (Opus + Sonnet, side-by-side)
+- The source paragraph
+- Diagnosis: ordering effect (round 1 vs 2 vs 3 differed)? Persistent ambiguity
+  (all rounds same wrong answer)?
+- Proposed fourth revision
+
+User decides: accept proposed revision, manually rewrite that section,
+abandon fail-loud-ify of that section, or pause file pending judgment.
+
+Class C divergence does NOT count against the cap — it's a setup-broken
+signal, not a file-broken signal. Re-spawn subagents instead.
+
+---
+
+## Phase 2 — deferred
+
+Procedural skills (`bugfix`, `code-review`, `task`, `interview`, `next`,
+`pr-merged`, `context-reset`, `verify`) NOT in scope. No commitment to
+revisit after Phase 1.
+
+---
+
+## Effort estimate
+
+| Phase | Per-file effort | Total |
+|---|---|---|
+| Phase 0 (style spec) | 30–60 min single PR | ~1 hour |
+| Phase 1 per file | 120–240 min (read, inventory, learnings cross-ref, probe drafting + rubrics + coverage map, Gate 1, rewrite, Gate 2, dual-model test, up to 3 iterations, self-review, fix, commit, PR) | ~10–20 hours across 5 files |
+| **Total** | | **~11–21 hours of session time, spread across 6 PRs over multiple days** |
+
+---
+
+## Citation in future PRs
+
+When a Phase 1 PR follows this workflow, cite this doc in its body:
+
+> Per `ai-docs/plans/2026-05-08-instruction-file-rewrite.md` § Phase 1 file N,
+> this PR rewrites `<file>` using probes drafted at Gate 1 (commit `<sha>`)
+> and the section-share-aware coverage rule.
+
+When a future rewrite plan reuses this template (e.g., Phase 2 procedural
+skills, or a different instruction-file family), cite this doc as the source
+template:
+
+> Workflow patterned on `ai-docs/plans/2026-05-08-instruction-file-rewrite.md`,
+> adapted for procedural skills as follows: \<deltas\>.
+
+---
+
+## Decision history
+
+- v1 — initial sketch: probes after rewrite (test-after); 2 rounds; flat
+  anti-clustering. Rejected: rewrite has no concrete success criterion.
+- v2 — added 3 probe classes (A failure-targeted / B failure-likely / C
+  control), but still test-after. Rejected: same flaw.
+- v3 — test-driven (probes BEFORE rewrite); 2 approval gates per file;
+  iteration cap = 3; random ordering. Rejected on anti-clustering rule:
+  flat 40% cap doesn't work for files with one rule-dominant section.
+- v4 — current. Adds section-share-aware anti-clustering (mechanical
+  override > 50% by lines, judgment-call override for rule-dominant
+  sections); adds probe-surface coverage requirement (≥ 60% sections
+  targeted) and Class B/C placement constraints.


### PR DESCRIPTION
## Summary

Phase 0 of the multi-PR rewrite plan. Three artefacts:

1. **`ai-docs/agent-writing-style.md`** — the citable reference for writing binary rules in instruction files so that both Opus 4.7 and Sonnet 4.6 land on the same interpretation.
2. **`ai-docs/plans/2026-05-08-instruction-file-rewrite.md`** — the full v4.1 workflow plan, saved as a self-contained document so it can be referenced by future Phase 1 PRs and reused as a template for later dual-model rewrites.
3. **GitHub issues #167–#171** — one per Phase 1 file, all labeled `blocked` (depend on this PR merging). Phase 1 files are now tracked independently rather than as a strict sequential chain.

Plus a single-line addition to AGENTS.md `## Agent Docs` table cross-referencing the new style spec.

## What the style spec codifies

Patterns demonstrated in PR #165:

- **AXIOM blockquote** — top-of-section binary rule with an action table
- **Fail-loud verbs** — bold uppercase, used sparingly (≤ 1 per paragraph)
- **Action tables** — "if you see X → do Y"
- **Explicit file lists** — never globs as the entire list
- **Numbered enumeration of triggers** — for "this fires when…"
- **Concrete do/not examples** — both shapes shown

Also includes a writing checklist, an anti-patterns table, a PR citation form, and explicit out-of-scope (Opus-only readers — `design`, `design-review`, `learnings-escalation-audit`, `self-improve`, `/ai-audit`, `/improve` — don't need this style).

The doc itself uses the patterns it advocates (eats its own dog food).

## What the plan document covers

The plan (~507 lines) captures:

- Goal + scope (in / out / deferred)
- Phase 0 + Phase 1 outline; Phase 1 files independent (not sequential), each tracked by its own GitHub issue
- Per-file workflow (19 numbered steps, test-driven)
- Probe composition (Classes A failure-targeted / B failure-likely / C control)
- Probe-surface coverage rules with section-share-aware anti-clustering (mechanical > 50% lines OR judgment-call rule-dominant) and three worked examples
- Rubric-based evaluation (no third LLM judge, no semantic similarity, no partial credit) with edge-case table
- Five distinct approval gates across the lifecycle
- Iteration cap = 3 with escalation procedure
- Cross-reference link-sanity audit (per-file, pre- and post-rewrite grep)
- Effort estimate
- Citation form for future PRs reusing this workflow
- Decision history (v1 → v4.1)

`Tracked in: none` for the meta-plan itself; each of the five Phase 1 files has its own issue (table below).

## Why now

Three /improve runs today escalated rules where two independent agents read the same paragraph and landed on different interpretations (PR #165 documents the marker-form mutex and learnings boundary cases). Without a written style spec, every future rewrite drifts into a different interpretation of "fail-loud." Without a saved plan, the multi-session workflow only exists in conversation context.

## Plan v4.1 roadmap (this PR is Phase 0 / 6)

| Phase | PR / Issue | Files |
|---|---|---|
| **Phase 0 (this PR)** | #166 | `ai-docs/agent-writing-style.md` + plan doc + AGENTS.md cross-reference |
| Phase 1 file 1 | #167 | `AGENTS.md` |
| Phase 1 file 2 | #168 | `ai-docs/code-style.md` |
| Phase 1 file 3 | #169 | `ai-docs/doc-convention.md` |
| Phase 1 file 4 | #170 | `.claude/agents/self-review.md` |
| Phase 1 file 5 | #171 | `.claude/agents/review-findings.md` |

Phase 1 issues are independent — work can be parallelised across sessions. The numbered "order" is a recommended priority (highest leverage first), not a sequencing requirement. All five issues are labeled `blocked` until this PR merges.

Each Phase 1 file is gated by:
- Gate 1 (before rewrite): probes A+B + rubrics + coverage map
- Gate 2 (after rewrite): Class C control probe
- Dual-model comprehension test (Opus + Sonnet subagents in parallel)
- Iteration cap = 3, with section-share-aware anti-clustering for rule-dense sections

Phase 2 (procedural skills: bugfix, code-review, task, interview, next, pr-merged, context-reset, verify) is deferred. Opus-only readers are explicitly out of scope.

## Verification

- `cargo build` clean
- AGENTS.md § Agent Docs has a row pointing at the new style spec
- No code changes — instruction-file-only PR

## Test plan

- [x] `ai-docs/agent-writing-style.md` created (156 lines) with 6 patterns + checklist + anti-patterns + citation form + out-of-scope
- [x] `ai-docs/plans/2026-05-08-instruction-file-rewrite.md` created (~507 lines) with full v4.1 workflow + worked examples + decision history (v1 → v4.1)
- [x] AGENTS.md § Agent Docs cross-references the new style spec
- [x] Style spec eats its own dog food (uses AXIOM, action tables, explicit file lists, etc.)
- [x] Plan doc has `Tracked in: none` for the meta-plan; each Phase 1 file has its own issue (#167–#171)
- [x] All five Phase 1 issues created and labeled `blocked`
- [x] `cargo build` clean
