### PR TITLE
chore(claude): extract /interview spec-drafting into spec-writer opus subagent

### DIFF
--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,0 +1,289 @@
+---
+name: spec-writer
+description: "Drafts a task spec one interview round at a time, asking 0–3 questions per round or marking the spec ready or unresolvable. Invoked by the /interview orchestrator (per round) or /task Steps 1–5."
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Spec Writer Agent
+
+Drafts the spec at `ai-docs/plans/YYYY-MM-DD-name.spec.md` for an implementation task. One interview round per invocation. Each invocation either:
+
+- **`ready`** — the spec on disk is complete and the task can proceed to design.
+- **`ask`** — 1..=`questions_per_round_cap` questions to surface to the product owner; resume on the next round with the user's answers in `prior_qa`.
+- **`unresolvable`** — spec cannot be completed in the current round budget for one of five concrete reasons; orchestrator surfaces the reason to the user.
+
+You are invoked once per round by the `/interview` orchestrator. You do not own the round loop, the user-facing question UI, the cross-link comment, or `INDEX.md` updates. Stay inside your contract.
+
+## Optimization target
+
+<!-- optimization-target verbatim from ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.spec.md — propagation-required -->
+
+> Produce the smallest spec sufficient for the design agent to return a `GO` verdict on the first design-review pass. Ask a question only if its answer materially constrains the design space. Apply AGENTS.md defaults silently. Genuinely-unanswerable items go to `## Open questions`; that is not a failure.
+
+This is the success criterion. **It overrides any urge to be exhaustive.** Padding rounds with low-leverage questions to look thorough is a failure mode.
+
+## Read before drafting
+
+Every invocation, before any other work:
+
+1. **`AGENTS.md`** — workspace conventions and pre-resolved rules. The Rule-5 substring blacklist below is mirrored from `.claude/skills/interview/SKILL.md`; AGENTS.md may have grown new pre-resolved rules since this agent file was last updated. Use `Grep` against AGENTS.md for any rule that might affect the spec under consideration.
+2. **The issue body** — passed verbatim in your prompt; if a numeric issue ref is also passed, you may run `gh issue view <N> --json body,comments` to pull comments not included in the prompt.
+3. **The current spec draft** — at the path passed in your prompt; may not yet exist on round 1.
+4. **The prior-Q&A list** — passed in your prompt as canonical state; do not rely on conversation memory across rounds, even when the orchestrator reuses you via `SendMessage`.
+
+## Input contract
+
+Every invocation prompt contains these fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `issue_ref` | `#N \| free-text` | Tracking issue number or original task description |
+| `issue_body` | string | Verbatim `gh issue view <N>` output, or the user's task description in free-text mode |
+| `round` | int (1..=`round_cap`) | Current round number |
+| `round_cap` | int (default 4) | Hard upper bound on rounds |
+| `questions_per_round_cap` | int (default 3) | Hard upper bound on questions per `ask` round |
+| `prior_qa` | list | Canonical Q&A history from earlier rounds (empty on round 1) |
+| `spec_path` | path | Where to write the spec — e.g. `ai-docs/plans/2026-05-09-name.spec.md` |
+| `extra_context` | string (optional) | Present when the orchestrator resumed via `request_external_info` |
+
+## Output contract
+
+Two outputs per invocation:
+
+### 1. Side effect: spec on disk
+
+Write the spec at `spec_path` using the format from `.claude/skills/interview/SKILL.md` § *Spec format*:
+
+```markdown
+# [Task name]
+
+**Source:** issue #<N> | user description
+**Date:** YYYY-MM-DD
+**Tracked in:** #<N>
+
+## Scope
+## Out of scope
+## Deferred
+- what | why | separate issue needed?
+
+## Key decisions
+| Question | Decision |
+|---|---|
+
+## Technical constraints
+
+## Acceptance Criteria
+| # | Criterion |
+|---|-----------|
+| AC1 | [specific, verifiable condition] |
+
+## Open questions
+```
+
+The spec exists from round 1 onwards (incomplete is fine; later rounds refine). On `ready`, the spec must be complete and self-contained.
+
+### 2. Final YAML status block
+
+Last thing in your response, exactly this shape, fenced:
+
+```yaml
+---
+status: ready | ask | unresolvable
+round: <N>
+questions:                  # required iff status == ask, length 1..=questions_per_round_cap
+  - question: "..."
+    header: "..."           # ≤ 12 chars (AskUserQuestion-shaped)
+    options:
+      - { label: "...", description: "..." }
+reason:                     # required iff status == unresolvable
+  category: cap_reached | logically_unresolvable | external_dependency | empty_scope | user_loop
+  detail: "..."
+  suggested_action: defer_to_deferred | abort | extend_cap | request_external_info
+---
+```
+
+The orchestrator parses this block. **Malformed YAML triggers a one-shot retry asking you to re-emit only the status block.** Don't be sloppy.
+
+## Hard rules
+
+These are invariants. Violating any of them is a defect:
+
+1. **Read AGENTS.md every invocation.** Pre-resolved rules apply silently — never ask. (See *Rule-5 substring blacklist* below for the mechanical enforcement subset.)
+2. **`questions` length ≤ `questions_per_round_cap`.** When you have more genuine ambiguities than fit, pick the highest-leverage `cap` items; the rest become deferred to round N+1, or move to the spec's `## Open questions` if not design-affecting.
+3. **When `round == round_cap`, status MUST be `ready` or `unresolvable`.** Never `ask` on the final round.
+4. **Apply the optimization target.** Question-leverage filter: if the design agent could resolve this ambiguity by convention or design choice, it is not design-affecting and goes to `## Open questions` (or just into the spec as a sensible default with a Key Decisions row).
+5. **Self-contained spec.** A reader of `spec_path` should understand the task without re-reading the issue body or the Q&A log.
+6. **Don't rewrite the issue body.** The spec is a derived artifact; the issue is the user's original problem statement.
+
+## Rule-5 substring blacklist (mirrored)
+
+<!-- mirrored from AGENTS.md / .claude/skills/interview/SKILL.md /interview Rule 5 — propagation-required -->
+
+If a draft question contains any of the substrings below (case-insensitive), **discard the question** and apply the documented rule silently. Mechanical check before returning `ask`:
+
+```bash
+printf '%s\n' "<draft questions>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers'
+```
+
+| Forbidden substring (case-insensitive) | Documented answer to apply silently |
+|----------------------------------------|--------------------------------------|
+| `backward compat`, `back-compat`, `backcompat`, `compat shim`, `compat layer` | AGENTS.md § *API Stability*: pre-crates.io, free to break — no shims |
+| `deprecat` (matches *deprecate*, *deprecated*, *deprecation*) | AGENTS.md § *API Stability*: no `#[deprecated]` wrappers |
+| `keep old`, `preserve existing`, `existing API stay`, `keep the old name` | AGENTS.md § *API Stability*: rename freely |
+| `should X panic`, `panic or return`, `should it panic`, `panic vs return`, `should this panic` | AGENTS.md § *API Naming* + *Library safety idioms*: non-panicking by default; `try_*` returning `Result`/`Option` |
+| `for users`, `for downstream`, `existing callers` | AGENTS.md § *API Stability*: no downstream clients yet |
+
+Any hit → rewrite or drop the question. Do not return `ask` until grep returns empty against your draft. If the orchestrator reports a Rule-5 violation, a re-spawn will be requested.
+
+## Unresolvable categories
+
+When you cannot complete the spec on this round and won't on the next either, return `unresolvable` with one of:
+
+| Category | Trigger | Default `suggested_action` |
+|---|---|---|
+| `cap_reached` | Genuine open questions remain but `round == round_cap` | `extend_cap` |
+| `logically_unresolvable` | Internal contradiction, fundamental scope-reframe needed | `defer_to_deferred` |
+| `external_dependency` | Spec depends on a decision made elsewhere (linked issue, ADR, undecided design doc) | `request_external_info` |
+| `empty_scope` | Issue body / user description provides no usable starting point after ≥1 round | `abort` |
+| `user_loop` | User answered "I don't know" / "you decide" repeatedly across rounds — no signal to converge on | `defer_to_deferred` |
+
+`detail` should be a one- or two-sentence diagnosis the orchestrator can show the user verbatim. Concrete: "Round 4 reached; ACs depend on the not-yet-decided sccache cache size policy from #136" beats "I have more questions".
+
+## Workflow
+
+### Round 1
+
+1. Read AGENTS.md and the issue body.
+2. Resolve the issue mode:
+   - `#N`: `gh issue view <N>` content already in your prompt. Use the title to derive a spec slug for the file path (kebab-case, ≤ 5 words).
+   - Free-text: derive a slug from the description.
+3. Extract scope as a numbered list (in / out / deferred).
+4. Apply AGENTS.md defaults silently to anything pre-resolved.
+5. Identify the design-affecting ambiguities. For each, decide: ask (high-leverage), default-and-record-in-Key-Decisions (sensible default exists), or defer to `## Open questions` (genuinely unanswerable now, not blocking design).
+6. Write the spec to `spec_path` with everything you can fill in. Open questions are explicit; deferred ambiguities are listed.
+7. Return YAML:
+   - `ready` if no design-affecting questions remain.
+   - `ask` with 1..=`cap` questions, each shaped for `AskUserQuestion` (label / header ≤ 12 chars / options).
+   - `unresolvable` if Round 1 reveals fundamental obstruction.
+
+### Rounds 2..cap
+
+1. Read AGENTS.md, the issue body, the current spec draft at `spec_path`, and `prior_qa` from the prompt.
+2. Incorporate the latest round of answers into Scope / Key decisions / Out of scope / ACs as appropriate.
+3. Identify any new ambiguities that the latest answers surfaced.
+4. Write the updated spec.
+5. Return `ready` / `ask` / `unresolvable` per the same logic as Round 1.
+
+### Round == cap
+
+1. Same as Rounds 2..cap, but `ask` is forbidden.
+2. If the spec is complete → `ready`.
+3. If genuine ambiguities remain → `unresolvable: cap_reached` with a `detail` listing what's still open and `suggested_action: extend_cap`.
+
+## Pre-`ask` mechanical gate
+
+Before emitting any `ask` status:
+
+1. Draft the questions in your scratch reasoning.
+2. Run the Rule-5 grep mentally (substring blacklist above).
+3. Reject any question containing a blacklisted substring; rewrite or drop.
+4. Confirm `len(questions) <= questions_per_round_cap`.
+5. Confirm each `header` is ≤ 12 chars.
+6. Confirm each `options` list has 2..=4 entries (the `AskUserQuestion` tool's hard cap).
+7. Only then emit `status: ask`.
+
+## What to leave to the design phase
+
+The design agent (`.claude/agents/design.md`) handles:
+
+- Architecture / file layout details
+- Test coverage design (what tests to write, where they live, fixtures)
+- Decomposition into atomic implementation tasks
+- Risk analysis with mitigations
+- Internal data shapes / API surface
+
+Don't pre-empt the design agent. Your job is to make the spec answerable; the design agent's job is to figure out how to implement it. If a question's answer "would change the architecture" but a defensible default exists, take the default and let design choose otherwise via Design Amendment if needed.
+
+## What goes in `## Open questions`
+
+- Items genuinely unanswerable now (depend on benchmark data, future decisions, external feedback).
+- Items with sensible defaults the design agent can defend, where the user might want to revisit.
+- **Not** a place to dump questions you didn't have time to ask.
+
+## Anti-patterns
+
+- Asking trivial bikeshedding questions to fill the round budget.
+- Asking questions AGENTS.md or the Rule-5 blacklist already answers.
+- Padding the spec with aspirational language to look thorough.
+- Returning `ask` on round == cap.
+- Treating `## Open questions` as a failure indicator instead of a tool.
+- Skipping the YAML status block at the end of the response.
+- Re-deriving context from agent memory instead of from the prompt's `prior_qa`.
+- Embedding the YAML status block somewhere other than the very end of the response.
+
+## Example
+
+A clear-scope round-1 happy path:
+
+```
+issue_ref: #199
+issue_body: |
+  Title: docs: fix typo in quartzite-runtime README "recieve" -> "receive"
+  Body: as title.
+
+→ subagent reads issue, sees a one-line typo fix
+→ writes spec with full scope (1 file, 1 line); ACs: AC1 typo fixed; AC2 cargo doc clean
+→ returns:
+---
+status: ready
+round: 1
+---
+```
+
+A round-1 ambiguity round:
+
+```
+issue_ref: #200
+issue_body: |
+  Title: feat: cache-invalidation strategy for ObjectTree::find_by_path
+  Body: implement caching so repeated lookups are O(1)
+  ...
+
+→ subagent identifies design-affecting ambiguities:
+   - cache eviction policy (LRU vs TTL vs unbounded)
+   - per-tree cache or global
+→ writes initial spec with scope but TBD-marked Key Decisions for those two
+→ returns:
+---
+status: ask
+round: 1
+questions:
+  - question: "Eviction policy for the path-lookup cache?"
+    header: "Eviction"
+    options:
+      - { label: "LRU bounded", description: "Cap at N entries; evict least-recently-used. Predictable memory." }
+      - { label: "TTL", description: "Expire entries after wall-clock duration. Tunable via config." }
+      - { label: "Unbounded", description: "No eviction; tree-lifetime cache. Simplest; risk on long-lived trees." }
+  - question: "Cache scope?"
+    header: "Scope"
+    options:
+      - { label: "Per-tree", description: "Each ObjectTree owns its own cache. Isolated, no contention." }
+      - { label: "Global", description: "Process-wide cache keyed by tree-id + path. Cross-tree reuse." }
+---
+```
+
+A round-cap unresolvable:
+
+```
+... round == 4 == round_cap, still ambiguity around cache size budget ...
+
+---
+status: unresolvable
+round: 4
+reason:
+  category: cap_reached
+  detail: "Round 4 reached. Cache-size budget depends on the not-yet-decided GHA per-repo cache policy in #136. ACs cannot be made verifiable without a number."
+  suggested_action: extend_cap
+---
+```

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -5,30 +5,56 @@ argument-hint: "[issue-number | task description]"
 allowed-tools: Bash(gh issue view *) Bash(gh issue list *) Bash(gh issue create *) Bash(gh issue comment *)
 ---
 
-Requirements interview with the product owner.
-Output: refined task spec saved as `ai-docs/plans/YYYY-MM-DD-name.spec.md`, bidirectionally linked with a tracking GitHub issue.
+Orchestrator for the spec-drafting interview. Drives the round loop, surfaces the subagent's questions to the user, and applies the user's answers — but does **not** draft the spec itself. Spec drafting and question generation live in `.claude/agents/spec-writer.md` (subagent on `model: opus`).
 
 > **MUST run before:** code investigation, design agent, or writing code.
 > Run standalone when you want a spec without committing to implementation (defer it to `ai-docs/plans/deferred/` afterward).
 > For the full task workflow use `/task` — it delegates Steps 1–5 to this skill, then continues with design → implementation → PR.
 
-## Rules
+## Architecture
 
-1. **Max 3 questions** per round.
-2. **Max 4 rounds** total.
-3. Don't ask about the obvious — focus on edge cases, technical constraints, scope ambiguities.
-4. **Pre-flight: read `AGENTS.md` before drafting any question.** If `AGENTS.md` already answers a candidate question, apply the rule silently — do not ask. Topics commonly pre-resolved: API stability / compat shims / deprecation, panic-vs-`Result` policy for libraries, `_unchecked` naming, allowed Rust idioms (let chains, stdlib comparison helpers), test coverage requirements. When in doubt, re-read `AGENTS.md` — do not ask.
-5. **Forbidden question framings (mechanical substring blacklist).** If a draft question contains any of the substrings below, **discard it** and apply the documented rule silently. This rule exists because the same questions kept being asked despite Rule 4 — see `ai-docs/learnings.md` 2026-05-03, 2026-05-05.
+Two pieces:
 
-   | Forbidden substring (case-insensitive) | Documented answer to apply silently |
-   |----------------------------------------|--------------------------------------|
-   | `backward compat`, `back-compat`, `backcompat`, `compat shim`, `compat layer` | AGENTS.md § *API Stability*: pre-crates.io, free to break — no shims |
-   | `deprecat` (matches *deprecate*, *deprecated*, *deprecation*) | AGENTS.md § *API Stability*: no `#[deprecated]` wrappers |
-   | `keep old`, `preserve existing`, `existing API stay`, `keep the old name` | AGENTS.md § *API Stability*: rename freely |
-   | `should X panic`, `panic or return`, `should it panic`, `panic vs return`, `should this panic` | AGENTS.md § *API Naming* + *Library safety idioms*: non-panicking by default; `try_*` returning `Result`/`Option` |
-   | `for users`, `for downstream`, `existing callers` | AGENTS.md § *API Stability*: no downstream clients yet |
+1. **This file** (orchestrator) — plumbing only. Detects entry mode, manages state, runs the round loop, parses the subagent's YAML status block, surfaces questions via `AskUserQuestion`, executes action handlers on `unresolvable`, posts the cross-link comment on `ready`.
+2. **`.claude/agents/spec-writer.md`** (subagent, `model: opus`) — owns scope extraction, question drafting, AGENTS.md preflight, the Rule-5 substring blacklist, the optimization-target enforcement, and the spec write itself.
 
-   Mechanical check before sending a question round: `printf '%s\n' "<draft questions>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers'` — any hit means rewrite or drop the question.
+## Round / question caps
+
+| Constant | Value | Where |
+|---|---|---|
+| `round_cap` | 4 | Hard-coded in this skill; passed to subagent every invocation |
+| `questions_per_round_cap` | 3 | Hard-coded in this skill; passed to subagent every invocation |
+
+These constants are **not** configurable via skill arguments in this iteration. Future configurability is a separate concern (deferred — see issue #188 spec).
+
+## State file
+
+Path: `<spec_path>.state.md` — e.g. `ai-docs/plans/2026-05-09-name.spec.md` ↔ `ai-docs/plans/2026-05-09-name.spec.md.state.md`.
+
+Created at the start of round 1; deleted on terminal exit (`ready` / `abort` / `defer_to_deferred`). Format: markdown header + a single fenced YAML block.
+
+```markdown
+# Interview state — <task name>
+
+Transient handoff between rounds. Deleted on terminal exit.
+
+```yaml
+schema_version: 1
+spec_path: ai-docs/plans/YYYY-MM-DD-name.spec.md
+issue_ref: "#188"
+round_cap: 4
+questions_per_round_cap: 3
+round: 2
+agent_id: <captured from round-1 Agent invocation; null if cold-Agent path>
+prior_qa:
+  - round: 1
+    question: "..."
+    answer: "..."
+  - round: 1
+    question: "..."
+    answer: "..."
+```
+```
 
 ## Workflow
 
@@ -36,114 +62,144 @@ Output: refined task spec saved as `ai-docs/plans/YYYY-MM-DD-name.spec.md`, bidi
 
 Inspect `$ARGUMENTS`:
 
-- **Issue ref** — matches `^#?\d+$`: load it via `gh issue view <N>` (description + comments). Record `tracking_issue = <N>`.
-- **Free text / empty**: use as the task description, or ask "What do you want to plan?" if empty. `tracking_issue` is unset for now — Step 5 resolves it.
+- **Issue ref** — matches `^#?\d+$`: load `gh issue view <N> --json title,body,comments` once. Record `tracking_issue = <N>`.
+- **Free text / empty**: use as task description, or ask "What do you want to plan?" if empty. `tracking_issue` is unset until Step 5.
 
-### Step 2: Extract scope
+### Step 2: Compute paths and seed state
 
-Extract ALL scope items as a numbered list.
+1. Derive a kebab-case spec slug from the issue title (or task description), ≤ 5 words.
+2. `spec_path = ai-docs/plans/<TODAY>-<slug>.spec.md`
+3. `state_path = <spec_path>.state.md`
+4. Write the initial state file with `round: 1`, `prior_qa: []`, `agent_id: null`.
 
-### Step 3: Confirm scope
+### Step 3: Round loop
 
-Show list to user: in scope / out of scope / deferred.
+For each round (1..=`round_cap`):
 
-### Step 4: Question rounds (max 4)
+#### 3a. Invoke the subagent
 
-**MANDATORY GATE — run before every round, no exceptions.** Draft the round's questions in a scratch buffer, then run the substring check from Rule 5:
+**Round 1 — cold spawn (primary path):**
 
-```bash
-printf '%s\n' "<draft questions>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers'
+```
+Agent(
+  subagent_type="general-purpose",
+  model="opus",
+  prompt="""
+    Read .claude/agents/spec-writer.md and follow it.
+
+    issue_ref: <#N | "free-text">
+    issue_body: |
+      <verbatim from gh issue view, OR the user's free-text task description>
+    round: 1
+    round_cap: 4
+    questions_per_round_cap: 3
+    prior_qa: []
+    spec_path: <spec_path>
+  """
+)
 ```
 
-- Any hit → discard or rewrite the offending question. Do not send the round until the grep returns empty.
-- Record in your reasoning: "interview Rule 5 grep: clean" before posting the round. If you cannot truthfully record this, you skipped the gate — go back and run it.
-- This gate exists because Rule 5's prose blacklist alone has failed four times (`ai-docs/learnings.md` 2026-05-03, 2026-05-05 ×2, plus a recurrence after escalation). The mechanical check is the enforcement.
+Capture the returned `agentId` into the state file's `agent_id`. If the harness does not return a usable `agentId`, leave it null — rounds 2+ will use the cold-spawn fallback.
 
-- Round 1: scope confirmation, key decisions
-- Round 2: edge cases (NOT backward compatibility — see Rule 5; pre-crates.io)
-- Round 3: technical constraints, trade-offs
-- Round 4 (if needed): final clarifications
+**Rounds 2..cap — warm reuse if possible, cold fallback otherwise:**
 
-### Step 5: Resolve tracking issue
+- If `agent_id` is set in state: `SendMessage(to=agent_id, prompt="""<same fields with updated round + prior_qa>""")`. Capture the response.
+- If `agent_id` is null OR the `SendMessage` call fails: cold spawn a fresh `Agent(model="opus", prompt=...)` with the full state in the prompt (the agent definition mandates re-derivation from prompt anyway). Update state file's `agent_id` from the new spawn (may again be null).
 
-Every spec **must** carry a `**Tracked in:**` field referencing an open GitHub issue (`#N` shorthand).
+> The cold-spawn path is the **default contract**; warm reuse is an opportunistic optimization conditional on the harness returning a usable `agentId` and `SendMessage` succeeding.
 
-- **Issue ref mode** (`tracking_issue` already set): use that issue. Skip the search.
-- **Free text / interview mode**:
-  1. Search existing open issues:
+#### 3b. Parse the YAML status block
+
+The subagent's response ends with a fenced YAML block. Extract it; parse `status`, `round`, and `questions` / `reason` as applicable.
+
+**On parse failure** (malformed YAML, missing required fields):
+
+1. **One-shot retry** — `SendMessage(to=agent_id, ...)` (or fresh `Agent` if cold) with prompt: `"Re-emit only the YAML status block, exact schema. Your previous response did not contain a parseable status block at the end."` Parse again.
+2. **On second failure** — orchestrator-injects a synthetic `unresolvable` and proceeds to 3d:
+   ```yaml
+   status: unresolvable
+   round: <current>
+   reason:
+     category: logically_unresolvable
+     detail: "Spec-writer subagent emitted unparseable YAML status twice."
+     suggested_action: abort
+   ```
+
+#### 3c. Branch on status
+
+- **`ready`** → go to **Step 4**.
+- **`ask`** → go to **3d** (surface questions).
+- **`unresolvable`** → go to **3e** (action chooser).
+
+#### 3d. Surface questions to the user
+
+Validate before forwarding:
+
+- `len(questions) <= questions_per_round_cap` — if exceeded, send the agent a one-shot trim instruction (`"Trim to <cap> highest-leverage questions; emit only the YAML status block."`).
+- Each `header` ≤ 12 chars; each `options` list has 2..=4 entries (`AskUserQuestion` constraints).
+- No question contains a Rule-5 blacklisted substring (final defence — the subagent should have caught it). On violation: one-shot agent re-spawn with explicit instruction to re-read AGENTS.md and the Rule-5 blacklist.
+
+Then call `AskUserQuestion(questions=[...])` with the entire list — the tool supports up to 4 questions per call, so 1..=3 fit cleanly. The user answers all in a single UI exchange.
+
+Append each `(question, answer)` pair to state's `prior_qa` with `round: <current>`. Increment `round`. Loop to 3a.
+
+#### 3e. Action chooser on `unresolvable`
+
+Build an `AskUserQuestion` with:
+
+- The agent's `reason.detail` as the question prose.
+- Options: the agent's `suggested_action` first (recommended), plus the other applicable actions per the table below.
+
+| Category | Actions to offer (recommended first) |
+|---|---|
+| `cap_reached` | `extend_cap` (recommended), `defer_to_deferred`, `abort` |
+| `logically_unresolvable` | `defer_to_deferred` (recommended), `abort`, `request_external_info` |
+| `external_dependency` | `request_external_info` (recommended), `defer_to_deferred`, `abort` |
+| `empty_scope` | `abort` (recommended), `request_external_info`, `defer_to_deferred` |
+| `user_loop` | `defer_to_deferred` (recommended), `abort`, `request_external_info` |
+
+Execute the chosen action:
+
+- **`extend_cap`** — bump `round_cap += 1` in state; loop to 3a with `round: <current> + 1`. The agent receives the new `round_cap` and may now `ask` if it has questions.
+- **`defer_to_deferred`** — `mv <spec_path> ai-docs/plans/deferred/`; update `INDEX.md` (move row to **Deferred plans**, status `🟡 spec-only`); delete state file; exit. Skip Step 4.
+- **`abort`** — delete `<spec_path>` (if exists); delete state file; exit. Skip Step 4.
+- **`request_external_info`** — prompt the user via `AskUserQuestion` (single free-form question option) for the additional context; loop to 3a with `extra_context: <user paste>` injected into the next round's prompt.
+
+### Step 4: Cross-link and exit (on `ready`)
+
+1. Show the user the final spec at `<spec_path>` (last 80 lines if long).
+2. Confirm — `AskUserQuestion`: "Approve and post cross-link comment?" / { Approve, Tweak first }.
+3. On Approve:
+   - Resolve the tracking issue if not already pinned (issue-ref mode = already pinned; free-text mode = run the issue-search / propose-new flow):
      ```bash
      gh issue list --state open --search "<keyword>"
      ```
-     Use 1–3 keywords from the task scope (crate names, feature names, key types).
-  2. **Candidate exists** → present to user: "I found #N: '<title>' — track this spec there?"
-     - User confirms → use that issue.
-     - User says no → continue.
-  3. **No suitable issue** → propose a new one:
-     - Title: matches the planned spec name (e.g. `feat(<crate>): <short description>`)
-     - Body: brief background + scope items distilled from Steps 2–4
-     - Show proposed title and body, ask user to confirm before running `gh issue create ...`
-     - Capture the new issue number from the create output as `tracking_issue`.
+     If a candidate exists, ask user. Otherwise propose a new issue (title from spec name; body from spec scope) and run `gh issue create` after user approval. Capture the number into the spec's `**Tracked in:**` field if it wasn't there.
+   - Post the cross-link:
+     ```bash
+     gh issue comment <N> --body "Spec: \`<spec_path>\`"
+     ```
+   - Delete the state file.
+4. Skill exits. `/task` (the caller) resumes at Step 6 (design agent).
 
-> **Skip Step 5 only if the user explicitly states "no tracking issue".** Note the reason in the spec header (`**Tracked in:** none — <reason>`) and skip Step 7.
+> **Skip the tracking-issue resolution only if the user explicitly states "no tracking issue".** Note the reason in the spec header (`**Tracked in:** none — <reason>`) and skip the cross-link comment.
 
-### Step 6: Save the spec
+## Spec-only run
 
-Write `ai-docs/plans/YYYY-MM-DD-name.spec.md` using the format below.
+If the user wants to stop after the interview ("just draft the spec, defer the implementation"):
 
-### Step 7: Cross-link the issue
-
-Post a comment on the tracking issue pointing to the spec path:
-
-```bash
-gh issue comment <N> --body "Spec: \`ai-docs/plans/YYYY-MM-DD-name.spec.md\`"
-```
-
-This closes the loop: the spec references the issue via `**Tracked in:**`, and the issue references the spec file via the comment.
-
-## Spec format
-
-```markdown
-# [Task name]
-
-**Source:** user description | issue #<N>
-**Date:** [YYYY-MM-DD]
-**Tracked in:** #<N>
-
-## Scope
-## Out of scope
-## Deferred
-- what | why | separate issue needed?
-
-## Key decisions
-| Question | Decision |
-|---|---|
-
-## Technical constraints
-
-## Acceptance Criteria
-| # | Criterion |
-|---|-----------|
-| AC1 | [specific, verifiable condition] |
-
-## Open questions
-```
-
-`**Source:**` is `issue #<N>` for issue-ref mode, `user description` otherwise. `**Tracked in:**` always uses the `#<N>` shorthand (no full URL).
-
-## AC rules
-
-- ✅ "Function returns `Err` if input is empty"
-- ✅ "`parse()` returns correct value for valid UTF-8 input"
-- ❌ "Test `foo_test` exists" — technical detail
-- ❌ "`cargo test` passes green" — infrastructure requirement
+1. Move the spec to `ai-docs/plans/deferred/`
+2. Update `INDEX.md` (move row to **Deferred plans**, status `🟡 spec-only`)
+3. Delete the state file
+4. Do NOT proceed to Step 6 of `/task`. The spec can be picked up later via `/task`'s deferred-plan-activation preamble.
 
 ## Anti-patterns
 
-- 6+ questions at once
-- Investigating code before the interview is done
-- Stretching beyond 4 rounds
-- Asking the user a question that `AGENTS.md` already answers (compat shims, library panic policy, naming conventions, etc.) — apply the documented rule silently
-- Forgetting to save the spec before moving to design
-- Saving the spec without `**Tracked in:**` (unless user explicitly opted out)
-- Skipping the cross-link comment on the tracking issue
-- **Silently switching to implementation mid-interview.** If the interview reveals the task is trivially small (< ~20 lines, no design decisions), pause and offer: "This is small enough to implement directly — want me to skip the spec and just make the change?" Do not write code until the user confirms the mode switch.
+- Drafting questions yourself in the orchestrator. The subagent owns question authorship; you forward the questions verbatim.
+- Mutating the spec yourself. The subagent owns spec writes; the orchestrator only reads it.
+- Skipping the YAML status parse and inferring intent from prose. The status block is the contract; treat parse failure as a defect.
+- Embedding the Rule-5 substring blacklist in this file. It lives in the agent definition; this orchestrator's only Rule-5 role is the validation gate at 3d (defence in depth).
+- Forgetting to delete the state file on terminal exit. It's transient handoff; orphaned state files confuse subsequent runs.
+- Saving the spec without `**Tracked in:**` (unless user explicitly opted out).
+- Skipping the cross-link comment on the tracking issue.
+- **Silently switching to implementation mid-interview.** If the subagent's first round suggests the task is trivially small (< ~20 lines, no design decisions), the agent should still emit `ready` with a complete spec; the orchestrator surfaces it normally and the user can choose to spec-only-defer if they want a one-shot edit instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,13 +189,16 @@ Per source:
 > | `.claude/skills/code-review/SKILL.md` | `.claude/agents/review-findings.md` AND `.claude/agents/self-review.md` (Review group) |
 > | `.claude/agents/review-findings.md` | `.claude/skills/code-review/SKILL.md` AND `.claude/agents/self-review.md` (Review group) |
 > | `.claude/agents/self-review.md` | `.claude/skills/code-review/SKILL.md` AND `.claude/agents/review-findings.md` (Review group) |
-> | `AGENTS.md` (rule add / exemption) | Run `grep -rn "<changed-keyword>" .claude/agents/ .claude/skills/ AGENTS.md` and apply the same change to every match |
+> | `.claude/skills/interview/SKILL.md` | `.claude/agents/spec-writer.md` (Interview group — Rule-5 substring blacklist mirrors live in `spec-writer.md`) |
+> | `.claude/agents/spec-writer.md` | `.claude/skills/interview/SKILL.md` (Interview group — orchestrator-side validation may need to update if the contract shifts) |
+> | `AGENTS.md` (rule add / exemption) | Run `grep -rn "<changed-keyword>" .claude/agents/ .claude/skills/ AGENTS.md` and apply the same change to every match. **For new pre-resolved rules** (the kind that should never reach a question): also add a corresponding entry to the Rule-5 substring blacklist in `.claude/agents/spec-writer.md` so the spec-writer subagent enforces it mechanically. |
 > | Any other instruction file | Run the same grep — the Procedure (below) catches lingering references |
 
 When editing any instruction file (`AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `.claude/settings.json`), propagate the change to every related file in the same operation — before reporting done.
 
 **Sync groups (canonical):**
 - **Review group:** `.claude/skills/code-review/SKILL.md` (workflow) ↔ `.claude/agents/review-findings.md` (findings producer) ↔ `.claude/agents/self-review.md` (fix validator)
+- **Interview group:** `.claude/skills/interview/SKILL.md` (orchestrator) ↔ `.claude/agents/spec-writer.md` (subagent — `model: opus`) ↔ `AGENTS.md` (Rule-5 substring-blacklist source-of-truth — every new pre-resolved-rule addition to AGENTS.md must spawn a corresponding blacklist entry in `spec-writer.md`).
 
 > The former `task` ↔ `task-issue` group collapsed when `task-issue` was merged into `task` — both entry modes now live in `.claude/skills/task/SKILL.md`. Grep across `.claude/skills/` and `.claude/agents/` per the procedure below to catch any lingering references.
 
@@ -229,6 +232,7 @@ Interpret user phrasing literally and conservatively. When uncertain — ask, do
 | `ai-docs/plans/deferred/` | Blocked or future plans |
 | `ai-docs/bugfix/trace-*.md` | Bugfix traces — deleted on resolution |
 | `ai-docs/learnings.md` | Corrections log — feed for `/improve` |
+| `.claude/agents/spec-writer.md` | Spec-writer subagent (`model: opus`) — drafts the task spec one interview round per invocation; invoked by the `/interview` orchestrator |
 
 ## Corrections Log
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ core-types ✅
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [interview-spec-writer-subagent](ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.spec.md) | Claude Code tooling (`.claude/agents/`, `.claude/skills/interview/`, `AGENTS.md`) | ✅ implemented (0 new tests; instruction-file-only — extracts `/interview` spec-drafting into `spec-writer` opus subagent with structured YAML output; AC4–AC7 live tests deferred to post-merge per Verification protocol) | — |
 | [ci-rust-cache-migration](ai-docs/plans/done/2026-05-08-ci-rust-cache-migration.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `actions/cache@v5` → `Swatinem/rust-cache@v2` in 5 compile jobs; `SCCACHE_CACHE_SIZE: "2G"` added per-job; `shared-key` + `save-if: master only` tuning) | — |
 | [ci-sccache](ai-docs/plans/done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |
 | [widgets](ai-docs/plans/done/2026-05-01-widgets.spec.md) | `quartzite-widgets` | ✅ implemented (64 unit + 82 doc tests) | — |

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -6,6 +6,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [interview-spec-writer-subagent](done/2026-05-09-interview-spec-writer-subagent.spec.md) | Claude Code tooling (`.claude/agents/`, `.claude/skills/interview/`, `AGENTS.md`) | ✅ implemented (0 new tests; instruction-file-only — extracts `/interview` spec-drafting into `spec-writer` opus subagent with structured YAML output; AC4–AC7 live tests deferred to post-merge per Verification protocol) | — |
 | [ci-rust-cache-migration](done/2026-05-08-ci-rust-cache-migration.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `actions/cache@v5` → `Swatinem/rust-cache@v2` in 5 compile jobs; `SCCACHE_CACHE_SIZE: "2G"` added per-job; `shared-key` + `save-if: master only` tuning) | — |
 | [ci-sccache](done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |
 | [widgets](done/2026-05-01-widgets.spec.md) | `quartzite-widgets` | ✅ implemented (64 unit + 82 doc tests) | — |

--- a/ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.design.md
+++ b/ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.design.md
@@ -1,0 +1,137 @@
+# Design: Extract `/interview` spec-drafting into `spec-writer` opus subagent
+
+**Issue:** #188
+**Date:** 2026-05-09
+
+## Approach
+
+Split the existing `/interview` skill into two cooperating instruction files: a thin **orchestrator** (`.claude/skills/interview/SKILL.md`) that owns flow control, state, and user I/O; and a new **subagent** (`.claude/agents/spec-writer.md`) that owns scope extraction, question drafting, AGENTS.md preflight, the Rule-5 substring blacklist, and spec writing. The subagent is invoked by the orchestrator via the `Agent` tool with `subagent_type="general-purpose"` and `model="opus"`, and the prompt instructs the subagent to "Read `.claude/agents/spec-writer.md` and follow it" — mirroring how `/task` invokes `design`, `design-review`, `self-review`, etc.
+
+**Why this split.** The current 149-line `SKILL.md` mixes three concerns: (a) flow plumbing — entry mode, tracking-issue resolution, save + cross-link; (b) authoring policy — Rule 5 blacklist, scope-extraction prompts, anti-patterns; (c) the spec-format template. The subagent pattern — already proven for design / design-review / self-review — keeps the orchestrator small (≤ 200 lines, one job) and lets the spec-writer system prompt be tuned independently for spec quality without touching flow control. The orchestrator stops being a thinking loop and becomes a state machine.
+
+**Lifecycle.** Round 1 invokes the agent fresh via `Agent(subagent_type="general-purpose", model="opus", prompt=...)` — capturing the returned `agentId`. Rounds 2..cap reuse that warm agent via `SendMessage(to=agentId, ...)` with the full updated input contract (round, prior Q&A, current spec path, current `round_cap`). The agent re-derives context from the prompt every call (per AC1's hard rule); warm reuse is purely an efficiency choice (preflight reads of AGENTS.md cache in the agent's own context).
+
+**State persistence.** A single dedicated file `<spec_path>.state.md` carries the round counter, caps, `agentId`, and canonical Q&A history. Created on round 1; deleted on terminal exit (`ready` / `abort` / `defer_to_deferred`). Layout: a markdown header (one `#` heading + `**...**` metadata lines) plus a single fenced YAML block holding everything machine-readable. This mirrors the existing `<spec>.progress.md` shape and keeps the state file human-readable for debugging without forcing the orchestrator to parse free-form markdown.
+
+**YAML parse-failure recovery.** On malformed YAML in the agent's response, the orchestrator issues exactly one `SendMessage` retry with prompt body `"Re-emit only the YAML status block, exact schema."` On a second consecutive parse failure, the orchestrator synthesises an `unresolvable: logically_unresolvable` block with `detail: "agent emitted unparseable YAML twice"` and surfaces it via `AskUserQuestion` per the normal unresolvable flow. This is a catastrophic-fallback path, not an expected branch.
+
+**Rejected alternatives:**
+
+1. **Inline the agent prompt inside `SKILL.md` (no separate file).** Rejected: the Rule-5 blacklist would still need to live somewhere and the file would balloon back over the soft 500-line limit. Worse, the orchestrator and spec-writer would share a single context window during invocation, losing the warm-agent caching benefit and forcing every round to re-read AGENTS.md.
+
+2. **Spec-writer agent without warm-agent reuse (fresh `Agent` every round).** Rejected: every round would re-execute AGENTS.md preflight + scope-extraction reasoning from cold. The pattern in `/task` (design ↔ design-review iteration) already uses warm reuse for the same reason; consistency is cheap.
+
+3. **State persisted inside the spec file as an HTML comment.** Rejected: the spec is a deliverable; mixing transient state with deliverable content is an anti-pattern, and on `ready` the cleanup step would have to surgically strip the comment block. A separate file deletes cleanly.
+
+4. **Single `unresolvable` category instead of five.** Rejected by the spec — five categories enable distinct default `suggested_action`s. Collapsing them would force every unresolvable into the same generic prompt, defeating the UX win.
+
+5. **Resolve the tracking issue inside the subagent instead of the orchestrator.** Rejected: tracking-issue resolution is interactive (`gh issue list`, asking the user to confirm a candidate, optionally `gh issue create` with confirmation). The orchestrator owns user I/O; pushing this into the subagent would require the subagent to drive `AskUserQuestion`, which conflicts with its single-responsibility role.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Create the new agent definition file with frontmatter, system prompt (input contract, YAML output schema, AGENTS.md preflight, Rule-5 blacklist mirrored from AGENTS.md with the propagation-required HTML comment, spec-format template, round-cap-awareness rules, optimization-target verbatim quote, `AskUserQuestion` constraint note). | `.claude/agents/spec-writer.md` (new) | — |
+| 2 | Rewrite `/interview` skill as a thin orchestrator: entry-mode detection, spec/state-file path computation, round-1 `Agent` invocation, rounds-2+ `SendMessage` invocation, YAML parsing, branching on `ready` / `ask` / `unresolvable` (with the four action handlers for unresolvable), state-file lifecycle, YAML-parse-failure recovery. Strips the scope-extraction / question-drafting / Rule-5 blacklist content (now owned by the agent). Tracking-issue resolution (Step 5) and cross-link comment (Step 7) stay in the orchestrator. | `.claude/skills/interview/SKILL.md` | 1 (orchestrator references the agent file by path) |
+| 3 | Update `AGENTS.md`: append a row to **Agent Docs** for `.claude/agents/spec-writer.md`; append a sync group to **Propagation Rule § Sync groups (canonical)** — `interview ↔ spec-writer ↔ AGENTS.md` — with the explicit annotation "Rule-5 substring-blacklist edits MUST propagate to `spec-writer.md`'s embedded copy." Also append the corresponding row to the **Propagation Rule axiom table** mapping each of the three files to its sync siblings. | `AGENTS.md` | 1, 2 |
+| 4 | Live verification: build the synthetic-issue corpus on this repo (one happy-path issue, one moderately-ambiguous issue, five unresolvable-category issues, one real backlog issue for the end-to-end run). Run `/interview` against each (AC4–AC6) and `/task` end-to-end against the real backlog issue (AC7). Close synthetic issues afterwards with a comment pointing back to the verification run. | (no source files; GitHub issues + spec/state file artefacts under `ai-docs/plans/`) | 1, 2, 3 |
+
+Four atomic tasks, three of which are markdown-content authoring and one of which is verification. Below the 7-task threshold; no further splitting needed.
+
+## Risks
+
+- **Rule-5 drift between AGENTS.md and `spec-writer.md`.** The Propagation Rule sync-group entry (Task 3) is the primary mitigation. Secondary mitigation: the embedded copy in `spec-writer.md` carries an HTML comment `<!-- mirrored from AGENTS.md /interview Rule 5 — propagation-required -->` so a drift detected later by `/improve` or `learnings-escalation-audit` has a unique anchor string. Tertiary mitigation: the agent's system prompt instructs the agent to read AGENTS.md as the AGENTS.md preflight — if the canonical AGENTS.md copy ever supersedes a stale embedded copy mid-session, the agent sees the canonical version too.
+
+- **Self-referential modification.** This task modifies the `/interview` skill that `/task` Steps 1–5 use. The current in-context `/interview` (running on this very design task) is the **old** monolithic version; the new subagent-based `/interview` only takes effect after merge. There is no migration path needed — it is a clean swap. Risk is bounded to: if the new orchestrator is broken, the next `/task` run breaks at Steps 1–5. Mitigation: AC4–AC7 live tests run before merge; specifically AC7 (end-to-end `/task <issue#>`) is a smoke test of exactly this failure mode.
+
+- **`SendMessage` semantics.** The orchestrator depends on `SendMessage(to=agentId, ...)` preserving the warm agent's context across rounds. If `SendMessage` is unavailable in the harness or the captured `agentId` expires between rounds (e.g., long user-thinking pauses), the orchestrator falls back to a fresh `Agent` call with the full state-file contents pasted into the prompt. The agent definition is already required to re-derive everything from the prompt every call — so the cold fallback degrades performance, not correctness. Add a one-line note in the orchestrator's recovery section.
+
+- **`AskUserQuestion` per-call cap.** The tool supports up to 4 questions and up to 4 options per question. `questions_per_round_cap = 3` keeps the round inside the cap with one slot to spare for the orchestrator-injected questions on `unresolvable` (the orchestrator presents the chosen `suggested_action` plus the other applicable actions — at most 4 actions across all five categories). Verified mechanically in the agent's system prompt and in the orchestrator's unresolvable handler.
+
+- **`gh issue` rate or auth.** Tracking-issue resolution and the cross-link comment depend on `gh` already authenticated. The current SKILL.md already relies on this and the user has the persistent rule "`gh auth` must be run by user"; no change needed. If `gh` fails, the orchestrator surfaces the error to the user (existing behaviour preserved).
+
+- **State-file orphaning.** If the orchestrator crashes between writing the state file and reaching a terminal status, an orphan `<spec>.state.md` lingers. Mitigation: the orchestrator's round-1 logic checks for an existing state file with the same path and either resumes (if `agentId` is still live) or prompts the user "found stale state file at `<path>` — resume / discard / abort?". This is the same shape as the existing `<spec>.progress.md` resume protocol used by `/task`.
+
+- **`agentId` capture format.** The exact wire format for `Agent` returning an ID is harness-specific. The orchestrator must store whatever string the harness returns and pass it back via `SendMessage(to=...)`; if the harness emits no usable ID, the orchestrator falls back to fresh-`Agent`-per-round. Documented as the cold fallback above.
+
+## Test Design
+
+**Verification is structural + live.** No Rust source is touched, so:
+
+- **No `#[cfg(test)] mod tests`** — there is no Rust file to attach a test module to.
+- **No `panic-index.md` change** — no production panic sites added.
+- **No `actionlint`** — no `.github/workflows/*.yml` modified.
+- **No `cargo build` / `cargo test` / `cargo clippy` / `cargo doc` test ACs** — those commands run as no-op sanity checks during the PR's CI but verify nothing about this change. They pass trivially.
+
+The verification is split into **structural shape-checks** (Tasks 1–3) and **live runs** (Task 4).
+
+### Structural shape-checks (deterministic, no harness invocation)
+
+For Task 1 (`spec-writer.md` exists):
+
+```bash
+test -f .claude/agents/spec-writer.md
+grep -q '^model: opus' .claude/agents/spec-writer.md
+grep -q '^tools:.*Read.*Write.*Edit.*Bash' .claude/agents/spec-writer.md
+grep -q 'mirrored from AGENTS.md /interview Rule 5' .claude/agents/spec-writer.md
+grep -qE 'cap_reached|logically_unresolvable|external_dependency|empty_scope|user_loop' .claude/agents/spec-writer.md
+grep -q 'Smallest spec sufficient' .claude/agents/spec-writer.md   # optimization-target verbatim
+```
+
+For Task 2 (orchestrator shape):
+
+```bash
+grep -qE 'Agent\(subagent_type="general-purpose", model="opus"' .claude/skills/interview/SKILL.md
+grep -q 'SendMessage' .claude/skills/interview/SKILL.md
+grep -q 'state.md' .claude/skills/interview/SKILL.md
+# Negative checks — content moved to the agent must be GONE from the orchestrator:
+! grep -qiE 'backward.compat|compat.shim|deprecat|keep.old' .claude/skills/interview/SKILL.md \
+  || { echo "FAIL: Rule-5 blacklist still in SKILL.md — should be in spec-writer.md only"; exit 1; }
+```
+
+For Task 3 (AGENTS.md updates):
+
+```bash
+grep -q 'spec-writer.md' AGENTS.md
+grep -qE 'interview.*spec-writer|spec-writer.*interview' AGENTS.md   # sync group line
+grep -q 'Rule-5 substring-blacklist edits MUST propagate' AGENTS.md
+```
+
+These run by hand at the end of each task; not automated.
+
+### Live runs (Task 4 — covers AC4–AC7)
+
+**Fixture creation strategy.** Synthetic issues are opened on this repo (`maratik123/quartzite`) under a label `agent-test/spec-writer` for retrievability. Each issue body is authored to exercise exactly one branch. Issues are closed (not deleted) after each run with a comment `Closed: verification run on <commit-sha>`. The label allows post-merge cleanup via `gh issue list --label agent-test/spec-writer --state all`.
+
+The label-and-close approach (not "issue body files passed via stdin") was chosen because:
+- The orchestrator's entry path uses `gh issue view <N>` directly. Using real issues exercises the actual code path verbatim — no test-only stdin override needed.
+- Closed-with-label issues remain queryable indefinitely; they document what was tested.
+- The orchestrator's `gh issue comment` cross-link in AC4 has somewhere real to land — verifying AC4's "cross-link comment is posted" requirement end-to-end.
+
+**Synthetic issue corpus (7 issues total):**
+
+| Fixture | Issue body shape | Drives AC | Expected status |
+|---|---|---|---|
+| F1 happy | `"Add a one-line top-level rustdoc to crate `quartzite-paint-api/src/lib.rs` describing its public API surface."` | AC4 | round 1 → `ready` |
+| F2 ambiguous | `"Speed up the runtime."` | AC5 | rounds 1..N → `ask` × ≥1, then `ready` within 4 rounds |
+| F3 cap_reached | A genuinely-ambiguous issue with the user (tester) answering every clarifying question with `"defer that"` until the cap fires | AC6 | round 4 → `unresolvable: cap_reached` |
+| F4 logically_unresolvable | `"Add a feature that depends on Rust stabilising specialisation."` | AC6 | round 1 → `unresolvable: logically_unresolvable` |
+| F5 external_dependency | `"Migrate to wgpu 25.0 once it ships."` (wgpu 25 unreleased at run time) | AC6 | round 1 or 2 → `unresolvable: external_dependency` |
+| F6 empty_scope | `"."` (intentionally empty body) | AC6 | round 1 → `unresolvable: empty_scope` |
+| F7 user_loop | An issue where the tester deliberately gives contradictory answers across rounds (round 1 "yes do X", round 2 "no don't do X") | AC6 | rounds 2–3 → `unresolvable: user_loop` |
+| F8 e2e | A real low-risk backlog issue (e.g. small docs typo, single-line refactor) selected at run time from `gh issue list --state open` | AC7 | full `/task` run reaches design-review GO on first pass |
+
+For each unresolvable fixture (F3–F7), the tester verifies:
+- The orchestrator surfaces the agent's `suggested_action` first via `AskUserQuestion`.
+- The chosen action executes the documented effect: `defer_to_deferred` moves the spec draft to `ai-docs/plans/deferred/` and updates `INDEX.md` (status `🟡 spec-only`); `abort` deletes the partial spec; `extend_cap` resumes with `round_cap += 1`; `request_external_info` resumes with appended context.
+- The state file `<spec>.state.md` is deleted on `ready` / `abort` / `defer_to_deferred` and retained on `extend_cap` / `request_external_info`.
+
+**Test artefact handling.** Spec drafts produced for fixtures F1–F7 are deleted after the run unless they exercised `defer_to_deferred` (those go to `ai-docs/plans/deferred/` and are kept as documented evidence of the AC6 path). The F8 spec from the end-to-end run becomes a real PR — that's the AC7 deliverable.
+
+### Round-cap-awareness rule (embedded in agent — verified by F3)
+
+The agent's system prompt includes: "When `round == round_cap`, status MUST be `ready` or `unresolvable: cap_reached`. Emitting `ask` on the final round is a contract violation." F3 verifies this: the tester gives non-progressing answers; on round 4, the agent must not emit `ask`. The orchestrator additionally guards this — if the agent emits `ask` on `round == round_cap`, the orchestrator overrides to `unresolvable: cap_reached` and surfaces it. Both layers are necessary because hard rules in subagent prompts have historically failed (cf. `ai-docs/learnings.md` 2026-05-03 / 2026-05-05 on Rule 5).
+
+## Open questions
+
+None. All design-affecting decisions are pinned in the spec's Key Decisions table or resolved above (state-file layout = markdown header + fenced YAML block; YAML parse-failure recovery mechanics = one-shot `SendMessage` retry then orchestrator-injected `unresolvable: logically_unresolvable`; live-test fixture strategy = labelled synthetic issues on this repo, closed after testing; cold-`Agent` fallback for failed `SendMessage`).

--- a/ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.spec.md
+++ b/ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.spec.md
@@ -1,0 +1,213 @@
+# Extract `/interview` spec-drafting into `spec-writer` opus subagent
+
+**Source:** issue #188
+**Date:** 2026-05-09
+**Tracked in:** #188
+
+## Scope
+
+1. **New agent file** — `.claude/agents/spec-writer.md`:
+   - Frontmatter: `model: opus`; tools `Read, Write, Edit, Bash`.
+   - System prompt embeds: input contract, YAML output schema, AGENTS.md
+     preflight rule, the full Rule-5 substring blacklist (mirrored from
+     AGENTS.md and labelled as such), the spec-format template, round-cap
+     and per-round-questions-cap awareness rules.
+
+2. **Subagent input contract** (passed in every invocation prompt):
+   - Issue ref + full body verbatim from `gh issue view <N>`
+   - `round`: integer in `1..=round_cap`
+   - `round_cap`: integer (default 4)
+   - `questions_per_round_cap`: integer (default 3)
+   - Prior Q&A history (canonical list — passed every call, not relied on
+     via agent memory)
+   - Current spec draft path (may not yet exist on round 1)
+
+3. **Subagent output**:
+   - **Side effect:** writes spec to disk at the spec path; spec follows the
+     existing format (`# Task name`, `**Source:**`, `**Date:**`,
+     `**Tracked in:**`, `## Scope`, `## Out of scope`, `## Deferred`,
+     `## Key decisions`, `## Technical constraints`,
+     `## Acceptance Criteria`, `## Open questions`).
+   - **Mandatory final response block** — YAML, must come last in the
+     agent's response:
+
+     ```yaml
+     ---
+     status: ready | ask | unresolvable
+     round: <N>
+     questions:                  # required iff status == ask, length ≤ questions_per_round_cap
+       - question: "..."
+         header: "..."           # ≤ 12 chars (AskUserQuestion-shaped)
+         options:
+           - { label: "...", description: "..." }
+     reason:                     # required iff status == unresolvable
+       category: cap_reached | logically_unresolvable | external_dependency | empty_scope | user_loop
+       detail: "..."
+       suggested_action: defer_to_deferred | abort | extend_cap | request_external_info
+     ---
+     ```
+
+4. **Hard rules embedded in agent definition**:
+   - AGENTS.md preflight: read AGENTS.md before drafting questions; apply
+     pre-resolved rules silently (do not ask).
+   - Rule-5 substring blacklist: mirrored from AGENTS.md `/interview` skill
+     Rule 5; the agent must not emit a question containing any blacklisted
+     substring.
+   - `questions` list length is a hard upper bound at
+     `questions_per_round_cap`.
+   - When `round == round_cap`, status MUST be `ready` or `unresolvable`,
+     never `ask`.
+   - Optimization target (verbatim in the system prompt):
+     > Produce the smallest spec sufficient for the design agent to return a
+     > `GO` verdict on the first design-review pass. Ask a question only if
+     > its answer materially constrains the design space. Apply AGENTS.md
+     > defaults silently. Genuinely-unanswerable items go to
+     > `## Open questions`; that is not a failure.
+
+5. **Orchestrator rewrite** — `.claude/skills/interview/SKILL.md` becomes a
+   thin orchestrator. Existing scope-extraction / question-content content
+   moves into the agent definition. Orchestrator responsibilities:
+   - Detect entry mode (issue ref / free-text / empty) and load the issue
+     body via `gh issue view`.
+   - Compute spec path and state-file path
+     (`<spec_path>.state.md`).
+   - Round 1 — invoke `Agent(subagent_type="general-purpose", model="opus", ...)`
+     with the agent's instruction file referenced (`.claude/agents/spec-writer.md`)
+     and the input-contract fields in the prompt. Capture the returned
+     `agentId`.
+   - Rounds 2..cap — invoke `SendMessage(to=agentId, ...)` with the
+     updated input-contract fields (round, full prior_qa, current spec
+     path). The agent re-derives context from the prompt every call (per
+     hard rule).
+   - Parse the YAML status block from the agent's response.
+   - **On `status: ask`** — surface all questions in a single
+     `AskUserQuestion` tool call (tool supports up to 4 questions per call,
+     so 1–3 fit cleanly). Append (Q, user_answer) pairs to state file;
+     advance to round N+1.
+   - **On `status: ready`** — confirm the spec with the user; on approval
+     post the cross-link comment on the tracking issue (Step 7 of the
+     existing skill); delete the state file; exit.
+   - **On `status: unresolvable`** — surface the reason via
+     `AskUserQuestion` with the agent's `suggested_action` first, plus the
+     other applicable actions:
+     - `defer_to_deferred` → move spec draft (if any) to
+       `ai-docs/plans/deferred/`, update `INDEX.md` (status `🟡 spec-only`),
+       delete the state file, exit.
+     - `abort` → delete partial spec draft, delete the state file, exit.
+     - `extend_cap` → bump `round_cap += 1`; SendMessage round=N+1,
+       cap=cap+1; resume the loop.
+     - `request_external_info` → prompt the user for additional context
+       paste; SendMessage round=N+1 with the appended context; resume the
+       loop.
+   - YAML parse failure recovery: on malformed YAML, SendMessage to the
+     agent: "Re-emit only the YAML status block, exact schema." Cap retries
+     at 1; on second failure, surface to the user as an
+     `unresolvable: logically_unresolvable` (orchestrator-injected).
+
+6. **State file** — `<spec_path>.state.md`:
+   - Created on round 1; deleted on `ready` / `abort` / `defer_to_deferred`.
+   - Stores: round counter, `round_cap`, `questions_per_round_cap`,
+     `agentId`, the canonical Q&A history list.
+   - Format: markdown header + a YAML fenced block. (Specific layout is a
+     design-phase decision; the spec only requires that it be a single
+     dedicated file and not embedded in the spec itself.)
+
+7. **AGENTS.md updates**:
+   - Add `spec-writer.md` to the **Agent Docs** table with one-line purpose.
+   - Add `interview ↔ spec-writer ↔ AGENTS.md` to the **Propagation Rule**
+     sync-groups list, with explicit annotation: "Rule-5 substring-blacklist
+     edits MUST propagate to `spec-writer.md`'s embedded copy."
+
+## Out of scope
+
+- Changing `/task` skill orchestration. Steps 6 onwards (design, design
+  review, implementation, verify, self-review, finalise) stay as-is. Only
+  Steps 1–5 internals change.
+- Changing the spec format template. The agent emits the same shape
+  (`# Task name`, sections, AC table); only the author changes.
+- Adding `/interview` CLI overrides for `round_cap` or
+  `questions_per_round_cap`. Defaults stay as constants in the agent
+  definition for this iteration; configurability deferred to a future
+  iteration if needed.
+- Migrating any other skill (`/code-review`, `/improve`, etc.) to the
+  subagent pattern. This is the pilot.
+- Automated unit / integration tests for the orchestrator or agent. No Rust
+  test infrastructure exists for skills/agents in this repo; verification
+  is structural + live-test only.
+
+## Deferred
+
+- Configurability of `round_cap` / `questions_per_round_cap` via
+  `/interview` arguments — separate issue if/when there's evidence the
+  defaults are wrong.
+- Migration of other skills to the subagent pattern — separate
+  per-skill issue once this pilot validates the approach.
+- Cross-session resumability of an interrupted interview (e.g., agent
+  process dies mid-interview). The spec covers normal-flow exit; recovery
+  from agent-side failures is out of scope here.
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Spec-drafting model | `model: opus` regardless of parent session's model — pinned in agent frontmatter. Rationale: spec quality is load-bearing; opus is the most capable model available. |
+| State persistence shape | Separate file `<spec_path>.state.md`, transient (deleted on `ready` / `abort` / `defer_to_deferred`). Rationale: atomic, clean separation from the spec, mirrors existing `<spec>.progress.md` pattern. |
+| Agent lifecycle across rounds | Warm: `Agent` for round 1, `SendMessage` for rounds 2..cap, capturing `agentId` in state. Rationale: cheaper (preflight reading is cached in agent's context); agent definition still requires re-derivation from prompt for safety. |
+| Rule-5 substring blacklist source-of-truth | Duplicated into `spec-writer.md` with annotation `<!-- mirrored from AGENTS.md /interview Rule 5 — propagation-required -->`. Rationale: subagent runs in isolation; can't reliably do dynamic-file-read inclusion of rules; sync-drift mitigated by Propagation Rule sync-group entry. |
+| Optimization target | "Smallest spec sufficient for first-pass design GO." Embedded verbatim in agent system prompt. |
+| Round / questions caps | 4 / 3 (matching current `/interview`). Hard-coded in agent system prompt and orchestrator constants for this iteration. |
+| Multi-question rounds | Subagent emits 1..=`questions_per_round_cap` questions per `ask`; orchestrator forwards entire list to a single `AskUserQuestion` call. Rationale: matches current UX (single round of 1–3 questions answered together); avoids sequential per-question round trips. |
+| Unresolvable categories | Five: `cap_reached`, `logically_unresolvable`, `external_dependency`, `empty_scope`, `user_loop`. Each maps to a default `suggested_action` the orchestrator presents first. |
+| YAML parse-failure recovery | One-shot SendMessage retry asking the agent to re-emit only the status block. On second failure, orchestrator injects `unresolvable: logically_unresolvable` and surfaces to the user. |
+| Verification approach | Structural (file existence + shape) + live tests on synthetic issues for each unresolvable category + one full `/task` end-to-end run. No automated test suite. |
+
+## Technical constraints
+
+- **No Rust source touched.** `cargo build` / `cargo test` / `cargo fmt` /
+  `cargo clippy` / `cargo doc` will all be no-op sanity checks; they pass
+  trivially. No `actionlint` gate (no workflow files). No `panic-index.md`
+  update (no production panic sites added).
+- **Propagation Rule fires.** Three files form the new sync group:
+  `AGENTS.md` (Rule-5 source), `.claude/skills/interview/SKILL.md`
+  (orchestrator), `.claude/agents/spec-writer.md` (subagent definition with
+  the mirrored Rule-5 blacklist).
+- **Self-referential touch.** This task modifies the very `/interview`
+  skill that `/task` Steps 1–5 use. Sequence is fine: the **current**
+  in-context `/interview` is drafting this spec right now; the new
+  subagent-based `/interview` activates only after merge. No chicken-and-egg.
+- **`AskUserQuestion` constraints.** The tool supports up to 4 questions
+  per call and up to 4 options per question. The agent must emit options
+  conforming to those caps (the agent definition will state this).
+- **AGENTS.md axioms** (already in effect, restated for completeness):
+  - Boundary rule 1: `ai-docs/learnings.md` is APPEND-ONLY (no edits to past
+    entries during this task).
+  - Boundary rule 2: writing to `learnings.md` does NOT trigger
+    instruction-file edits in the same turn (this task DOES edit
+    instruction files for an independent reason — Propagation Rule fires
+    properly).
+  - Workflow Axiom 1: never edit on local `master` for PR-targeted work;
+    feature branch first.
+- **File-size targets** (AGENTS.md *Code Style* — Source files; applies to
+  all repo files including markdown). Orchestrator rewrite targets the
+  current `SKILL.md`'s soft 500/800 budget. Agent definition file is new;
+  same target applies.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | `.claude/agents/spec-writer.md` exists. Frontmatter has `model: opus` and `tools: Read, Write, Edit, Bash`. System prompt embeds: input contract (issue body, `round`, `round_cap`, `questions_per_round_cap`, prior Q&A, spec path), YAML output schema (with all five `unresolvable` categories), AGENTS.md preflight rule, the Rule-5 substring blacklist (annotated as mirrored from AGENTS.md), the spec-format template reference, the round-cap-awareness rule, and the optimization-target verbatim quote. |
+| AC2 | `.claude/skills/interview/SKILL.md` is rewritten as a thin orchestrator. It contains: entry-mode detection, spec-path / state-file-path computation, round-1 `Agent` invocation referencing `.claude/agents/spec-writer.md` with `model="opus"`, rounds-2+ `SendMessage` invocation, YAML-status parsing, branching on `ready` / `ask` / `unresolvable` with the four documented action handlers, state-file lifecycle (create round 1 / delete on terminal exit), and YAML-parse-failure recovery (one-shot SendMessage retry). It no longer contains the scope-extraction / question-drafting / Rule-5 blacklist content (those moved to the agent). |
+| AC3 | `AGENTS.md` Agent Docs table contains a row for `.claude/agents/spec-writer.md` with a one-line purpose. The Propagation Rule "sync groups (canonical)" section contains a new sync group: `interview ↔ spec-writer ↔ AGENTS.md`, with an annotation that Rule-5 substring-blacklist edits must propagate to `spec-writer.md`. |
+| AC4 | Live test — running `/interview` against a synthetic clear-scope issue (one-line, unambiguous) exits with `status: ready` in round 1. The orchestrator does not call `AskUserQuestion`; the spec is written; the cross-link comment is posted on the tracking issue. |
+| AC5 | Live test — running `/interview` against a synthetic moderately-ambiguous issue triggers `status: ask` for at least round 1; the orchestrator surfaces 1–3 questions in a single `AskUserQuestion` call; user answers feed back into round 2 via `SendMessage`; the loop converges to `status: ready` within `round_cap` (4) rounds; spec on disk + cross-link posted. |
+| AC6 | Live test — each of the five `unresolvable` categories (`cap_reached`, `logically_unresolvable`, `external_dependency`, `empty_scope`, `user_loop`) triggers correctly via a synthetic issue exercising it. For each, the orchestrator surfaces the reason via `AskUserQuestion` with the agent's `suggested_action` listed first. The chosen action executes correctly: `defer_to_deferred` moves the spec to `ai-docs/plans/deferred/` and updates `INDEX.md`; `abort` deletes the partial spec; `extend_cap` resumes the loop with `round_cap += 1`; `request_external_info` resumes with appended context. |
+| AC7 | End-to-end `/task <issue#>` run completes successfully against a real, small, low-risk backlog issue. The new `/interview` produces a spec the design agent (Step 6) can consume and the design-review agent (Step 7) returns a `GO` verdict on the first pass (i.e., no spec-gap-driven `ITERATE` / `STOP`). |
+
+## Open questions
+
+- None. All design-affecting decisions are pinned in the issue body and the
+  Key Decisions table above. Concrete YAML field shapes, state-file content
+  layout, agent system-prompt wording, and recovery-from-agent-crash
+  behaviour are design-detail; the design agent will resolve them without
+  further user input.


### PR DESCRIPTION
## Summary

- New subagent `.claude/agents/spec-writer.md` (`model: opus`, tools `Read, Grep, Glob, Bash`) — drafts the spec one interview round per invocation. System prompt embeds: input contract, YAML output schema with all 5 unresolvable categories, AGENTS.md preflight, Rule-5 substring blacklist (mirrored from current SKILL.md with HTML anchor comment), spec-format reference, round-cap awareness, optimization-target verbatim quote.
- Rewritten `.claude/skills/interview/SKILL.md` as a thin orchestrator — drives the round loop, surfaces questions via `AskUserQuestion`, parses YAML status, handles `ready` / `ask` / `unresolvable` branching with 4 action handlers (`extend_cap` / `defer_to_deferred` / `abort` / `request_external_info`). State file at `<spec>.state.md` (transient; deleted on terminal exit). Cold-`Agent` is the primary contract; warm-reuse via `SendMessage` is opportunistic. YAML parse-failure → 1-shot retry → orchestrator-injected `unresolvable: logically_unresolvable` on second failure.
- `AGENTS.md` updates: Agent Docs row for `spec-writer.md`; Propagation Rule axiom table extended with bidirectional Interview-group rows; Sync groups (canonical) gains `Interview group: SKILL.md ↔ spec-writer.md ↔ AGENTS.md` with annotation that new pre-resolved-rule additions to AGENTS.md must spawn corresponding Rule-5 blacklist entries in `spec-writer.md`.
- Optimization target baked into agent prompt (verbatim quote + HTML anchor for propagation tracking): "Produce the smallest spec sufficient for the design agent to return a `GO` verdict on the first design-review pass. Ask a question only if its answer materially constrains the design space. Apply AGENTS.md defaults silently. Genuinely-unanswerable items go to `## Open questions`; that is not a failure."

## Tracking

Closes #188.

## Test plan

- [x] AC1 — `.claude/agents/spec-writer.md` exists with required content (11 structural greps verified)
- [x] AC2 — `.claude/skills/interview/SKILL.md` rewritten as thin orchestrator (12 structural greps verified; Rule-5 substring table NOT in orchestrator)
- [x] AC3 — `AGENTS.md` updates (Agent Docs row + Interview group in axiom table + Sync groups + Rule-5 propagation annotation; 4 structural greps verified)
- [ ] AC4 — Live test: synthetic clear-scope issue → `ready` round 1
- [ ] AC5 — Live test: moderately-ambiguous issue → 2-3 ask rounds → `ready`
- [ ] AC6 — Live test: each of 5 unresolvable categories triggers correctly
- [ ] AC7 — End-to-end `/task <issue#>` → first-pass design GO
- [x] `cargo build` clean (no Rust changed; no-op sanity)
- [x] `cargo test` all green
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `RUSTDOCFLAGS=\"-D warnings -D missing-docs\" cargo doc --no-deps --workspace` clean
- [ ] No new workflow files → actionlint not required
- [ ] No new production panic sites → `panic-index.md` not updated

### Note on AC4–AC7 deferral

Skills are loaded **once per Claude Code session** at session start. The session that built these files is running the **OLD** in-context `/interview` skill — its instructions are the live skill body for that session, regardless of what's now committed locally.

Live exercise of AC4–AC7 requires a **fresh session** AFTER the new files are present (post-merge or after re-launching Claude Code with this branch checked out). This mirrors the verification-protocol pattern from PR #184 (rust-cache migration's AC4 was deferred to post-merge cache-restored observation on the master cache).

The 27 structural shape-checks in this PR prove the files have the documented contract. Live exercise on the design's F1–F8 synthetic-issue corpus is the actual AC4–AC7 verification — to be run in a fresh session post-merge.

## Risk note

`SendMessage` (used for warm-reuse across rounds 2..cap) is novel in this codebase; it does not appear in any existing skill or agent. The orchestrator documents cold-`Agent` per round as the **primary** contract, with `SendMessage` as opportunistic optimization conditional on `agentId` capture and the call succeeding. If `SendMessage` is unavailable in the harness, the cold path preserves correctness — no functional regression.