### PR TITLE
chore(deferred): /triage bridge — mark 33 stale Tracked refs as (closed)

### DIFF
--- a/ai-docs/deferred/ci-docs-workflow.md
+++ b/ai-docs/deferred/ci-docs-workflow.md
@@ -6,25 +6,25 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| Badge links in README \| will be added later by user | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #60 |
-| Contributing guide, roadmap \| user will add later | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #60 |
-| Additional facade features \| will be added based on needs as the project grows | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #60 |
+| Badge links in README \| will be added later by user | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #60 (closed) |
+| Contributing guide, roadmap \| user will add later | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #60 (closed) |
+| Additional facade features \| will be added based on needs as the project grows | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #60 (closed) |
 
 ## Out of scope
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #133 |
+| Windows / macOS CI runners | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #133 (closed) |
 | Auto-merge | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | — |
-| Code coverage (`cargo-llvm-cov` + Codecov) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #134 |
-| Benchmarks (`criterion` + PR regression comments) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #135 |
+| Code coverage (`cargo-llvm-cov` + Codecov) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #134 (closed) |
+| Benchmarks (`criterion` + PR regression comments) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #135 (closed) |
 | Release workflow (cargo publish on tagged versions) | [github-workflow spec](../plans/done/2026-05-01-github-workflow.spec.md) | | #136 |
 | Removing `rstest` from `quartzite-core` — it is genuinely used in `quartzite-core/src/value.rs` | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | | — |
 | Any other code-quality changes not listed above | [code-quality-cleanup spec](../plans/done/2026-05-02-code-quality-cleanup.spec.md) | | — |
 | `std` feature on `quartzite-runtime` (would gate nothing today) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
 | Full wildcard re-exports beyond `prelude` | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
 | Future features (`extension`, `8k_pages`, etc.) | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | — |
-| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #137 |
+| `cargo doc` publishing / CI integration | [docs-and-facade spec](../plans/done/2026-05-02-docs-and-facade.spec.md) | | #137 (closed) |
 | Unit tests inside example files | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | — |
 | Private/internal items | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | — |
 | Separate EXAMPLES.md or README additions beyond existing content | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | — |

--- a/ai-docs/deferred/future-crates.md
+++ b/ai-docs/deferred/future-crates.md
@@ -6,16 +6,16 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| Examples for geometry-events, widgets, paint-style \| those crates not yet implemented | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #45, #46, #47 |
+| Examples for geometry-events, widgets, paint-style \| those crates not yet implemented | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #45 (closed), #46 (closed), #47 (closed) |
 
 ## Out of scope
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
 | Proc macros (separate crate) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done | |
-| Widget hierarchy (quartzite-widgets) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #46 |
-| Event system (quartzite-events) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #45 |
-| Widget rendering (quartzite-widgets) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #46 |
-| Event model types (quartzite-events) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #45 |
-| Examples for unimplemented crates (geometry, events, widgets, paint, style) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #45, #46, #47 |
-| `quartzite-widgets` (not yet implemented) | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | #46 |
+| Widget hierarchy (quartzite-widgets) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #46 (closed) |
+| Event system (quartzite-events) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #45 (closed) |
+| Widget rendering (quartzite-widgets) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #46 (closed) |
+| Event model types (quartzite-events) | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #45 (closed) |
+| Examples for unimplemented crates (geometry, events, widgets, paint, style) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #45 (closed), #46 (closed), #47 (closed) |
+| `quartzite-widgets` (not yet implemented) | [public-api-docs spec](../plans/done/2026-05-02-public-api-docs.spec.md) | | #46 (closed) |

