### PR TITLE
ci: skip Rust matrix on instruction-only PRs (paths-filter + aggregator reshape)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,28 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            # Any future Rust artefact (e.g. .cargo/config.toml, clippy.toml) must be
+            # added here in the same PR that introduces it to keep the matrix gate accurate.
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/**'
+              - 'rust-toolchain*'
+
   format:
     name: Format
     runs-on: ubuntu-latest
@@ -24,6 +46,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -49,6 +73,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -74,6 +100,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -101,39 +129,47 @@ jobs:
 
   features-pass:
     name: Feature matrix
-    needs: features
+    needs: [changes, features]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          if [[ "${{ needs.features.result }}" != "success" ]]; then exit 1; fi
+          c="${{ needs.changes.result }}"
+          r="${{ needs.features.result }}"
+          if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi
 
   build-pass:
     name: Build
-    needs: build
+    needs: [changes, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          if [[ "${{ needs.build.result }}" != "success" ]]; then exit 1; fi
+          c="${{ needs.changes.result }}"
+          r="${{ needs.build.result }}"
+          if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi
 
   test-pass:
     name: Test
-    needs: test
+    needs: [changes, test]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          if [[ "${{ needs.test.result }}" != "success" ]]; then exit 1; fi
+          c="${{ needs.changes.result }}"
+          r="${{ needs.test.result }}"
+          if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi
 
   clippy-pass:
     name: Clippy
-    needs: clippy
+    needs: [changes, clippy]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          if [[ "${{ needs.clippy.result }}" != "success" ]]; then exit 1; fi
+          c="${{ needs.changes.result }}"
+          r="${{ needs.clippy.result }}"
+          if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi
 
   roadmap-sync:
     name: ROADMAP sync
@@ -155,7 +191,9 @@ jobs:
           if [[ "${{ needs.roadmap-sync.result }}" != "success" ]]; then exit 1; fi
 
   docs:
-    name: Docs
+    name: Docs (build)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -177,8 +215,21 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings -D missing-docs"
 
+  docs-pass:
+    name: Docs
+    needs: [changes, docs]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          c="${{ needs.changes.result }}"
+          r="${{ needs.docs.result }}"
+          if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi
+
   features:
     name: Feature matrix
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ core-types ✅
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [ci-skip-rust-matrix](ai-docs/plans/done/2026-05-09-ci-skip-rust-matrix.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `dorny/paths-filter@v4` `changes` job gates Rust matrix on Rust-affecting paths; aggregators reshaped to treat `skipped` as `success`; new `docs-pass` aggregator) | — |
 | [interview-spec-writer-subagent](ai-docs/plans/done/2026-05-09-interview-spec-writer-subagent.spec.md) | Claude Code tooling (`.claude/agents/`, `.claude/skills/interview/`, `AGENTS.md`) | ✅ implemented (0 new tests; instruction-file-only — extracts `/interview` spec-drafting into `spec-writer` opus subagent with structured YAML output; AC4–AC7 live tests deferred to post-merge per Verification protocol) | — |
 | [ci-rust-cache-migration](ai-docs/plans/done/2026-05-08-ci-rust-cache-migration.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `actions/cache@v5` → `Swatinem/rust-cache@v2` in 5 compile jobs; `SCCACHE_CACHE_SIZE: "2G"` added per-job; `shared-key` + `save-if: master only` tuning) | — |
 | [ci-sccache](ai-docs/plans/done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |

--- a/ai-docs/plans/INDEX.md
+++ b/ai-docs/plans/INDEX.md
@@ -6,6 +6,7 @@ Legend: ✅ done · 🟢 ready (spec+design, no blockers) · 🟡 spec-only (no 
 
 | Plan | Crate(s) | Status | Blocked by |
 |------|----------|--------|------------|
+| [ci-skip-rust-matrix](done/2026-05-09-ci-skip-rust-matrix.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `dorny/paths-filter@v4` `changes` job gates Rust matrix on Rust-affecting paths; aggregators reshaped to treat `skipped` as `success`; new `docs-pass` aggregator) | — |
 | [interview-spec-writer-subagent](done/2026-05-09-interview-spec-writer-subagent.spec.md) | Claude Code tooling (`.claude/agents/`, `.claude/skills/interview/`, `AGENTS.md`) | ✅ implemented (0 new tests; instruction-file-only — extracts `/interview` spec-drafting into `spec-writer` opus subagent with structured YAML output; AC4–AC7 live tests deferred to post-merge per Verification protocol) | — |
 | [ci-rust-cache-migration](done/2026-05-08-ci-rust-cache-migration.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — `actions/cache@v5` → `Swatinem/rust-cache@v2` in 5 compile jobs; `SCCACHE_CACHE_SIZE: "2G"` added per-job; `shared-key` + `save-if: master only` tuning) | — |
 | [ci-sccache](done/2026-05-08-ci-sccache.spec.md) | CI / repo config | ✅ implemented (0 new tests; CI config only — sccache layer added to 5 merge-gate compile jobs in ci.yml) | — |

--- a/ai-docs/plans/done/2026-05-09-ci-skip-rust-matrix.design.md
+++ b/ai-docs/plans/done/2026-05-09-ci-skip-rust-matrix.design.md
@@ -1,0 +1,221 @@
+# Design: CI — skip Rust matrix on instruction-only PRs
+
+**Issue:** #190
+**Spec:** [`2026-05-09-ci-skip-rust-matrix.spec.md`](2026-05-09-ci-skip-rust-matrix.spec.md)
+**Date:** 2026-05-09
+
+## Approach
+
+The workflow `.github/workflows/ci.yml` is restructured so that the heavy
+Rust matrix jobs (`build`, `test`, `clippy`, `docs`, `features`) only run
+when a path-filter has determined the PR / push touched Rust-relevant
+files. Branch-protection check names are preserved by aggregator jobs
+(`build-pass`, `test-pass`, `clippy-pass`, `docs-pass`, `features-pass`)
+which now treat `result == 'skipped'` as success, so instruction-only PRs
+finish quickly while still satisfying the six required contexts
+(`Format`, `Build`, `Test`, `Clippy`, `Docs`, `Feature matrix`).
+
+**Mechanism**: a new job `changes` runs `dorny/paths-filter@v4` on
+`ubuntu-latest`, declares one boolean output `rust`, and is added to
+`needs:` of every gated job. Each gated job carries
+`if: needs.changes.outputs.rust == 'true'`. Aggregator scripts are
+rewritten to fail only on `failure` / `cancelled` and pass on
+`success` / `skipped`.
+
+**Why a `changes` job + job-level `if:` (not workflow-level
+`paths-ignore`)**: workflow-level `paths-ignore` would prevent the
+workflow from triggering at all on instruction-only PRs, which leaves
+required status checks in `expected` state forever and blocks merge.
+The `changes`-driven approach lets the workflow run, mark matrix jobs
+as `skipped`, and have aggregators report `success` so branch protection
+is satisfied. This is the well-known GitHub idiom for the "skipped vs.
+success on required checks" trap.
+
+**Live-version verification (per AGENTS.md § Dependency Versions)**:
+- `dorny/paths-filter` latest release: `v4.0.1` (queried 2026-05-09);
+  `action.yml` declares `using: 'node24'` — modern runtime, current major.
+- All other actions remain at their currently-pinned major (no change).
+
+**Rejected alternatives**:
+
+1. **Workflow-level `paths-ignore:`** — rejected because GitHub treats
+   "workflow did not run" differently from "workflow ran and skipped";
+   required checks remain pending and PR cannot merge.
+2. **Filter at `on: pull_request:` + duplicate `on: push:`** — same
+   skipped-vs-pending failure mode, plus duplicates trigger config.
+3. **`tj-actions/changed-files`** — supersedes `paths-filter` for some
+   use cases but pulls in heavier git history scanning and has had
+   security incidents (2024 supply-chain). `dorny/paths-filter` is
+   simpler, smaller-surface, and matches the spec's named pin.
+4. **Move the matrix into a callable workflow gated by an outer
+   `workflow_call`** — overkill for this scope; reshapes the public
+   check graph more than necessary and complicates branch-protection
+   maintenance.
+5. **Reuse a single generic `pass` aggregator parametrised by job
+   name** — GitHub Actions has no good way to template `needs:` on a
+   matrix-of-aggregators; explicit one-aggregator-per-matrix-job is
+   the maintainable shape and matches what's already in the file.
+
+## Decomposition
+
+| # | Task | Files | Depends on |
+|---|------|-------|------------|
+| 1 | Add the `changes` job (top of `jobs:`, before `format`) using `dorny/paths-filter@v4` with one output `rust` driven by the path patterns from spec § Scope item 2. The step gets `id: filter` so outputs can be referenced. The job declares `outputs.rust: ${{ steps.filter.outputs.rust }}`. Runs on `ubuntu-latest`; uses `actions/checkout@v6` only when needed (paths-filter v4 supports `pull_request` events without a checkout, but on `push` events a checkout is required — include checkout unconditionally for simplicity, as per the action's README guidance). | `.github/workflows/ci.yml` | — |
+| 2 | Add `needs: changes` and `if: needs.changes.outputs.rust == 'true'` to the `build` job. No other changes to the job body. | `.github/workflows/ci.yml` | 1 |
+| 3 | Add `needs: changes` and `if: needs.changes.outputs.rust == 'true'` to the `test` job. | `.github/workflows/ci.yml` | 1 |
+| 4 | Add `needs: changes` and `if: needs.changes.outputs.rust == 'true'` to the `clippy` job. | `.github/workflows/ci.yml` | 1 |
+| 5 | Rename the existing `docs` job's `name:` from `Docs` to `Docs (build)` so the new `docs-pass` aggregator can own the public `Docs` name without check-name collision. Add `needs: changes` and `if: needs.changes.outputs.rust == 'true'` to the same job. | `.github/workflows/ci.yml` | 1 |
+| 6 | Add `needs: changes` and `if: needs.changes.outputs.rust == 'true'` to the `features` job. | `.github/workflows/ci.yml` | 1 |
+| 7 | Reshape the four existing aggregators (`build-pass`, `test-pass`, `clippy-pass`, `features-pass`) so the bash check passes only when the underlying job is `success` OR (the underlying job is `skipped` AND the `changes` job itself succeeded). Add `changes` to each aggregator's `needs:` list so its result is observable. Pattern (single line, exits 1 on failure):<br>`c='${{ needs.changes.result }}'; r='${{ needs.<job>.result }}'; if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then echo "changes=$c <job>=$r"; exit 1; fi`<br>This guards AC4 against the `changes`-failed cascade (every gated job auto-skips, and a naive `success || skipped` check would falsely report aggregator success). | `.github/workflows/ci.yml` | 1, 2, 3, 4, 6 |
+| 8 | Add a new `docs-pass` aggregator with `name: Docs`, `needs: [changes, docs]`, `if: always()`, and the same `changes`-aware bash logic from Task 7 (require `changes == success` AND `docs ∈ {success, skipped}`). This job is what branch protection will see for the `Docs` required context. | `.github/workflows/ci.yml` | 1, 5 |
+| 9 | Run `actionlint .github/workflows/ci.yml` and resolve any reported issues; the workflow is the only file changed in this PR. | `.github/workflows/ci.yml` | 7, 8 |
+
+Total: 9 atomic tasks, all in one file. Under the 7-task threshold for splitting (the threshold is for *complex* multi-file decomposition; here all changes are localised co-edits to one workflow file, so they're presented separately for reviewability but are intended to be made in a single commit/PR).
+
+## Risks
+
+- **Risk: required-context name collision during transition.** The
+  existing `docs` job is named `Docs`; the new `docs-pass` aggregator
+  is also named `Docs`. If both exist with the same `name:` at any
+  point, GitHub will report two checks with the same name, and branch
+  protection's match becomes ambiguous.
+  **Mitigation:** Task 5 renames the underlying `docs` job's `name:` to
+  `Docs (build)` *before* (or in the same diff as) Task 8 introduces
+  the `docs-pass` aggregator with `name: Docs`. The implementer must
+  apply both edits in the same commit; they cannot be split across
+  pushes. Verification: `actionlint` and a live PR check showing only
+  one check with name `Docs` (the aggregator).
+- **Risk: `dorny/paths-filter@v4` behaviour on `push` to master.** On
+  `push` events the action compares against the push's `before` commit;
+  when a PR is merged with a merge commit, the `before` is master's tip
+  before the merge, so changes are detected correctly. On a force-push
+  scenario `before` may point to a non-existent commit, causing the
+  action to fall back to comparing against `HEAD~1`.
+  **Mitigation:** documented behaviour, no special config needed; if a
+  force-push to master ever occurs (server-blocked today), the worst
+  case is a full matrix run — safe failure mode.
+- **Risk: skipping the matrix on master push misses cache regeneration.**
+  The spec acknowledges this and accepts it: an instruction-only push
+  to master changes nothing the cache covers, so no cache work is
+  meaningfully missed. The next code-touching push will warm the cache
+  as before.
+- **Risk: `actionlint` rejects the new `if:` expression syntax.**
+  `if: needs.changes.outputs.rust == 'true'` is the canonical pattern
+  documented in the GitHub Actions context expressions reference and
+  is well-supported by `actionlint`. **Mitigation:** Task 9 runs
+  `actionlint` as the gate.
+- **Risk: an undocumented Rust-relevant path is missed by the filter,
+  causing a code-affecting change to skip the matrix.** The spec's
+  filter set (`**/*.rs`, `**/Cargo.toml`, `Cargo.lock`,
+  `.github/workflows/**`, `rust-toolchain*`) covers everything that
+  could affect a Rust build today. **Mitigation:** any future Rust
+  artefact added to the repo (e.g. `.cargo/config.toml`, `clippy.toml`)
+  must be added to the filter in the same PR that introduces it. Add a
+  brief comment above the filter listing this contract.
+- **Risk: `roadmap-sync` and `roadmap-sync-pass` left untouched, but
+  their aggregator does not need skipped-as-success because the
+  underlying job runs unconditionally.** No real risk — by spec they
+  remain unchanged. Mention in the design so the implementer doesn't
+  attempt symmetry edits that would be no-ops.
+- **Risk: `format` job left untouched, ditto.** Same — runs
+  unconditionally per spec, no changes needed. Format job has no
+  aggregator today (the job's `name: Format` is itself the required
+  context); preserve that.
+- **Risk: `dorny/paths-filter@v4` token permissions on `pull_request`
+  events.** On `pull_request` events the action calls the GitHub REST
+  API to compute the changed-file list; this requires the
+  `pull-requests: read` scope on `GITHUB_TOKEN`. The repo's `ci.yml`
+  has no top-level `permissions:` block today, so it relies on the
+  default `GITHUB_TOKEN` scopes, which include `pull-requests: read`
+  for non-fork PRs in this repo's settings. **Mitigation:** acceptable
+  to rely on defaults (matches the pattern used elsewhere in this
+  workflow). For robustness against a future tightening of default
+  scopes, the implementer MAY add an explicit
+  `permissions: { pull-requests: read }` block on the `changes` job —
+  cheap, narrow, and self-documenting. Not required for AC.
+
+## Test Design
+
+This is a workflow-only change with no Rust source touched, so there are
+no `cargo test` cases to add. Validation is split across static checks
+and live CI behaviour.
+
+### Static gate (mandatory, blocks merge)
+
+- **Tool:** `actionlint .github/workflows/ci.yml`
+- **Entry point:** the modified workflow file
+- **Scenarios:**
+  - All YAML, expression, and shell syntax valid.
+  - No deprecated action versions or expression-syntax errors.
+  - Bash heredoc-style inline scripts pass the embedded shellcheck rules.
+- **Fixtures:** none — single-file static analysis.
+- **Failure mode:** any `error` or `warning` from `actionlint` is a
+  blocker per AGENTS.md § Build & Test "AXIOM — `actionlint` MUST pass
+  before `git add`".
+
+### Live CI verification (per spec § Verification protocol)
+
+These are out-of-tree validations performed on the PR before merge.
+They are part of the acceptance evidence, not unit tests.
+
+- **Scenario 1 — instruction-only PR (AC1, AC3, AC6):**
+  - Touch one file under `ai-docs/` only.
+  - Push, open PR.
+  - Expect: `changes` job logs `rust=false`; `build`/`test`/`clippy`/
+    `docs`/`features` all `Skipped`; all five `*-pass` aggregators
+    report `success`; the six required contexts (`Format`, `Build`,
+    `Test`, `Clippy`, `Docs`, `Feature matrix`) all `success`; total
+    runner wall-clock < 60 s.
+- **Scenario 2 — code-affecting PR (AC2, AC4):**
+  - Touch any `.rs` file (e.g. add a comment).
+  - Push, open PR.
+  - Expect: full matrix runs as today; all aggregators only succeed
+    when underlying jobs do.
+- **Scenario 3 — `Cargo.toml`-only PR (negative test, AC2):**
+  - Bump a comment or whitespace in `Cargo.toml` (no `.rs` change).
+  - Push, open PR.
+  - Expect: `changes` job logs `rust=true`; full matrix runs.
+- **Scenario 4 — workflow-only PR (recursive case):**
+  - The PR that lands this change itself touches
+    `.github/workflows/ci.yml`, which matches `.github/workflows/**`
+    in the filter — so the matrix runs on this PR. This is the
+    correct behaviour and is also the live AC2/AC4 evidence for the
+    PR introducing the rule.
+
+### Aggregator failure-propagation matrix (AC4)
+
+The reshape rewrites the bash check from
+`if [[ "$r" != "success" ]]; then exit 1; fi`
+to
+`c='${{ needs.changes.result }}'; r='${{ needs.<job>.result }}'; if [[ "$c" != "success" ]] || [[ "$r" != "success" && "$r" != "skipped" ]]; then exit 1; fi`.
+Treating `skipped` as success is conditional on `changes` itself having
+succeeded — otherwise a `changes` failure would silently cascade to
+`skipped` on every gated job and falsely report aggregator success.
+The transition table the implementer should keep in mind:
+
+| `changes` result | Underlying job result | Old aggregator | New aggregator |
+|---|---|---|---|
+| `success` | `success` | `success` | `success` |
+| `success` | `skipped` (rust filter false — instruction-only PR) | `failure` (regression today) | `success` (intended) |
+| `success` | `failure` | `failure` | `failure` |
+| `success` | `cancelled` | `failure` | `failure` |
+| `failure` | `skipped` (auto, because `needs: changes` failed) | n/a | `failure` (intended — guards AC4 against `changes`-failure cascade) |
+| `cancelled` | `skipped` (auto) | n/a | `failure` |
+| any | `null` / unevaluated | n/a | `failure` (defensive — empty `$r` fails the `!=` check) |
+
+No new tests are added to the Rust workspace.
+
+## Open questions
+
+- **Force-rerun escape hatch** (carried from spec § Open questions).
+  Default position is "no" — contributors who want to validate the
+  matrix against an instruction change can include a trivial whitespace
+  edit to a `.rs` file. If this proves friction-creating in practice,
+  open a follow-up issue to add a `[force-ci]` PR-title token or a
+  `workflow_dispatch` trigger; not part of this design.
+- **Filter contract documentation.** Should the path-filter list carry
+  an inline YAML comment naming the contract ("any future Rust artefact
+  must be added here in the same PR that introduces it")? Recommendation:
+  yes — one-line comment above the filter is cheap insurance against
+  silent drift. Defer to implementer / reviewer if they prefer to keep
+  the YAML uncommented.

--- a/ai-docs/plans/done/2026-05-09-ci-skip-rust-matrix.spec.md
+++ b/ai-docs/plans/done/2026-05-09-ci-skip-rust-matrix.spec.md
@@ -1,0 +1,142 @@
+# CI: skip Rust matrix on instruction-only PRs
+
+**Source:** issue #190
+**Date:** 2026-05-09
+**Tracked in:** #190
+
+## Scope
+
+1. Add a `changes` job to `.github/workflows/ci.yml` using
+   `dorny/paths-filter@v4` (live current major as of 2026-05-09; node24
+   runtime). The job runs on `ubuntu-latest`, checks out the repo, and exposes
+   one boolean output `rust` driven by the path filter below.
+2. Path-filter triggers (any match → `rust == true` → full Rust matrix runs):
+   - `**/*.rs`
+   - `**/Cargo.toml`
+   - `Cargo.lock`
+   - `.github/workflows/**`
+   - `rust-toolchain*` (future-proof; not present today)
+3. Anything else (notably `*.md`, `ai-docs/**`, `.claude/**`, `LICENSE*`,
+   `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, top-level non-Rust scripts) does
+   NOT match → `rust == false` → matrix jobs skipped.
+4. Gate the following matrix / Rust jobs on `needs.changes.outputs.rust == 'true'`:
+   - `build`
+   - `test`
+   - `clippy`
+   - `docs`
+   - `features`
+5. Reshape the existing aggregator jobs (`build-pass`, `test-pass`,
+   `clippy-pass`, `features-pass`) so that `result == 'success' || result == 'skipped'`
+   passes; only `failure` / `cancelled` fails. Keep the public check name on the
+   aggregator (the names that branch protection consumes — see § Technical
+   constraints).
+6. Add a `docs-pass` aggregator named `Docs` (matching the existing
+   required-check naming pattern), and rename the underlying single-job `docs`
+   to a non-conflicting `name:` (e.g. `Docs (build)`) so the aggregator owns
+   the public `Docs` check name. Apply the same skipped-as-success logic.
+7. `format` and `roadmap-sync` remain unconditional (cheap; ~15 s combined;
+   `roadmap-sync` actively wants to validate `INDEX.md`-driven `ROADMAP.md`
+   consistency).
+8. Path filter applies on both `push` (to `master`) and `pull_request`
+   triggers. Skipping the matrix on instruction-only master pushes is
+   intentional: no source changed, so no cache regeneration is needed.
+
+## Out of scope
+
+- Path filtering for the separate workflows: `coverage.yml`, `docs.yml`,
+  `base_benchmarks.yml`, `fork_pr_benchmarks_run.yml`,
+  `fork_pr_benchmarks_track.yml`. Each is its own file with its own trigger;
+  address separately if/when they become noisy.
+- Removing `format` or `roadmap-sync` from instruction-only PRs.
+- Adding a `Cargo.toml`-only fast-path. `Cargo.toml` changes can affect
+  feature flags, dependency resolution, and workspace topology — safer to run
+  the full matrix.
+- Changing branch-protection settings on `origin`. The existing required
+  contexts (`Format`, `Build`, `Test`, `Clippy`, `Docs`, `Feature matrix`)
+  are preserved by aggregator naming.
+- A `[force-ci]` / `workflow_dispatch` escape hatch for forcing the full
+  matrix on a doc-only PR (see § Open questions).
+
+## Deferred
+
+- Force-rerun escape hatch — deferred to Open questions; separate issue
+  needed only if the team wants explicit override semantics.
+
+## Key decisions
+
+| Question | Decision |
+|---|---|
+| Detection mechanism | `dorny/paths-filter@v4` — community-standard GHA path filter. Live current major as of 2026-05-09 (node24 runtime). Issue body cited `v3`; live registry query supersedes per AGENTS.md § Dependency Versions. |
+| `paths-ignore:` at workflow level vs. job-level `if:` | Job-level `if:` driven by a `changes` job. Workflow-level `paths-ignore` would cause GHA to not run the workflow at all, leaving required `*-pass` aggregators in `expected` state forever — PR cannot merge. This is the well-known "skipped vs success on required checks" issue. |
+| Aggregator behavior when matrix skipped | `success` if dependent job's result is `success` OR `skipped`; fail on `failure` / `cancelled`. Branch protection then sees `success` and allows merge. |
+| `docs` job aggregator | Add `docs-pass` named `Docs` with skipped-as-success logic; rename underlying `docs` job's `name:` to avoid the GitHub check-name collision (current job is `Docs`, branch protection requires `Docs`, and the aggregator must own that name). |
+| Filter scope: PR + push to master | Filter applies on both `push` and `pull_request`. Skipping the matrix on master push is fine: no source changed, so no cache save is missed in any meaningful sense. |
+| `Cargo.toml` triggers full matrix | Always. Manifest changes can shift feature flags, dependency resolution, or workspace topology — full matrix is safer. (Listed explicitly in the path filter MUST-trigger set.) |
+| `.github/workflows/**` triggers full matrix | Always. Workflow edits need real validation; skipping them would defeat the point of CI. |
+| `format` / `roadmap-sync` stay unconditional | Cheap (~15 s combined). `roadmap-sync` validates `INDEX.md`/`ROADMAP.md` integrity which is touched by instruction-only PRs. Filtering would create false negatives. |
+
+## Technical constraints
+
+- Branch protection on `origin/master` requires these named contexts (verified
+  via `gh api /repos/.../branches/master/protection`):
+  `Format`, `Build`, `Test`, `Clippy`, `Docs`, `Feature matrix`.
+  The redesigned workflow must produce a `success` result for each of these
+  on every PR — including instruction-only PRs. Achieved by:
+  - `Format` → unchanged; `format` job runs unconditionally.
+  - `Build` → owned by `build-pass` aggregator (matches today's pattern).
+  - `Test` → owned by `test-pass` aggregator.
+  - `Clippy` → owned by `clippy-pass` aggregator.
+  - `Docs` → owned by NEW `docs-pass` aggregator (rename underlying `docs`
+    job's `name:` to avoid collision).
+  - `Feature matrix` → owned by `features-pass` aggregator.
+- `actionlint` must pass on the modified workflow file (AGENTS.md gate).
+- The `changes` job adds a one-time fixed cost (`actions/checkout@v6` +
+  paths-filter run) to every CI run. Empirically this is a few seconds; well
+  under the AC1 budget.
+- `dorny/paths-filter@v4` on `pull_request` events compares against the PR
+  base branch; on `push` events it compares against the push's `before`
+  commit. Default behavior is correct for both triggers; no special
+  configuration needed.
+- Workspace crates are NOT cached by `Swatinem/rust-cache@v2` — but on
+  instruction-only PRs the matrix is skipped entirely, so cache state is not
+  a factor.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|-----------|
+| AC1 | An instruction-only PR (touches only `.claude/**`, `ai-docs/**`, `*.md`, no `.rs` / `Cargo.toml` / `Cargo.lock` / `.github/workflows/**` / `rust-toolchain*` changes) completes CI in under 60 seconds total runner wall-clock — measured as the sum of all jobs that actually ran, not the matrix-skipped jobs' notional cost. |
+| AC2 | A code-affecting PR (any `*.rs`, `Cargo.toml`, `Cargo.lock`, workflow, or `rust-toolchain*` change) still runs the full Rust matrix as today: `build`/`test`/`clippy` × 3 OS, `docs`, `features` × 4. |
+| AC3 | All `*-pass` aggregator jobs (`build-pass`, `test-pass`, `clippy-pass`, `docs-pass`, `features-pass`) report `success` on instruction-only PRs (matrix skipped → aggregator success → branch protection allows merge). |
+| AC4 | All `*-pass` aggregator jobs report `success` on code PRs ONLY when their underlying matrix jobs all succeed. A `failure` or `cancelled` in the underlying job MUST propagate to a `failure` on the aggregator. (No false-success regressions.) |
+| AC5 | `actionlint .github/workflows/ci.yml` passes cleanly with no errors or warnings. |
+| AC6 | The required branch-protection contexts (`Format`, `Build`, `Test`, `Clippy`, `Docs`, `Feature matrix`) all appear and report `success` on instruction-only PRs after this change. Verified by inspecting the live PR's check list. |
+
+## Verification protocol
+
+1. Live test on a docs-only branch: edit one file under `ai-docs/` (e.g.
+   touch a comment), push, open PR. Verify:
+   - `changes` job logs `rust == false`.
+   - Matrix jobs (`build`/`test`/`clippy`/`docs`/`features`) all report
+     `Skipped`.
+   - Each `*-pass` aggregator reports `success`.
+   - All six required-context checks report `success`.
+   - Total runner wall-clock < 60 s.
+2. Live test on a code-affecting branch: touch any `.rs` file, push, open PR.
+   Verify the full matrix runs as today and all aggregators only succeed when
+   underlying jobs succeed.
+3. Negative test: a PR with a `Cargo.toml` change but no `.rs` — must still
+   trigger the full matrix.
+4. `actionlint .github/workflows/ci.yml` clean before merge.
+
+## Open questions
+
+- **Force-rerun escape hatch**: should there be an explicit way to force the
+  full matrix on a doc-only PR (e.g. `[force-ci]` PR title token, or
+  `workflow_dispatch`)? Default position: no — if a contributor wants to
+  validate the matrix against an instruction change, they can include a
+  trivial whitespace edit to a `.rs` file (which would also serve as a clear
+  signal in the diff). Revisit if this proves friction-creating in practice.
+- **`actionlint` validation of the `if:` expression syntax**: confirmed
+  expressible as `if: needs.changes.outputs.rust == 'true'` per GHA docs;
+  design phase will verify against the live `actionlint` rule set.


### PR DESCRIPTION
## Summary

- Add `dorny/paths-filter@v4` `changes` job that detects whether any Rust-affecting path (`**/*.rs`, `**/Cargo.toml`, `Cargo.lock`, `.github/workflows/**`, `rust-toolchain*`) changed
- Gate `build` / `test` / `clippy` / `docs` / `features` on `needs.changes.outputs.rust == 'true'`; instruction-only PRs skip all five jobs
- Reshape `build-pass`, `test-pass`, `clippy-pass`, `features-pass` aggregators to treat `skipped` as `success` — with a `changes.result == 'success'` guard so a `changes` failure still propagates as failure (AC4)
- Add `docs-pass` aggregator with `name: Docs` so branch-protection's `Docs` context is owned by the aggregator; rename underlying `docs` job's `name:` to `Docs (build)` to avoid check-name collision
- `format` and `roadmap-sync` remain unconditional (~15 s combined; `roadmap-sync` actively validates `ROADMAP.md` consistency)

## Tracking

Closes #190

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean (no errors or warnings)
- [x] AC2 / AC4 (code-affecting PR): this PR itself touches `.github/workflows/ci.yml`, which matches `.github/workflows/**` in the filter → full matrix runs on this PR; aggregators only pass if matrix succeeds
- [ ] AC1 (instruction-only PR ≤ 60 s): open a second PR touching only `ai-docs/` — verify `changes` logs `rust=false`, matrix jobs skipped, all `*-pass` aggregators `success`, total wall-clock < 60 s
- [ ] AC3 (aggregators `success` when skipped): verified by AC1 live test above
- [ ] AC6 (6 required contexts all `success`): inspect live PR check list — `Format`, `Build`, `Test`, `Clippy`, `Docs`, `Feature matrix` must all appear exactly once and report `success`
- [x] `cargo build` / `cargo test` / `cargo clippy --workspace -- -D warnings` / `cargo fmt -- --check` — all clean (no Rust source modified; sanity only)