### PR TITLE
docs: convert reference-form intra-doc links to inline form workspace-wide

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -914,3 +914,15 @@ All three must be kept in sync whenever a new optional feature adds public API w
 **Rule:** The `/task` deferred-activation keyword check ("activate", "start", "proceed") fires only on those literal words in the arg. When the arg is a bare issue number, load the issue body first, then check whether any deferred spec already has `**Tracked in:** #N` matching that issue. If found, treat it as "already have a spec" — move it to `ai-docs/plans/`, update `INDEX.md`, confirm ACs with the user, and skip to Step 6. Do not run the interview and do not create a state file.
 
 **Escalated?** no
+
+### 2026-05-10 — documentation — prefer inline form `[`Foo`](path)` over reference form `[`Foo`][path]` for intra-doc links
+
+**What happened:** Post-merge code review of PR #200 (issue #199 docs cleanup) surfaced 24 intra-doc links across 8 files using the CommonMark **reference-style** form `` [`Foo`][crate::path::Foo] `` instead of the **inline** form `` [`Foo`](crate::path::Foo) ``. Both forms render to identical HTML, but the workspace was inconsistent — 100+ inline-form sites against 24 reference-form sites concentrated in the snapshot module (one author's stylistic choice).
+
+**Rule:** Use the inline form `` [`Foo`](path::Foo) `` for intra-doc links throughout the codebase. This matches the dominant convention in the Rust ecosystem — `std`, the rustdoc book examples, tokio, serde, and most popular crates use the inline form. Reference form is the minority style; reserve it only when the link target legitimately contains characters that would break the inline form (rare for Rust paths). When auditing or writing new doc comments, pick inline; when touching a file with reference-form links, convert them in the same edit.
+
+**Why:** consistency makes the codebase navigable; aligning with the ecosystem default reduces cognitive load for newcomers; the only tooling-equivalent variation is form (rendered output is identical), so the choice is purely stylistic and there's no reason to retain two forms.
+
+**How to apply:** when writing or reviewing doc comments, the intra-doc link form is `` [`Type`](crate::path::Type) `` — text in `[]`, target in `()`. Reject the reference form `` [`Type`][crate::path::Type] `` in review unless the target genuinely cannot be expressed inline.
+
+**Escalated?** no

--- a/quartzite-core/src/lib.rs
+++ b/quartzite-core/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! - **Property layer** — [`value::Value`] implements `serde::Serialize`/`Deserialize`.
 //! - **Object layer** — [`snapshot::ObjectSnapshot`] captures all
-//!   [`Stored`][meta::PropertyFlag::Stored] properties of a single object.
+//!   [`Stored`](meta::PropertyFlag::Stored) properties of a single object.
 //! - **Tree layer** — [`snapshot::TreeSnapshot`] captures an entire `ObjectTree` including
 //!   parent/child relationships.
 //!

--- a/quartzite-core/src/snapshot.rs
+++ b/quartzite-core/src/snapshot.rs
@@ -5,12 +5,12 @@
 //! This module is the entry point for the quartzite snapshot layer. It provides
 //! three levels of granularity:
 //!
-//! 1. **Property layer** — [`Value`][crate::value::Value] itself implements `serde::Serialize` /
+//! 1. **Property layer** — [`Value`](crate::value::Value) itself implements `serde::Serialize` /
 //!    `serde::Deserialize` (enabled by the `serde` cargo feature). Any
 //!    `serde`-compatible backend can be used.
 //!
 //! 2. **Object layer** — [`ObjectSnapshot`] captures all
-//!    [`Stored`][crate::meta::PropertyFlag::Stored] properties of a single
+//!    [`Stored`](crate::meta::PropertyFlag::Stored) properties of a single
 //!    object (produced by `quartzite_runtime::snapshot::capture_object`,
 //!    restored by `quartzite_runtime::snapshot::restore_object`).
 //!
@@ -25,13 +25,13 @@
 //! |---|---|
 //! | `ConnectionTable` entries (signal connections) | **Dropped.** Connections hold runtime closures with no portable representation. Caller re-establishes them after restore. |
 //! | `signals_blocked` flag | **Reset to `false`.** Persisting this state is tracked in [#39](https://github.com/maratik123/quartzite/issues/39). |
-//! | Non-`Stored` properties | **Skipped.** Properties without [`PropertyFlag::Stored`][crate::meta::PropertyFlag::Stored] are not included in the snapshot. |
+//! | Non-`Stored` properties | **Skipped.** Properties without [`PropertyFlag::Stored`](crate::meta::PropertyFlag::Stored) are not included in the snapshot. |
 //!
 //! ## `Value::Custom` round-trip
 //!