--- a/ai-docs/deferred/macros-codegen.md
+++ b/ai-docs/deferred/macros-codegen.md
@@ -6,8 +6,8 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| `#[object_impl]` on multiple impl blocks for one type \| single impl block only for now | [macros spec](../plans/done/2026-05-01-macros.spec.md) | | #57 |
-| `proc_macro_crate` based path detection in `quartzite-macros` \| would let users depend on only `quartzite` or only `quartzite-core`; non-trivial, separate task | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #57 |
+| `#[object_impl]` on multiple impl blocks for one type \| single impl block only for now | [macros spec](../plans/done/2026-05-01-macros.spec.md) | | #57 (closed) |
+| `proc_macro_crate` based path detection in `quartzite-macros` \| would let users depend on only `quartzite` or only `quartzite-core`; non-trivial, separate task | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #57 (closed) |
 
 ## Out of scope
 
@@ -17,8 +17,8 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 | `#[derive(Extend)]` on enums or tuple structs (named fields only) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | | — |
 | Test-only `AsObject` impls inside `#[cfg(test)]` modules | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) | | — |
 | Any generated or hand-written function with branches, loops, or more than one call to a non-simple function | [inline-simple-fns spec](../plans/done/2026-05-02-inline-simple-fns.spec.md) (superseded by AGENTS.md Code Style → `#[inline]` recursive rule) | | — |
-| Codegen emission of `/// _Simple._` doc tag for generated generic simple fns and for generated trait-method docs whose impls are always simple | AGENTS.md Code Style → `#[inline]` and the `_Simple._` doc tag | | #117 |
-| Changing `quartzite-macros` codegen (deferred — `proc_macro_crate` is a separate future task) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #57 |
+| Codegen emission of `/// _Simple._` doc tag for generated generic simple fns and for generated trait-method docs whose impls are always simple | AGENTS.md Code Style → `#[inline]` and the `_Simple._` doc tag | | #117 (closed) |
+| Changing `quartzite-macros` codegen (deferred — `proc_macro_crate` is a separate future task) | [examples-crate spec](../plans/done/2026-05-02-examples-crate.spec.md) | | #57 (closed) |
 
 ## Open questions
 
@@ -26,5 +26,5 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 |------|--------|--------|---------|
 | Should `Base` suffix be stripped when forming `As{Name}` trait? (`WidgetBase` → `AsWidget` or `AsWidgetBase`?) | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done | |
 | Should `#[derive(Object)]` require `#[derive(Extend)]` to be present, or are they independent? | [macros spec](../plans/done/2026-05-01-macros.spec.md) | ✅ done | |
-| How to handle generic structs with `#[derive(Extend)]`? | [macros spec](../plans/done/2026-05-01-macros.spec.md) | | #57 |
+| How to handle generic structs with `#[derive(Extend)]`? | [macros spec](../plans/done/2026-05-01-macros.spec.md) | | #57 (closed) |
 | Should `MetaObject::new()` be extended with fn pointer params or replaced by struct literal construction in the macro? Decide in design phase. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | ✅ done | |

--- a/ai-docs/deferred/object-tree.md
+++ b/ai-docs/deferred/object-tree.md
@@ -6,23 +6,23 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
-| `ObjectTree::find_by_name` subtree scoping \| future; flat search sufficient for v1 | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 |
+| `ObjectTree::find_by_name` subtree scoping \| future; flat search sufficient for v1 | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 (closed) |
 
 ## Out of scope
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
 | Object tree / arena / ownership model (quartzite-runtime) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done | |
-| Subtree-scoped `find_by_name` (flat search sufficient for now) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 |
-| Async/reactive name-change notifications (needs event system) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 |
+| Subtree-scoped `find_by_name` (flat search sufficient for now) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 (closed) |
+| Async/reactive name-change notifications (needs event system) | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #54 (closed) |
 
 ## Open questions
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
 | Should `WeakObjectRef` be a type alias or a newtype? (Depends on runtime ownership choice) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done | |
