### PR TITLE
docs(AGENTS): dual-model rewrite (Phase 1 file 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,15 +35,41 @@ cargo build -p quartzite --no-default-features   # verify derive-free / no_std p
 actionlint .github/workflows/<file>.yml   # required gate for any new/modified workflow file
 ```
 
-**Workflow files.** Any new or modified `.github/workflows/*.yml` is a required `actionlint` gate before staging — same status as `cargo build` / `cargo clippy`. Run `actionlint <file>` (or pass every changed file in one invocation) and fix all errors before `git add`. actionlint catches runner-version mismatches, deprecated action versions, expression syntax errors, and shell quoting issues that `cargo` checks cannot see.
+> **AXIOM — `actionlint` MUST pass before `git add` on any modified workflow file.**
+> Required gate, same status as `cargo build` and `cargo clippy --workspace -- -D warnings`. Skipped twice despite the rule existing — escalated to AGENTS.md after the second occurrence.
+>
+> | If you see... | Action |
+> |---|---|
+> | `M .github/workflows/<name>.yml` in `git status` | Run `actionlint <file>` (or pass every changed workflow file in one invocation) **before** `git add` |
+> | `actionlint` reports any error | Fix it. **NEVER** bypass. |
+>
+> What `actionlint` catches that `cargo` cannot: runner-version mismatches, deprecated action versions, expression-syntax errors, shell-quoting issues.
 
 Search: `rg <pattern> --type rust [-l | -C 3]`
 
 ## API Stability
 
-The project has **not yet been published to crates.io** and has no downstream clients. Public API may be freely renamed, removed, or restructured without backward-compat shims or deprecation layers. Do not add old-name aliases or `#[deprecated]` wrappers "for compatibility" — just make the clean change. Revisit this rule before the first `cargo publish`.
+> **AXIOM — Pre-publish: clean breaks. No compat shims.**
+> The project has **not** been published to crates.io and has no downstream clients. Public API may be freely renamed, removed, or restructured without backward-compat shims, deprecation layers, or `#[deprecated]` wrappers.
+>
+> | If you're tempted to... | Do this instead |
+> |---|---|
+> | Add `pub use OldName as NewName;` "for compat" | **REMOVE** the alias — make the clean rename |
+> | Wrap removed fn with `#[deprecated] pub fn old() -> _ { new() }` | **DELETE** the wrapper — call sites update directly |
+> | Keep both old and new APIs side-by-side temporarily | Pick one — old is gone |
+
+Revisit this rule before the first `cargo publish`.
 
 ## API Naming
+
+> **AXIOM — `_unchecked` means `unsafe` AND UB-on-failure. Period.**
+> The suffix is reserved exclusively for `unsafe fn` whose contract documents Undefined Behaviour on caller-invariant violation. **NEVER** apply it to a safe fn — even one that "skips a runtime check" — because the suffix carries unsafety implications that mislead readers and reviewers.
+>
+> | Your fn... | Suffix |
+> |---|---|
+> | Is `unsafe`, UB on caller violation (`# Safety` section required) | `_unchecked` ✓ (e.g., `slice::get_unchecked`, `str::from_utf8_unchecked`) |
+> | Is **safe**, skips a non-safety check (validation, sort-order, etc.) | A descriptive suffix like `_unverified` / `_skip_validation` / `_unsorted` — **NEVER** `_unchecked` |
+> | Is **safe**, returns `Result` / `Option` on failure | Unsuffixed (`do_something`); add a `try_*` variant if a panicking sibling exists |
 
 Follow `std` ecosystem conventions. The unsuffixed name is the **safe, ergonomic default**; suffixes mark deviations. Path of least resistance must be the safe path.
 
@@ -69,6 +95,17 @@ See [`ai-docs/code-style.md`](ai-docs/code-style.md) for the canonical reference
 
 ## Dependency Versions
 
+> **AXIOM — Query the live registry BEFORE writing any specific version string. Training data is stale.**
+> Whenever you write a specific version of a Cargo crate or a GitHub Action — anywhere (`Cargo.toml`, workflow file, issue body, spec, design doc, learning, any `ai-docs/**` page) — query the live source first. Treating remembered versions as authoritative has put wrong majors into specs twice in this repo (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`).
+>
+> | If you need to write... | Run this first |
+> |---|---|
+> | A Cargo crate version | `curl -sS "https://crates.io/api/v1/crates/<name>" \| jq -r '.crate.max_stable_version'` |
+> | A GitHub Action version | `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` (and verify the action's Node runtime is current) |
+> | A version into a long-lived doc (won't be revisited for months) | Annotate `(verified current YYYY-MM-DD)` next to the version |
+>
+> Then apply the pinning rule (below) to the **observed** version, never the remembered one.
+
 When adding or editing dependencies in `Cargo.toml`:
 
 - Use `0.x` for `0.x.y` versions — never pin the patch.
@@ -85,6 +122,17 @@ Per source:
 - **Long-lived references** (a doc that won't be revisited for months): annotate `(verified current YYYY-MM-DD)` next to the version so the next reader can spot drift before a `/task` session pins the stale value.
 
 ## Workflow
+
+> **AXIOM 1 — NEVER edit on local `master` when work is intended for a PR.**
+> Create a feature branch (`git checkout -b feat/...` or `chore/...`) **before** any file edit — not before commit, **before edit**. Accumulating uncommitted edits on `master` leaves the tree dirty on the wrong branch and forces a reactive switch later.
+>
+> | If `git branch --show-current` returns... | Action |
+> |---|---|
+> | `master` AND you're about to make a PR-targeted edit | **STOP**. Run `git checkout -b <prefix>/<descriptive-name>` first. Only then edit. |
+> | A feature branch | Proceed with edits |
+> | `master` AND you've already made commits (recovery) | `git stash` → `git checkout -b <feature>` → `git checkout master && git reset --soft origin/master && git restore --staged .` → push feature branch → open PR. Pop stash on feature branch if needed. |
+>
+> The first action of any skill/workflow that produces commits (`/task`, `/improve`, `/ai-audit`, etc.) is `git branch --show-current`; if `master`, switch **before** any `Edit`/`Write`. Before any `git push`, confirm again — if it is `master`, stop and apply recovery.
 
 - Merge PRs with a merge commit (`gh pr merge --merge`). Never squash or rebase-merge.
 - **Never edit on local `master` when work is intended for a PR.** Create a feature branch (`git checkout -b feat/...`) *before* making any file edit — not just before commit. Accumulating uncommitted edits on `master` is the failure mode this rule guards: it leaves the working tree dirty on the wrong branch and forces a reactive switch later. The first action of any skill/workflow that produces commits (`/task`, `/improve`, `/ai-audit`, etc.) is `git branch --show-current`; if `master`, switch before any `Edit`/`Write`. Before any `git push`, confirm `git branch --show-current` is not `master` — if it is, stop and apply the recovery procedure below.
@@ -119,7 +167,30 @@ Per source:
   4. Skip threads where you posted an objection — those stay open for the reviewer.
 - **PR body sync after every push.** When the current branch has an open PR, every `git push` is followed by `gh pr view <N> --json title,body` *unconditionally* — read the body first, then decide whether to edit. Sync via `gh pr edit` if the body now contradicts the diff (renames, scope drift, AC checkbox flips, cited counts that drifted, dropped/added items). Routine commits within already-described scope do not need an edit, but the **read** is non-negotiable. Reasoning your way out of the read is the failure mode this rule prevents. **Exception:** the read is not required when `gh pr create` immediately followed the push (the body is what you just authored — nothing to discover). The rule starts firing on the *next* push to the branch. The **upstream tracking issue's** title and body are the user's original problem statement — do not rewrite them; communicate scope changes via `gh issue comment` instead.
 
+> **AXIOM 2 — Read the PR body via `gh pr view <N>` after EVERY `git push` to a feature branch with an open PR. Unconditional.**
+> The READ is mandatory even when the push was a routine typo / format / nit. The EDIT is conditional — only when the body contradicts the new commits.
+>
+> | After... | Required action |
+> |---|---|
+> | `git push` to a feature branch with an open PR | Run `gh pr view <N> --json title,body` immediately. Read the body. |
+> | The body still describes the diff accurately | No `gh pr edit` needed — read complete |
+> | The body contradicts the new commits (renames, scope drift, AC flips, cited counts that drifted) | Run `gh pr edit` to sync |
+> | `gh pr create` immediately preceded the push (i.e., this is the first push that opened the PR) | **Skip** the read — the body is what you just authored. The rule fires on the **next** push. |
+>
+> The upstream tracking **issue**'s title and body are the user's original problem statement — do not rewrite them. Communicate scope changes via `gh issue comment` instead.
+
 ## Propagation Rule
+
+> **AXIOM — Edits to one instruction file MUST propagate to its sync-group siblings in the SAME PR.**
+> The Propagation Rule fires whenever you edit an instruction file. Sister files in the same sync group must receive the corresponding change before the PR is opened.
+>
+> | If you edit... | You MUST also check / update... |
+> |---|---|
+> | `.claude/skills/code-review/SKILL.md` | `.claude/agents/review-findings.md` AND `.claude/agents/self-review.md` (Review group) |
+> | `.claude/agents/review-findings.md` | `.claude/skills/code-review/SKILL.md` AND `.claude/agents/self-review.md` (Review group) |
+> | `.claude/agents/self-review.md` | `.claude/skills/code-review/SKILL.md` AND `.claude/agents/review-findings.md` (Review group) |
+> | `AGENTS.md` (rule add / exemption) | Run `grep -rn "<changed-keyword>" .claude/agents/ .claude/skills/ AGENTS.md` and apply the same change to every match |
+> | Any other instruction file | Run the same grep — the Procedure (below) catches lingering references |
 
 When editing any instruction file (`AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `.claude/settings.json`), propagate the change to every related file in the same operation — before reporting done.
 

--- a/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
+++ b/ai-docs/plans/2026-05-08-instruction-file-rewrite.md
@@ -486,6 +486,196 @@ template:
 
 ---
 
+## Implementation hints
+
+Concrete patterns derived during the first execution of the per-file workflow
+(issue #167, AGENTS.md rewrite). Future sessions applying this workflow to
+other Phase 1 files (#168–#171) can imitate these for consistency.
+
+### Branch naming
+
+Pattern: `chore/<YYYY-MM-DD>-rewrite-<filename-kebab-case>` — drop the file
+extension; convert dots and slashes to hyphens.
+
+| File under rewrite | Branch name |
+|---|---|
+| `AGENTS.md` | `chore/2026-05-08-rewrite-agents-md` |
+| `ai-docs/code-style.md` | `chore/2026-05-08-rewrite-code-style` |
+| `ai-docs/doc-convention.md` | `chore/2026-05-08-rewrite-doc-convention` |
+| `.claude/agents/self-review.md` | `chore/2026-05-08-rewrite-self-review` |
+| `.claude/agents/review-findings.md` | `chore/2026-05-08-rewrite-review-findings` |
+
+### Section inventory format
+
+At workflow step 3, build a table with columns: `Section | Lines | Range | Share`.
+Compute `Share = section_lines / total_file_lines`. Identify the largest
+section — that's the candidate for the heavy-section override (mechanical >50%
+or judgment-call rule-dominant) per the coverage rules.
+
+### Cross-reference link audit
+
+Pre-rewrite (after step 4) and post-rewrite (after step 17):
+
+```bash
+grep -rn '<file>#' ai-docs/ .claude/skills/ .claude/agents/
+```
+
+Pre-rewrite enumerates incoming anchor links. Post-rewrite verifies each
+still resolves. Renaming or restructuring a `## Section` heading changes its
+GitHub-style anchor (`#section-heading`); preserve the heading or update
+siblings in the same PR.
+
+### Probe drafting heuristics
+
+**Class A (failure-targeted, 4–6 probes):**
+- One per `learnings.md` misread event traceable to the file under rewrite
+- Phrase as a realistic scenario asked as yes/no or what-do-you-do
+- Include at least one detail that disambiguates the misread direction
+  (e.g., explicitly offer (a)/(b)/(c) options to force a choice)
+
+**Class B (failure-likely, 1–3 probes):**
+- Target structural-complexity hot spots: nested conditionals, multi-axis
+  decision trees, carve-out exemptions, cross-references requiring synthesis
+- Place at least one Class B in a section with zero Class A probes —
+  extends coverage beyond hindsight
+
+**Class C (control, 1 probe):**
+- Anchor on a stable, low-rule-density section (one that primarily points
+  at another doc, or a short orientation paragraph)
+- Required answer: a single literal token (file path, command, version)
+- Verifies the test setup itself is intact
+
+### Rubric authoring heuristics
+
+For **Class A and B (prose-with-rubric):**
+
+| Field | Items | Rules |
+|---|---|---|
+| Required-present | 2–4 | Each must be load-bearing (rule cannot be understood without it). Match leniently on synonyms (negation: `no` / `not authorised` / `forbidden` / `MUST NOT` all count). Match strictly on substantives (file paths, command names, specific triggers — verbatim). |
+| Required-absent | 1–2 | Concepts that, if present, indicate the rule was misread in a known direction. Avoid common stop-words (don't required-absent `not` or `for example`). |
+| Verdict | binary | ALL required-present matched AND NO required-absent matched → CORRECT. Anything else → WRONG. |
+
+**Anti-rubrics — do NOT do:**
+
+- Grade for exact wording (defeats dual-model neutrality)
+- List required-present items that are synonyms of each other (graders end up checking the same concept twice)
+- Required-absent on natural English phrases (`however`, `for example`)
+
+For **Class C (literal-token):**
+
+- Type: `literal-token`
+- Required value: verbatim string from the rewritten file
+- Comparison: case-sensitive substring search — model's answer must contain
+  the literal value as a substring
+
+### Subagent spawn
+
+Spawn both models **in parallel** — single tool-use message with two `Agent`
+calls:
+
+```
+Agent(
+  description = "Comprehension test (Opus)",
+  subagent_type = "general-purpose",
+  model = "opus",
+  prompt = <prompt template, see below>,
+)
+
+Agent(
+  description = "Comprehension test (Sonnet)",
+  subagent_type = "general-purpose",
+  model = "sonnet",
+  prompt = <IDENTICAL prompt>,
+)
+```
+
+Both subagents receive identical prompts including the same shuffled probe
+order — divergence is then attributable to the file's wording, not to setup
+variance.
+
+### Subagent prompt template
+
+```
+You are a comprehension-test subagent for the quartzite project's <FILE>
+rewrite (issue #<N>). Your task is narrow and self-contained.
+
+INSTRUCTIONS:
+
+1. Read the file at <ABSOLUTE-PATH> — that file is the rewritten version
+   under test.
+2. Do NOT read any other file in the codebase.
+3. Do NOT search for additional context, run grep, or open the web.
+4. Answer each probe below INDEPENDENTLY, based ONLY on what's in the file.
+5. Be brief: 1–4 sentences per answer. State the answer first, then briefly
+   justify by referring to the relevant section.
+
+OUTPUT FORMAT — for each probe, exactly this shape:
+
+PROBE <N>:
+<your answer>
+
+PROBES (randomized order):
+
+Probe 1: <verbatim Q>
+Probe 2: <verbatim Q>
+...
+
+After answering all <N> probes, output a final line: `END OF PROBES`.
+```
+
+**Why each instruction is load-bearing:**
+
+- "Do NOT read other files / grep / web search" — without this, subagents
+  read sibling instruction files to "verify" cross-references and
+  contaminate the test (model answers based on what *should* be true,
+  not what the rewritten file says)
+- "1–4 sentences" cap — keeps answers short enough for mechanical
+  rubric-checking; longer answers risk burying the verdict-relevant token
+- "State the answer first" — forces the verdict signal early; rubric
+  matching becomes more reliable
+- `END OF PROBES` sentinel — makes truncation detectable
+
+### Probe order randomization
+
+Per round, generate a fresh permutation of the probe set. Both subagents
+get the **same** permutation in a given round — different orders across
+models would introduce a confounding variable.
+
+If round 2 is needed (some probes failed in round 1), shuffle again. If
+round 2 with reshuffled order produces *different* convergence than round 1
+on the same probes, that's diagnostic information about order-dependence in
+the file's logical flow.
+
+### Reporting format for dual-model results
+
+For all-CONVERGE rounds, a per-probe summary table is sufficient:
+
+| Probe | Class | Topic | Opus | Sonnet | Verdict |
+|---|---|---|---|---|---|
+| A1 | failure-targeted | <topic> | CORRECT | CORRECT | ✅ CONVERGE |
+
+For DIVERGE outcomes, add a per-probe detail block:
+
+```
+Probe N (Class X — derived from <source>)
+
+Question: <verbatim>
+
+Opus answer: "<verbatim>"
+  Rubric check:
+    required-present 1: ✓/✗ <reason>
+    required-absent  1: ✓/✗ <reason>
+  Verdict: CORRECT / WRONG
+
+Sonnet answer: "<verbatim>"
+  Rubric check: ...
+  Verdict: ...
+
+Convergence: DIVERGE — <one-sentence diagnosis>
+Source paragraph: <file>:<line range>
+Proposed revision: <text>
+```
+
 ## Decision history
 
 - v1 — initial sketch: probes after rewrite (test-after); 2 rounds; flat


### PR DESCRIPTION
## Summary

Phase 1 file 1 of the [instruction-file rewrite plan v4.1](https://github.com/maratik123/quartzite/blob/master/ai-docs/plans/2026-05-08-instruction-file-rewrite.md). First execution of the dual-model rewrite workflow — applies AXIOM blockquotes per [`ai-docs/agent-writing-style.md`](https://github.com/maratik123/quartzite/blob/master/ai-docs/agent-writing-style.md) to seven binary-rule sections in `AGENTS.md`.

Two commits:

1. **`AGENTS.md` rewrite** — adds AXIOM blockquotes to seven sections that have produced documented misread events; AXIOMs include action tables (\"if you see X → do Y\") and explicit file lists.
2. **Plan doc hints capture** — new `## Implementation hints` section captures concrete patterns derived during this execution (subagent prompt template, probe drafting heuristics, rubric authoring, etc.) so subsequent Phase 1 sessions (#168–#171) can imitate them.

## Sections rewritten

| Section | Probe(s) | Trigger |
|---|---|---|
| Build & Test | A4 | actionlint gate twice-escalated; rule was a paragraph, now AXIOM with action table |
| API Stability | A6 | pre-publish breaks rule; AXIOM with do/not table |
| API Naming | B2 | `_unchecked` reservation; AXIOM with shape→suffix table |
| Dependency Versions | B1 | registry-query rule; AXIOM with per-source query table |
| Workflow (×2) | A2, A3 | feature-branch-before-edits + PR-body-sync-after-push; both AXIOMs with state→action tables |
| Propagation Rule | B3 | sync-group rule; AXIOM with edit→sister-files table |

## Sections deliberately untouched

- **Project, Communication, Corrections Log** — existing wording already passes dual-model probes (Boundary rules in Corrections Log were just rewritten in PR #165)
- **Permissions, Code Style summary, Agent Docs, Rust Test Conventions** — no probe targeted them; not in scope this PR

## Dual-model comprehension test

Round 1, 10/10 probes **CONVERGE on CORRECT**. No iteration needed.

| Probe | Class | Topic | Verdict |
|---|---|---|---|
| B2 | failure-likely | `_unchecked` reservation | ✅ CONVERGE |
| A3 | failure-targeted | PR body sync after push | ✅ CONVERGE |
| C | control | Project literal-token | ✅ CONVERGE |
| A1 | failure-targeted | Boundary rule 2 (corrections) | ✅ CONVERGE |
| B1 | failure-likely | Registry-query | ✅ CONVERGE |
| A6 | failure-targeted | Pre-publish breaking changes | ✅ CONVERGE |
| A4 | failure-targeted | actionlint gate | ✅ CONVERGE |
| B3 | failure-likely | Propagation Rule sync-group | ✅ CONVERGE |
| A5 | failure-targeted | \"submit to PR\" semantics | ✅ CONVERGE |
| A2 | failure-targeted | Feature branch before edits | ✅ CONVERGE |

Both Opus 4.7 and Sonnet 4.6 cited the same AXIOM blocks and gave matching action verbs. Wording differed (Opus terser, Sonnet more quotational) but every required-present concept matched and no required-absent concept appeared.

## Cross-reference link sanity

Pre-rewrite grep: only one incoming anchor link — \`ai-docs/code-style.md:57\` → \`#api-naming\`. Post-rewrite: heading \`## API Naming\` preserved; anchor still resolves. ✅

## Semantic preservation

Rewrite was largely additive (AXIOMs added above existing prose; original bullets retained). Two edits replaced prose with AXIOMs (Build & Test § Workflow files paragraph; API Stability paragraph) — every original rule preserved (required-gate status, command list, what-it-catches list, no-compat-shims, no-deprecation, etc.).

## Tracking

Closes #167.

## Test plan

- [x] AGENTS.md grew from 221 → 294 lines (+73)
- [x] AXIOM blockquotes added to 7 in-scope sections
- [x] All 10 probes CONVERGE on CORRECT in round 1
- [x] Cross-reference (code-style.md → api-naming) still resolves
- [x] Plan doc \`## Implementation hints\` captures subagent template + rubric heuristics for #168–#171
- [x] \`cargo build\` clean
- [x] No code changes — instruction-file-only PR