-//! [`Value::Custom`][crate::value::Value::Custom] payloads are round-tripped via
+//! [`Value::Custom`](crate::value::Value::Custom) payloads are round-tripped via
 //! [`typetag`](https://crates.io/crates/typetag). Every concrete
-//! [`CustomValue`][crate::value::CustomValue] implementation that should survive
+//! [`CustomValue`](crate::value::CustomValue) implementation that should survive
 //! serialization must be annotated:
 //!
 //! ```ignore
@@ -88,7 +88,7 @@ pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 #[non_exhaustive]
 pub enum SerializeError {
     /// `read_property` returned `None` for a property that is listed as
-    /// [`Stored`][crate::meta::PropertyFlag::Stored] in the object's meta.
+    /// [`Stored`](crate::meta::PropertyFlag::Stored) in the object's meta.
     ///
     /// This indicates a meta-system invariant violation — the meta declared the
     /// property as readable and stored, but the object did not return a value
@@ -103,13 +103,13 @@ pub enum SerializeError {
         property: String,
     },
 
-    /// The requested [`ObjectId`][crate::ObjectId] was not found in the tree during capture.
+    /// The requested [`ObjectId`](crate::ObjectId) was not found in the tree during capture.
     ///
-    /// This occurs when `capture_tree` is called with an [`ObjectId`][crate::ObjectId] that is
+    /// This occurs when `capture_tree` is called with an [`ObjectId`](crate::ObjectId) that is
     /// not present in the provided `ObjectTree`.
     #[error("object id {id} is not present in the tree")]
     ObjectNotInTree {
-        /// The raw `u64` of the [`ObjectId`][crate::ObjectId] that was not found.
+        /// The raw `u64` of the [`ObjectId`](crate::ObjectId) that was not found.
         id: u64,
     },
 }

--- a/quartzite-core/src/snapshot/object.rs
+++ b/quartzite-core/src/snapshot/object.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::value::Value;
 
-/// A serializable snapshot of a single object's [`Stored`][crate::meta::PropertyFlag::Stored]
+/// A serializable snapshot of a single object's [`Stored`](crate::meta::PropertyFlag::Stored)
 /// properties.
 ///
 /// Produced by the capture functions in `quartzite-runtime::snapshot` and consumed by the
@@ -31,6 +31,6 @@ use crate::value::Value;
 pub struct ObjectSnapshot {
     /// The class name used to reconstruct the object via the runtime factory.
     pub class_name: String,
-    /// The [`Stored`][crate::meta::PropertyFlag::Stored] property values keyed by name.
+    /// The [`Stored`](crate::meta::PropertyFlag::Stored) property values keyed by name.
     pub properties: BTreeMap<String, Value>,
 }

