### PR TITLE
ci: add sccache layer for compiler-artefact caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Cache dependencies
         uses: actions/cache@v5
         with:
@@ -56,6 +58,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Cache dependencies
         uses: actions/cache@v5
         with:
@@ -81,6 +85,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Cache dependencies
         uses: actions/cache@v5
         with:
@@ -155,6 +161,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Cache dependencies
         uses: actions/cache@v5
         with:
@@ -185,6 +193,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Cache dependencies
         uses: actions/cache@v5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ core-types ✅
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [ci-sccache](ai-docs/plans/done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |
 | [widgets](ai-docs/plans/done/2026-05-01-widgets.spec.md) | `quartzite-widgets` | ✅ implemented (64 unit + 82 doc tests) | — |
 | [project-docs](ai-docs/plans/done/2026-05-08-project-docs.spec.md) | `quartzite` (facade) + repo-level docs + CI | ✅ implemented (0 new tests; README description block + comprehensive `lib.rs` rustdoc + `CONTRIBUTING.md` + auto-generated `ROADMAP.md` + CI sync-gate) | — |
 | [generic-simple-tags](ai-docs/plans/done/2026-05-07-generic-simple-tags.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; annotation-only) | — |

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -6,6 +6,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [ci-sccache](done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |
 | [widgets](done/2026-05-01-widgets.spec.md) | `quartzite-widgets` | ✅ implemented (64 unit + 82 doc tests) | — |
 | [project-docs](done/2026-05-08-project-docs.spec.md) | `quartzite` (facade) + repo-level docs + CI | ✅ implemented (0 new tests; README description block + comprehensive `lib.rs` rustdoc + `CONTRIBUTING.md` + auto-generated `ROADMAP.md` + CI sync-gate) | — |
 | [generic-simple-tags](done/2026-05-07-generic-simple-tags.spec.md) | `quartzite-core` `quartzite-runtime` | ✅ implemented (0 new tests; annotation-only) | — |

--- a/ai-docs/plans/done/2026-05-08-ci-sccache.design.md
+++ b/ai-docs/plans/done/2026-05-08-ci-sccache.design.md
@@ -1,0 +1,231 @@
+# Design: CI sccache layer for compiler-artefact caching
+
+**Issue:** #178
+**Date:** 2026-05-08
+
+## Approach
+
+Add a single `Run sccache-cache` step (using `mozilla-actions/sccache-action`)
+to every merge-gate job in `.github/workflows/ci.yml` that compiles Rust:
+`build`, `test`, `clippy`, `docs`, and `features`. The action wraps the
+toolchain by exporting `RUSTC_WRAPPER=sccache` into the job environment and
+configures the GitHub Actions cache as the sccache backend (the default
+`SCCACHE_GHA_ENABLED=true` mode of the action). All subsequent `cargo`
+invocations in the job route compiler calls through sccache transparently.
+
+The existing `actions/cache@v5` block (cargo registry + `target/`) stays
+untouched in every job. sccache layers under it: the cargo cache covers
+`target/` and the registry, keyed on `Cargo.lock`; sccache covers per-source
+compiler outputs (object files / `rlib`s) keyed on source-content hash.
+The two layers are complementary, not redundant — when `Cargo.lock` changes
+and the cargo cache is invalidated, sccache still hits when source bytes
+have not changed.
+
+### Per-job step placement
+
+Per the spec's "Per-job placement" constraint, the sccache-action step is
+inserted **after** `dtolnay/rust-toolchain@stable` and **before**
+`actions/cache@v5`. This ordering ensures `RUSTC_WRAPPER=sccache` is
+exported into the job environment before any cargo-aware step runs,
+including the cache restore (which does not itself invoke `cargo`, but
+keeping the action ordering uniform across jobs reduces cognitive load
+during review).
+
+Concretely, every affected job's `steps:` list becomes:
+
+```
+- uses: actions/checkout@v6
+- name: Install Rust toolchain
+  uses: dtolnay/rust-toolchain@stable
+  with: { ... }            # only on jobs that already had a `with:` block
+- name: Run sccache-cache
+  uses: mozilla-actions/sccache-action@<pinned major>
+- name: Cache dependencies
+  uses: actions/cache@v5
+  with: { ... }            # unchanged
+- name: <existing compile step>   # unchanged
+```
+
+No `env:` block, no `with:` block on the sccache-action step is required —
+the action's defaults (`SCCACHE_GHA_ENABLED=true`, `RUSTC_WRAPPER=sccache`)
+match the spec's "GHA-backed (default)" decision and the "Leave default"
+cache-size decision. Stats emission at end-of-job is also default behaviour
+of the action and satisfies AC4 without any extra step.
+
+### Rejected alternatives
+
+- **`Swatinem/rust-cache@v2`** — out of scope per spec ("file as follow-up
+  if desired"). It would replace the existing `actions/cache@v5` block, not
+  layer with sccache. Different concern, different PR.
+- **Per-OS sccache version overrides in the matrix** — rejected per spec
+  ("Matrix consistency — same sccache version across all matrix entries").
+  No data yet to justify divergence.
+- **Custom `SCCACHE_CACHE_SIZE`** — rejected per spec ("Leave default").
+  Tunable later if 10 GB GHA repo cache shows pressure.
+- **`continue-on-error: true` on the sccache step** — rejected per spec
+  ("Fail loud — surfaces regressions immediately"). A misconfigured
+  sccache wrapper that breaks `cargo build` should block merge by design.
+- **Adding sccache to `coverage.yml` / benchmark workflows** — out of scope
+  per spec. Coverage instrumentation interaction is unevaluated; benchmarks
+  intentionally measure unwrapped wall time.
+- **Adding sccache to the `format` job** — out of scope per spec
+  (`cargo fmt --check` does not compile).
+
+## Decomposition
+
+All edits target the same file (`.github/workflows/ci.yml`). They are
+mechanical and parallel; one commit is appropriate. The task table breaks
+the work into reviewable units rather than separate commits.
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Run registry-query commands to obtain live-current `mozilla-actions/sccache-action` major tag and confirm the action's Node-runtime currency. Record the tag + verification date in the implementation log (and PR body, per AC3). | — (research only) | — |
+| 2 | Insert `Run sccache-cache` step into the `build` job between `Install Rust toolchain` and `Cache dependencies`. | `.github/workflows/ci.yml` | 1 |
+| 3 | Insert `Run sccache-cache` step into the `test` job in the same position. | `.github/workflows/ci.yml` | 1 |
+| 4 | Insert `Run sccache-cache` step into the `clippy` job in the same position. | `.github/workflows/ci.yml` | 1 |
+| 5 | Insert `Run sccache-cache` step into the `docs` job in the same position. | `.github/workflows/ci.yml` | 1 |
+| 6 | Insert `Run sccache-cache` step into the `features` job in the same position. | `.github/workflows/ci.yml` | 1 |
+| 7 | Run `actionlint .github/workflows/ci.yml`; resolve any diagnostics; commit. After push, verify on the PR-CI run that sccache stats are emitted in at least one job log (AC4) and all required checks pass (AC5). | `.github/workflows/ci.yml` | 2, 3, 4, 5, 6 |
+
+Tasks 2–6 are independent edits in different regions of the same file and
+can be applied in one editing pass. They are listed separately so that
+review and (if needed) bisection can isolate any per-job regression.
+
+## Implementation steps
+
+### Step 1 — registry query (run at task time, not pre-resolved here)
+
+Per AGENTS.md § Dependency Versions ("Query the registry before pinning"),
+the implementer runs these commands at task execution time and uses the
+**observed** version, not anything cached in conversation memory or
+training data:
+
+```bash
+# Latest release tag (apply x / 0.x pinning rule per AGENTS.md to the result)
+gh api /repos/Mozilla-Actions/sccache-action/releases --jq '.[0].tag_name'
+
+# Confirm Node-runtime currency on the action's manifest
+gh api /repos/Mozilla-Actions/sccache-action/contents/action.yml --jq '.content' \
+    | base64 -d \
+    | grep -E 'using:|node'
+```
+
+Pin to the **major** the registry returns (e.g. if the tag is `v0.0.9`,
+the design treats this as a `0.x`-style pinning rule and the spec's intent
+is "live-current major"; if Mozilla starts publishing `v1.x.y`, pin `@v1`).
+Record the tag plus the verification date in the PR body for AC3.
+
+If the Node-runtime grep shows a deprecated runtime (Node 16 or earlier),
+flag it before pinning — per AGENTS.md, that is the failure mode the
+runtime check exists to catch.
+
+### Step 2 — edit ci.yml
+
+Add the step block below into each of the five affected jobs, between
+`Install Rust toolchain` and `Cache dependencies`:
+
+```yaml
+- name: Run sccache-cache
+  uses: mozilla-actions/sccache-action@<tag from Step 1>
+```
+
+No `env:` and no `with:` block. The action sets `RUSTC_WRAPPER=sccache`
+and `SCCACHE_GHA_ENABLED=true` itself; both are required and both are the
+defaults.
+
+### Step 3 — verify locally
+
+```bash
+actionlint .github/workflows/ci.yml
+```
+
+Fix any diagnostics before staging. `actionlint` catches indentation
+errors, deprecated action versions, expression-syntax errors, and shell
+quoting issues that `cargo` checks cannot see. Per AGENTS.md, this is a
+required gate.
+
+### Step 4 — verify on PR-CI
+
+After `git push`, on the resulting PR-CI run:
+
+- Open at least one of `Build (ubuntu-latest)`, `Test (ubuntu-latest)`,
+  `Clippy (ubuntu-latest)`, `Docs`, `Feature matrix (*)`. Confirm a step
+  named `Run sccache-cache` ran near the start of the job and a sccache
+  stats block ("Compile requests", "Cache hits", etc.) appears near the
+  end of the log. (sccache-action emits stats automatically by default —
+  no extra step required.) **AC4 satisfied.**
+- Confirm Format, Build, Test, Clippy, Docs, Feature matrix all pass green.
+  **AC5 satisfied.**
+
+## Risks
+
+- **Cache contention with the existing 10 GB GHA repo cache.** The repo
+  already runs cargo cache (multi-OS, several keys), benchmarks, and
+  coverage caches. Adding sccache claims more cache budget. **Mitigation:**
+  ship at default `SCCACHE_CACHE_SIZE` per spec; observe hit rate and
+  eviction churn in the post-merge sccache stats blocks. If churn is
+  visibly high (low hit rate after a warm-up period), tune
+  `SCCACHE_CACHE_SIZE` per OS or evict less-valuable caches first
+  (benchmarks have separate retention policies). Tracked as the spec's
+  first open question.
+- **clippy may not benefit from sccache.** sccache caches `rustc` outputs
+  via `RUSTC_WRAPPER`; `cargo clippy` runs `clippy-driver` (a `rustc`
+  fork) and may or may not drive codegen. Hit rate on the `clippy` job
+  may be substantially lower than `build` / `test`. **Mitigation:**
+  observe in stats; this is acceptance, not a blocker — the spec's second
+  open question already calls this out. If clippy gains nothing and the
+  cache cost is non-trivial, removing sccache from `clippy` only is a
+  cheap follow-up.
+- **`cargo doc` may bypass sccache entirely.** `cargo doc` invokes
+  `rustdoc`, not `rustc`; `RUSTC_WRAPPER` does not wrap `rustdoc`.
+  **Mitigation:** acceptable per spec ("doc may bypass sccache entirely
+  — acceptable if so"). The `docs` job is short anyway.
+- **Action version drift between authoring and merge.** If the spec /
+  design / PR pin lag behind the action's `main` branch by weeks, a
+  reviewer running the registry query later sees a different tag.
+  **Mitigation:** spec mandates live-current tag at task-execution time
+  and explicit citation in the PR body with the verification date.
+- **YAML indentation regressions.** Inserting a step at the wrong indent
+  would silently break a job. **Mitigation:** `actionlint` gate (Step 3).
+- **`RUSTC_WRAPPER` collision.** If a future change adds another
+  `RUSTC_WRAPPER` (e.g. for a custom linker driver), the latter would
+  override sccache and silently disable the layer. **Mitigation:** none
+  pre-emptive; sccache stats showing zero compile requests in a future
+  CI log is the early-warning signal.
+- **Fail-loud consequence.** A transient sccache-action outage (GHA
+  cache backend unavailable) would fail the merge gate. **Mitigation:**
+  spec accepts this trade-off explicitly ("Fail loud — surfaces
+  regressions immediately"). If outages prove repeated, revisit with
+  `continue-on-error: true` as a follow-up.
+
+## Test Design
+
+This task produces only a CI workflow YAML edit — no Rust source changes.
+There is no `#[cfg(test)]` module to write. Validation is CI-level:
+
+**Local lint (mandatory pre-commit):**
+
+- `actionlint .github/workflows/ci.yml` exits 0. Required gate per AGENTS.md.
+
+**Post-push verification on PR-CI (one PR-CI run is sufficient):**
+
+| AC | Verification |
+|---|---|
+| AC1 | Read the diff in the PR: every job in `{build, test, clippy, docs, features}` has a `mozilla-actions/sccache-action@<pinned>` step before its compile step. |
+| AC2 | `actionlint` passed locally before push (Step 3); the GHA workflow validator on push also passes (a syntax error blocks the run from starting). |
+| AC3 | PR body cites the pinned tag and the date the registry query was run. |
+| AC4 | Open any compile job log; locate the `Run sccache-cache` step; locate the end-of-job sccache stats block (the action prints "Compile requests / Cache hits / Cache misses" automatically). One job log suffices. |
+| AC5 | All required checks pass on the PR (Format, Build, Test, Clippy, Docs, Feature matrix). |
+
+**Non-goals for this PR's verification (out of scope per spec):**
+
+- No formal Windows-runtime measurement (≥30% reduction). Spec dropped
+  this; observe in GitHub Actions UI post-merge instead.
+- No comparison run with sccache disabled to A/B the cache-hit rate.
+  First-run stats (cold cache) are not informative; second-run-onwards
+  observation is informal and post-merge.
+
+## Open questions
+
+_(none — spec's two open questions are explicit observe-and-tune
+items for post-merge, not blockers for this design.)_

--- a/ai-docs/plans/done/2026-05-08-ci-sccache.spec.md
+++ b/ai-docs/plans/done/2026-05-08-ci-sccache.spec.md
@@ -1,0 +1,71 @@
+# CI sccache layer for compiler-artefact caching
+
+**Source:** issue #178
+**Date:** 2026-05-08
+**Tracked in:** #178
+
+## Scope
+
+Add [`mozilla-actions/sccache-action`](https://github.com/Mozilla-Actions/sccache-action) to every merge-gate job in `.github/workflows/ci.yml` that compiles Rust. sccache caches compiler output (object files / `rlib`s) keyed on source-content hash — complements the existing `actions/cache@v5` cargo cache, which caches the registry and `target/` keyed on `Cargo.lock` hash. Both layers stay; sccache hits when cargo decides to recompile but the source bytes haven't changed.
+
+In-scope jobs (transitively required for merge per `master` branch-protection list — Format, Build, Test, Clippy, Docs, Feature matrix):
+
+| Job | Matrix? | Compiles Rust? | Add sccache? |
+|---|---|---|---|
+| `build` | ubuntu / macos / windows | ✅ | ✅ |
+| `test` | ubuntu / macos / windows | ✅ | ✅ |
+| `clippy` | ubuntu / macos / windows | ✅ | ✅ |
+| `docs` | ubuntu only | ✅ (`cargo doc`) | ✅ |
+| `features` | matrix | ✅ | ✅ |
+
+## Out of scope
+
+- `format` job in ci.yml — runs `cargo fmt --check` only; no compilation, sccache wouldn't help
+- `*-pass` aggregator jobs (`build-pass`, `test-pass`, `clippy-pass`, `features-pass`, `roadmap-sync-pass`) — pure `needs:`-wait jobs, no compile
+- `roadmap-sync` — runs the gen-roadmap script, no Rust compile
+- `coverage.yml` — does not gate merge; coverage instrumentation may interact with sccache in ways that need separate evaluation
+- `docs.yml` (Pages-deploy workflow) — does not gate merge; rebuilds docs only on master push
+- `base_benchmarks.yml`, `fork_pr_benchmarks_run.yml`, `fork_pr_benchmarks_track.yml` — don't gate merge; benchmark wall-time should be measured on a stable build, not a sccache-affected one
+- Self-hosted sccache backend (S3 / Azure) — overkill at this CI volume
+- Replacing `actions/cache@v5` with `Swatinem/rust-cache@v2` — separate concern, file as follow-up if desired
+
+## Deferred
+
+- `Swatinem/rust-cache@v2` migration | smarter cargo-side caching with better eviction | follow-up issue if observed gain warrants it
+- Coverage workflow sccache integration | needs separate validation that sccache doesn't perturb coverage instrumentation | follow-up
+- Self-hosted sccache backend | only worthwhile at much higher CI volume than this project has | re-evaluate if GHA cache exhaustion becomes an issue
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Which CI workflows get sccache? | Only `ci.yml` merge-gate compile jobs. Other workflows out of scope this PR. |
+| Which sccache backend? | GHA-backed (default for `mozilla-actions/sccache-action`) |
+| Failure mode if sccache breaks at runtime | Fail loud (default sccache-action behaviour) — do NOT add `continue-on-error`. Surfaces regressions immediately. |
+| Formal Windows-runtime measurement (≥30% reduction)? | Dropped — ship and observe in GitHub Actions UI |
+| Cache size tuning (`SCCACHE_CACHE_SIZE`)? | Leave default. Tune later if GHA repo cache (10 GB total) shows pressure. |
+| Action version pinning | Per AGENTS.md § Dependency Versions: registry-query before pinning (`gh api /repos/Mozilla-Actions/sccache-action/releases --jq '.[0].tag_name'`); pin to live-current major. Verify Node-runtime currency on the action's `action.yml`. |
+
+## Technical constraints
+
+- **`actionlint` gate** — per AGENTS.md, every modified `.github/workflows/*.yml` must pass `actionlint` before staging. Required for this PR.
+- **Cargo cache stays** — keep the existing `actions/cache@v5` block in each job. Don't delete or alter it. sccache layers under it: cargo cache covers `target/` and registry; sccache covers compiler output. Complementary.
+- **Per-job placement** — sccache-action's `Run sccache-cache` step must run AFTER `dtolnay/rust-toolchain` and BEFORE the `actions/cache@v5` restore (so cargo cache restore sees `RUSTC_WRAPPER` already set if needed). The action sets `RUSTC_WRAPPER=sccache` automatically.
+- **Matrix consistency** — same sccache version across all matrix entries (no per-OS overrides at this stage). Per-OS tuning is a follow-up if the data warrants it.
+- **No CI volume increase** — adding sccache must not require a new workflow file or new job. Strict in-place modification of `ci.yml`.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | sccache action added to all merge-gate compile jobs in `ci.yml`: `build` (matrix), `test` (matrix), `clippy` (matrix), `docs`, `features` (matrix). Verified by reading the diff: every such job has a `mozilla-actions/sccache-action@<pinned>` step before its compile step. |
+| AC2 | `actionlint .github/workflows/ci.yml` passes clean on the modified file (per AGENTS.md required-gate) |
+| AC3 | sccache-action version pinned to the live-current major: tag pulled via `gh api /repos/Mozilla-Actions/sccache-action/releases --jq '.[0].tag_name'` at task time, not from training memory. Action version explicitly cited in the spec / PR body alongside the date verified. |
+| AC4 | sccache stats visible in job logs on at least one PR-CI run — confirms the cache is wired up and the wrapper is active. (sccache-action emits stats automatically at end-of-job by default.) |
+| AC5 | All required CI checks pass on the PR (Format, Build, Test, Clippy, Docs, Feature matrix). Fail-loud failure mode means a sccache misconfiguration would block merge — by design. |
+
+## Open questions
+
+- **Cache contention with existing 10 GB GHA repo cache** — current cargo cache + sccache cache + benchmarks cache + coverage cache may collectively exceed the GHA repo limit, causing eviction churn that erodes the win. Worth observing post-merge: if cache hit rates show high churn, tune `SCCACHE_CACHE_SIZE` per OS.
+- **Does sccache benefit `cargo clippy`?** — clippy runs the full type-check / borrow-check pipeline; sccache caches up to and including codegen. Clippy may not actually drive codegen, in which case sccache hit rate on the clippy job will be lower than on build/test. Worth observing in stats.
+- **`cargo doc` interaction** — `cargo doc` invokes `rustdoc`, not `rustc` directly. sccache's wrapping is on `rustc` via `RUSTC_WRAPPER`. doc may bypass sccache entirely. Acceptable if so — `docs` job is shorter than build/test anyway.


### PR DESCRIPTION
## Summary

Adds [`mozilla-actions/sccache-action@v0.0.10`](https://github.com/Mozilla-Actions/sccache-action) to every merge-gate job in `ci.yml` that compiles Rust:

- `build` (matrix: ubuntu / macos / windows)
- `test` (matrix: ubuntu / macos / windows)
- `clippy` (matrix: ubuntu / macos / windows)
- `docs`
- `features` (matrix)

sccache caches compiler output (object files / `rlib`s) keyed on source-content hash, **complementing** the existing `actions/cache@v5` cargo cache (kept untouched). When `Cargo.lock` changes and the cargo cache is invalidated, sccache still hits when source bytes haven't changed.

## Per-job change

A single `Run sccache-cache` step inserted between `Install Rust toolchain` and `Cache dependencies`:

```yaml
- name: Install Rust toolchain
  uses: dtolnay/rust-toolchain@stable
- name: Run sccache-cache
  uses: mozilla-actions/sccache-action@v0.0.10
- name: Cache dependencies
  uses: actions/cache@v5
  ...
```

No `env:` or `with:` block — the action sets `RUSTC_WRAPPER=sccache` and `SCCACHE_GHA_ENABLED=true` automatically (defaults match spec).

## Out of scope

- `format` job — `cargo fmt --check` only, no compilation
- `*-pass` aggregator jobs, `roadmap-sync` — no compilation
- `coverage.yml`, `docs.yml`-deploy, benchmarks — don't gate merge
- Self-hosted sccache backend (S3 / Azure)
- Replacing `actions/cache@v5` with `Swatinem/rust-cache@v2` — separate concern, file as follow-up if desired

## Failure mode

Fail-loud (default sccache-action behaviour). A sccache misconfiguration blocks merge by design rather than silently degrading to no-cache builds. No `continue-on-error` added.

## Registry-query verification (AGENTS.md § Dependency Versions)

```bash
$ gh api /repos/Mozilla-Actions/sccache-action/releases --jq '.[0].tag_name'
v0.0.10

$ gh api /repos/Mozilla-Actions/sccache-action/contents/action.yml --jq '.content' | base64 -d | grep -E 'using:|node'
  using: \"node24\"
```

- Latest tag: `v0.0.10` (Mozilla publishes only patch tags; no moving `v0` major-tag exists, so we pin the exact released tag)
- Node runtime: `node24` (current; not deprecated)
- Verified: 2026-05-08

## Tracking

Closes #178.

## Test plan

- [x] AC1 — `mozilla-actions/sccache-action@v0.0.10` step present in `build` (3-matrix), `test` (3-matrix), `clippy` (3-matrix), `docs`, and `features` (matrix) — verified via `grep -c 'mozilla-actions/sccache-action' .github/workflows/ci.yml` = 5
- [x] AC2 — `actionlint .github/workflows/ci.yml` exits 0 (clean)
- [x] AC3 — sccache-action version pinned to `v0.0.10` (live-current; query verified 2026-05-08; node24 runtime current)
- [ ] AC4 — sccache stats block visible in at least one job log on this PR's CI run (post-push verification — sccache-action emits stats automatically)
- [ ] AC5 — All required CI checks (Format, Build, Test, Clippy, Docs, Feature matrix) pass on this PR (post-push verification)
- [x] cargo build clean
- [x] cargo test pass
- [x] cargo fmt --check clean
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo doc --no-deps --workspace clean (RUSTDOCFLAGS=\"-D warnings -D missing-docs\")

## Notes for review

- Risks (per design) — coverage areas to watch on first PR-CI run:
  - **Cache contention** with the 10 GB GHA repo cache shared across cargo cache + sccache cache + benchmarks + coverage. If hit-rate stats show high churn, follow-up issue can tune `SCCACHE_CACHE_SIZE` per OS.
  - **Clippy hit-rate** likely lower than build/test — clippy-driver may not drive codegen; `cargo doc` likely bypasses sccache entirely (rustdoc not rustc). Both are documented as expected and acceptable.
- For AC4 verification, prefer opening a `windows-latest` matrix entry of `build` or `test` (per the design-review's note) — Windows is the OS the issue title singles out, so the same log doubles as the runtime-observation point referenced in the spec.