### PR TITLE
docs(plans): INDEX.md footnote cleanups (maintenance plans + deferred-plans)

### DIFF
--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -87,7 +87,7 @@ core-types ✅
 
 Serialization-layer track (#107) is independent of the dependency chain above and itself blocks #39.
 
-Maintenance plans (cross-cutting, all ✅): code-quality-cleanup, docs-and-facade, public-api-docs, lookup-perf, inline-simple-fns, recursive-inline-annotations, signals-blocked, receiver-guard-auto, connect-queued-codegen, signal-emit-checked, macro-codegen-improvements, object-part-redesign, doc-convention, signal-emit-rename, signal-emit-macro, signal-to-signal, per-thread-event-loops, generic-fn-split, criterion-benchmarks (10 benches; 3 Bencher CI workflows), macro-object-bench (6 macro-derived criterion benches in root facade crate), codegen-simple-marker (dropped `#[inline]` from generated trait-impl methods; added missing `/// _Simple._` to `IntoValue::into_value` trait declaration; 10 codegen tests updated), codegen-inline-concrete-trait-impls (restored `#[inline]` on concrete-struct trait-impl method emissions in all three macro codegen modules; adds `generics` field to `ObjectImplInput`/`MetaEnumInput`; 11 new codegen tests). These touched multiple crates and are not part of the dependency tree.
+Maintenance plans (cross-cutting, all ✅): see [`../context.md` § Maintenance plans](../context.md#maintenance-plans-cross-cutting) for the canonical list. These touched multiple crates and are not part of the dependency tree.
 
 ## Suggested next steps
 

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -63,8 +63,16 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 |------|----------|--------|------------|
 | [paint-style](deferred/2026-05-01-paint-style.spec.md) | `quartzite-paint` `quartzite-style` | 🟡 spec-only | style portion blocked on widgets #46 — tracked in #47; paint-api blocker (#73) ✅ resolved |
 
-> Tracking issues for further deferred items not represented as plans here:
-> #35 (dynamic_properties), #39 (signals_blocked serde — blocked on #107), #48 (BlockingQueued — blocked on per-thread loops ✅ done), #52 (object mobility), #53 (multi-window — blocked on #46, #73), #56 (property extensions), #58 (Python interop), #59 (CI extras), #60 (docs extras), #107 (serialization layer).
+Tracked future work without dedicated specs (cross-cutting items only — not plans). INDEX.md-only footnote; not surfaced in `ROADMAP.md`.
+
+- **#35** dynamic_properties — runtime read/write of non-schema properties
+- **#39** signals_blocked serde (persist across serialization) — blocked on #107
+- **#48** BlockingQueued connection type — ready (per-thread loops ✅ implemented)
+- **#52** object mobility / thread migration with stale `thread_id` invalidation
+- **#53** multi-window support — ready (#46, #73 ✅ implemented)
+- **#56** property system extensions — computed properties / bindings / custom getter/setter closures
+- **#58** Python interop crate (`quartzite-python` via PyO3)
+- **#107** object/property serialization layer (snapshot, save/restore)
 
 ## Dependency order
 


### PR DESCRIPTION
## Summary

Two related INDEX.md footnote cleanups in one PR — both reduce wall-of-text content below the deferred / completed plan tables to scannable shapes, both leave ROADMAP.md unchanged.

### Change 1 — Maintenance plans (cross-reference to context.md)

**Before** (line 90, 1019 chars):

```
Maintenance plans (cross-cutting, all ✅): code-quality-cleanup, docs-and-facade, ... [22 plans] ... These touched multiple crates and are not part of the dependency tree.
```

**After:**

```
Maintenance plans (cross-cutting, all ✅): see [`../context.md` § Maintenance plans](../context.md#maintenance-plans-cross-cutting) for the canonical list. These touched multiple crates and are not part of the dependency tree.
```

INDEX.md's list had drifted from context.md's (after PR #180's restructure): INDEX listed 22, context.md listed 28, with mismatched entries on each side. Mirroring would create two parallel lists that drift again. Instead: deduplicate. context.md is canonical; INDEX.md cross-references it.

### Change 2 — Deferred-plans footnote (blockquote → bullet list + staleness cleanup)

**Before** (single-line blockquote with 10 inline items, including 2 closed and 2 with stale "blocked" notes):

```
> Tracking issues for further deferred items not represented as plans here:
> #35 (dynamic_properties), #39 (...), #48 (BlockingQueued — blocked on per-thread loops ✅ done), #52 (...), #53 (multi-window — blocked on #46, #73), #56 (...), #58 (...), #59 (CI extras), #60 (docs extras), #107 (...).
```

**After:**

```markdown
Tracked future work without dedicated specs (cross-cutting items only — not plans). INDEX.md-only footnote; not surfaced in `ROADMAP.md`.

- **#35** dynamic_properties — runtime read/write of non-schema properties
- **#39** signals_blocked serde (persist across serialization) — blocked on #107
- **#48** BlockingQueued connection type — ready (per-thread loops ✅ implemented)
- **#52** object mobility / thread migration with stale `thread_id` invalidation
- **#53** multi-window support — ready (#46, #73 ✅ implemented)
- **#56** property system extensions — computed properties / bindings / custom getter/setter closures
- **#58** Python interop crate (`quartzite-python` via PyO3)
- **#107** object/property serialization layer (snapshot, save/restore)
```

Cleanup applied alongside format change:
- Drop **#59** (CI extras) — closed (split into #133–#137 per earlier triage)
- Drop **#60** (docs extras) — closed (resolved by project-docs PR #156)
- **#48** BlockingQueued — re-stated as "ready" (per-thread loops ✅ implemented; was previously listed with stale "blocked on" note)
- **#53** multi-window — re-stated as "ready" (#46 widgets ✅; #73 graphics-stack ✅; was previously listed with stale "blocked on #46, #73" note)

10 items → 8 (closed entries dropped).

## Why bullets, not a table for change 2

Tables (lines starting with `|`) would be picked up by `gen-roadmap.sh` and **leak into ROADMAP.md's deferred-plans table**. The script intentionally separates "deferred plans with specs" (table → ROADMAP) from "tracked future work without specs" (footnote → INDEX.md only). Bullets are non-pipe lines; gen-roadmap closes the deferred-plans table-collector at the first such line (same as the existing blockquote did). Preserving that ROADMAP isolation is correct.

## Verification

- `cargo build` clean
- ROADMAP.md unchanged for both changes (gen-roadmap re-run, `git diff --exit-code` clean)
- No incoming refs to either INDEX.md footnote in the wider docs tree (grep verified for both)
- Cross-reference link `../context.md#maintenance-plans-cross-cutting` resolves to the section added in PR #180

## Test plan

- [x] Change 1: INDEX.md maintenance-plans paragraph replaced with 1-line cross-reference
- [x] Change 2: deferred-plans blockquote replaced with paragraph + bullet list
- [x] Closed entries (#59, #60) dropped
- [x] Stale blockers (#48, #53) updated to "ready"
- [x] ROADMAP.md unchanged after both changes
- [x] No incoming refs broken
- [x] `cargo build` clean