--- a/quartzite-core/src/snapshot/tree.rs
+++ b/quartzite-core/src/snapshot/tree.rs
@@ -26,7 +26,7 @@ pub struct ObjectNode {
     pub snapshot: ObjectSnapshot,
     /// Ordered child nodes.
     pub children: Vec<ObjectNode>,
-    /// The original [`ObjectId`][crate::ObjectId] raw u64 of this object at capture time.
+    /// The original [`ObjectId`](crate::ObjectId) raw u64 of this object at capture time.
     ///
     /// Used by `quartzite_runtime::snapshot::restore_tree` to build an
     /// `old_id → new_id` remap table so that intra-tree `Value::Object`
@@ -70,8 +70,8 @@ impl TreeSnapshot {
     ///
     /// # Errors
     ///
-    /// Returns [`DeserializeError::UnsupportedVersion`][crate::snapshot::DeserializeError::UnsupportedVersion]
-    /// when `schema_version` exceeds [`CURRENT_SCHEMA_VERSION`][crate::snapshot::CURRENT_SCHEMA_VERSION].
+    /// Returns [`DeserializeError::UnsupportedVersion`](crate::snapshot::DeserializeError::UnsupportedVersion)
+    /// when `schema_version` exceeds [`CURRENT_SCHEMA_VERSION`](crate::snapshot::CURRENT_SCHEMA_VERSION).
     ///
     /// # Examples
     ///

--- a/quartzite-runtime/src/snapshot.rs
+++ b/quartzite-runtime/src/snapshot.rs
@@ -3,13 +3,13 @@
 //! This module provides three levels of granularity:
 //!
 //! 1. **Object layer** — [`capture_object`] / [`restore_object`] operate on a
-//!    single [`Object`][quartzite_core::Object] and its
-//!    [`Stored`][quartzite_core::meta::PropertyFlag::Stored] properties.
+//!    single [`Object`](quartzite_core::Object) and its
+//!    [`Stored`](quartzite_core::meta::PropertyFlag::Stored) properties.
 //!
 //! 2. **Tree layer** — [`capture_tree`] / [`restore_tree`] snapshot an entire
-//!    [`ObjectTree`][crate::ObjectTree] including parent/child relationships.
-//!    Intra-tree [`WeakObjectRef`][quartzite_core::value::WeakObjectRef]
-//!    payloads are remapped to the fresh [`ObjectId`][quartzite_core::ObjectId]s
+//!    [`ObjectTree`](crate::ObjectTree) including parent/child relationships.
+//!    Intra-tree [`WeakObjectRef`](quartzite_core::value::WeakObjectRef)
+//!    payloads are remapped to the fresh [`ObjectId`](quartzite_core::ObjectId)s
 //!    minted during restore.
 //!
 //! ## What is NOT preserved

--- a/quartzite-runtime/src/snapshot/object.rs
+++ b/quartzite-runtime/src/snapshot/object.rs
@@ -7,7 +7,7 @@ use quartzite_core::{
 
 use crate::factory::ObjectFactory;
 
-/// Captures all [`Stored`][PropertyFlag::Stored] properties of `obj` into an
+/// Captures all [`Stored`](PropertyFlag::Stored) properties of `obj` into an
 /// [`ObjectSnapshot`].
 ///
 /// Properties without the `Stored` flag are silently skipped.

--- a/quartzite-runtime/src/snapshot/tree.rs
+++ b/quartzite-runtime/src/snapshot/tree.rs
@@ -15,7 +15,7 @@ use super::object::{capture_object, restore_object};
 /// [`TreeSnapshot`].
 ///
 /// The walk is depth-first. Only
-/// [`Stored`][quartzite_core::meta::PropertyFlag::Stored] properties are
+/// [`Stored`](quartzite_core::meta::PropertyFlag::Stored) properties are
 /// included in each node's snapshot.
 ///
 /// # Parameters
@@ -69,7 +69,7 @@ fn capture_node(tree: &ObjectTree, id: ObjectId) -> Result<ObjectNode, Serialize
 /// tree is completely fresh — it does not merge into or mutate any existing tree.
 ///
 /// After restore:
-/// - Each object is constructed via the process-wide [`ObjectFactory`][crate::factory::ObjectFactory].
+/// - Each object is constructed via the process-wide [`ObjectFactory`](crate::factory::ObjectFactory).
 /// - `Stored` properties are written back; non-`Stored` properties retain their defaults.
 /// - Signal connections are **dropped** — the restored objects start with empty connection
 ///   tables and `signals_blocked = false`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ pub mod events {
 ///   `serde::Deserialize`; any backend works.
 /// - **Object level** — [`capture_object`](quartzite_runtime::snapshot::capture_object) /
 ///   [`restore_object`](quartzite_runtime::snapshot::restore_object) snapshot a single
-///   object's [`Stored`][quartzite_core::meta::PropertyFlag::Stored] properties.
+///   object's [`Stored`](quartzite_core::meta::PropertyFlag::Stored) properties.
 /// - **Tree level** — [`capture_tree`](quartzite_runtime::snapshot::capture_tree) /
 ///   [`restore_tree`](quartzite_runtime::snapshot::restore_tree) snapshot an entire
 ///   [`ObjectTree`](crate::runtime::ObjectTree) including parent/child structure.


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #200 (issue #199 docs cleanup). Code review surfaced 24 intra-doc links across 8 files using the CommonMark **reference-style** form `[Foo][crate::path]` instead of the **inline** form `[Foo](crate::path)`. Both render to identical HTML, but the inline form is the dominant convention in the Rust ecosystem (`std`, the rustdoc book, tokio, serde, …), and 100+ existing sites in this workspace already use it. Reference form was concentrated in the `snapshot` module across `quartzite-core` + `quartzite-runtime` — one author's stylistic choice.

Mechanical conversion via `perl -i -pe 's/\]\[([^\]]+)\]/](\1)/g'` on the 8 affected files. No false positives — pre-substitution check confirmed every `][` in those files was an intra-doc link (no array indexing in doc comments). 24 lines changed, zero functional change, identical rendered HTML.

Convention recorded in `ai-docs/learnings.md` (entry dated 2026-05-10). Not escalated to `ai-docs/doc-convention.md` in this PR per the append-only-then-defer-escalation boundary rule — `/improve` will pick it up if the rule needs to be enforced workspace-wide as a future review-checklist item.

## Test plan

- [x] `rg -c '\]\[[A-Za-z_]' --type rust` returns 0 (down from 24)
- [x] `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --no-deps --workspace --all-features` exits 0 — rendered output identical to pre-conversion
- [x] `cargo build` exits 0
- [x] `cargo clippy --workspace --all-features -- -D warnings` exits 0
- [x] `cargo fmt -- --check` exits 0
- [x] `ai-docs/learnings.md` gains a single new entry (append-only)