-| Should `ObjectBase` derive `Debug`? (Useful for testing; `dynamic_properties` contains `Value`) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #61 |
+| Should `ObjectBase` derive `Debug`? (Useful for testing; `dynamic_properties` contains `Value`) | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #61 (closed) |
 | **Object ownership**: arena (SlotMap + ObjectId keys) vs `Rc<RefCell<dyn Object>>`? This is the primary decision blocking implementation. | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done | |
 | Should `ObjectRef<T>` be a typed wrapper around `ObjectId` or around `Rc<RefCell<T>>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done | |
-| **`ObjectExt::parent()` / `children()` accessor mechanism**: With parent/children removed from `ObjectBase`, these methods need to reach `ObjectTree`. The simplest approach is a process-global `fn with_tree<R>(f: impl FnOnce(&ObjectTree) -> R) -> R` registered by `Application`. Needs decision before Task 4 finalizes the `ObjectExt` blanket impl. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | | #55 |
-| Should `ObjectTree::rename` be a no-op when called with the object's current name? Implementation must be correct either way; no special case required. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #61 |
+| **`ObjectExt::parent()` / `children()` accessor mechanism**: With parent/children removed from `ObjectBase`, these methods need to reach `ObjectTree`. The simplest approach is a process-global `fn with_tree<R>(f: impl FnOnce(&ObjectTree) -> R) -> R` registered by `Application`. Needs decision before Task 4 finalizes the `ObjectExt` blanket impl. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | | #55 (closed) |
+| Should `ObjectTree::rename` be a no-op when called with the object's current name? Implementation must be correct either way; no special case required. | [lookup-perf spec](../plans/done/2026-05-02-lookup-perf.spec.md) | | #61 (closed) |

--- a/ai-docs/deferred/signals-slots.md
+++ b/ai-docs/deferred/signals-slots.md
@@ -7,19 +7,19 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
 | `BlockingQueued` connection type \| threading model not yet decided | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #48 |
-| Signal-to-signal connections \| needs runtime design first | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #49 |
+| Signal-to-signal connections \| needs runtime design first | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | | #49 (closed) |
 | `BlockingQueued` connection type \| depends on per-thread loops | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #48 |
-| Enforcing the signals_blocked check at `Signal` level rather than codegen level \| requires API redesign (#38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | | #38 |
-| `auto_cross_thread_slot_not_posted_after_receiver_destroyed` test \| requires `Weak<ReceiverGuard>` in the auto slot entry; `AutoSlotInner` does not hold a guard in v1 | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | | #50 |
-| `ReceiverGuard` for `Auto` connections \| `connect_auto` currently accepts no guard; cross-thread Auto slots will post even after the receiver is destroyed; requires `ConnectionTable` integration | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | | #50 |
+| Enforcing the signals_blocked check at `Signal` level rather than codegen level \| requires API redesign (#38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | | #38 (closed) |
+| `auto_cross_thread_slot_not_posted_after_receiver_destroyed` test \| requires `Weak<ReceiverGuard>` in the auto slot entry; `AutoSlotInner` does not hold a guard in v1 | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | | #50 (closed) |
+| `ReceiverGuard` for `Auto` connections \| `connect_auto` currently accepts no guard; cross-thread Auto slots will post even after the receiver is destroyed; requires `ConnectionTable` integration | [auto-connection design](../plans/done/2026-05-01-auto-connection.design.md) | | #50 (closed) |
 
 ## Out of scope
 
 | Item | Source | Status | Tracked |
 |------|--------|--------|---------|
 | `BlockingQueued` — threading model not yet decided (already deferred in core-types spec) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | | #48 |
-| Signal-to-signal connections — blocked on runtime design (already deferred) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | | #49 |
-| Changes to `Signal::emit` itself (tracked in #38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | | #38 |
+| Signal-to-signal connections — blocked on runtime design (already deferred) | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | | #49 (closed) |
+| Changes to `Signal::emit` itself (tracked in #38) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | | #38 (closed) |
 | Serialization of `signals_blocked` state (tracked in #39) | [signals-blocked spec](../plans/done/2026-05-02-signals-blocked.spec.md) | | #39 |
 
 ## Open questions

--- a/ai-docs/deferred/threading-runtime.md
+++ b/ai-docs/deferred/threading-runtime.md
@@ -8,7 +8,7 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 |------|--------|--------|---------|
 | No-std validation \| design for it but don't enforce until runtime exists | [core-types spec](../plans/done/2026-05-01-core-types.spec.md) | ✅ done | |
 | Multi-window support \| needs platform backend first | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #53 |
-| Thread event loops (one loop per thread) \| defer until threading model decided | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #51 |
+| Thread event loops (one loop per thread) \| defer until threading model decided | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | | #51 (closed) |
 | Stale `thread_id` invalidation \| needs object-mobility / thread-affinity-change API first | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | | #52 |
 | `AutoConnection` in no_std \| same gating as `Queued`; unblocked when std feature is defined | [auto-connection spec](../plans/done/2026-05-01-auto-connection.spec.md) | ✅ done | |
 
@@ -25,5 +25,5 @@ Items extracted from completed plans. See [index](../deferred-items.md).
 | Should `ConnectionTable` use `DashMap` (lock-free) or `Mutex<HashMap>`? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done | |
 | Should the event loop be `async`-runtime-agnostic (pluggable executor) or std-thread-based only? | [runtime spec](../plans/done/2026-05-01-runtime.spec.md) | ✅ done | |
 | **`QueuedDispatcher` trait location**: Proposed to live in quartzite-core behind `feature = "std"`. Alternative: define it in quartzite-runtime and have core use a raw function pointer or a `OnceLock<fn(Box<dyn FnOnce() + Send>)>`. Needs decision before Task 5. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | ✅ done | |
-| **`ObjectFactory` global vs. per-`Application`**: Should there be a process-wide factory singleton (like `ConnectionTable`), or one per `Application`? **Proposed**: per-`Application`, accessible via `Application::factory()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | | #61 |
+| **`ObjectFactory` global vs. per-`Application`**: Should there be a process-wide factory singleton (like `ConnectionTable`), or one per `Application`? **Proposed**: per-`Application`, accessible via `Application::factory()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | | #61 (closed) |
 | **`ThreadPool` shutdown semantics**: Should `ThreadPool::drop` wait for in-flight tasks to complete (graceful) or abandon them? **Proposed**: graceful — close the sender and join all workers. Panic in a worker thread propagates as a resumed panic in `join()`. | [runtime design](../plans/done/2026-05-01-runtime.design.md) | ✅ done | |


### PR DESCRIPTION
## Summary

`/triage` run on 2026-05-11. Phase 4.5 bridge detected **33 Type-1 stale-tracked conflicts**: deferred-row `Tracked` cells pointing to gh issues whose state is `CLOSED`. Resolved all 33 with `update md` (no gh issue state changes); appended ` (closed)` inline after each closed `#N`.

## Bridge resolution

| File | Cells rewritten |
|---|---:|
| `ai-docs/deferred/signals-slots.md` | 6 |
| `ai-docs/deferred/macros-codegen.md` | 5 |
| `ai-docs/deferred/object-tree.md` | 6 |
| `ai-docs/deferred/threading-runtime.md` | 2 |
| `ai-docs/deferred/future-crates.md` | 7 (3 cells contained multi-ref `#N, #N, #N` — each marked) |
| `ai-docs/deferred/ci-docs-workflow.md` | 7 |
| **Total** | **33** |

`gh issue` calls made: **0**. `ai-docs/deferred-items.md` row count: unchanged (closed-marker is inline annotation only).

## Out of scope (deferred to follow-up runs)

- Phase 6 cell-iteration sweep: 12 thematic-file `—` rows (3 `macros-codegen.md`, 9 `ci-docs-workflow.md`) + 21 widget-backlog 🟡 v2 rows.
- Phase 7 `_inbox.md` drain: 331 rows.

## Test plan

- [x] `git diff --stat` shows only the 6 deferred files, 33 ins / 33 del
- [x] Open `#N` references (e.g., `#48`, `#39`, `#52`, `#53`, `#56`, `#58`, `#136`) NOT marked
- [x] Multi-ref cells in `future-crates.md` (lines 9, 20) annotate each `#N` independently
- [x] No `(closed)` substring existed pre-edit (idempotency guard fired 0 times)