### PR TITLE
chore: /improve escalations for action-behaviour and GO-notes

### DIFF
--- a/.claude/agents/design-review.md
+++ b/.claude/agents/design-review.md
@@ -55,7 +55,7 @@ Every suspicion — **investigate via Read/grep**, don't guess and don't give be
 ```
 
 Verdict is one of three values:
-- **GO** — actively checked, no blockers found. Notes are allowed.
+- **GO** — actively checked, no blockers found. Notes / minors / recommendations are allowed, **but they are not free**: every such item MUST be written back into the design document (the relevant API table, helper list, risk table, decomposition section) by the orchestrator BEFORE Step 8 implementation begins. The design doc is the implementation contract; "applied in code later" is not the same as "resolved in the design", and a stale design doc misleads every future reviewer. Surface this expectation explicitly in the verdict — when emitting GO with notes, append a final line under `## Recommendations`: `**Round-trip required:** before Step 8, update the design doc to incorporate each note/recommendation above.` Empty notes / recommendations → no round-trip line needed.
 - **ITERATE** — blockers exist, specific sections need rework
 - **STOP** — fundamental problem with the approach, needs rethinking. Iterations won't help.
 

--- a/.claude/agents/self-review.md
+++ b/.claude/agents/self-review.md
@@ -41,6 +41,7 @@ A passing test doesn't mean it's correct. Mentally comment out the production fi
 - Implementation architecture matches the design?
 - All files from the decomposition are present and changed?
 - No architectural decisions made on-the-fly without being reflected in the design?
+- **GO-with-notes round-trip closure.** Locate the most recent design-review verdict in the conversation context / progress file. For every `note` / `minor` row in its `## Issues` table and every bullet in its `## Recommendations` section, verify the corresponding section of the design doc (`ai-docs/plans/YYYY-MM-DD-name.design.md`) was updated to incorporate the note BEFORE the implementation diff started. If the design doc still says one thing and the implementation does another (even correctly), the design is stale — REJECT (`major`) with the specific note that was applied in code but not written back. See `ai-docs/learnings.md` 2026-05-13 entry on design-review notes closure.
 
 ### 3. Test coverage
 - Every non-trivial function / branch has a test?

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -133,7 +133,7 @@ finding (Step 11) requires a design change rather than a code fix:
 
 ### Step 8: Implementation
 
-> First action: verify both spec and design (with GO verdict) exist. Missing = previous steps incomplete.
+> First action: verify both spec and design (with GO verdict) exist AND that **every note / minor / recommendation from the latest design-review GO verdict has been written back into the design document**. "Applied in code later" is NOT the same as "resolved in the design"; the design doc is the implementation contract. Scan the most recent `## Self-Review (Round N)` / `## Verdict: GO` block emitted by `.claude/agents/design-review.md` — for each `## Issues` row of `Severity: note` / `minor` and each `## Recommendations` bullet, confirm the corresponding API table / helper list / risk table / decomposition section of `ai-docs/plans/YYYY-MM-DD-name.design.md` was updated to match. If any note is unresolved → stop, edit the design doc to incorporate it (and re-run design-review if the change is non-trivial per the Design Amendment rule), and only then begin coding. Missing spec, missing design, missing GO verdict, OR unresolved GO-notes = previous steps incomplete.
 
 - **Create a feature branch immediately** — before writing any code or making any commits:
   ```bash
@@ -323,7 +323,7 @@ Step 12 continues normally; `_inbox.md` is unchanged for that section.
 |---|---|
 | Steps 1–5 | Spec saved at `ai-docs/plans/YYYY-MM-DD-name.spec.md`? `**Tracked in:** #N` present (or `none` with reason)? Cross-link comment posted on the tracking issue (unless tracking skipped)? ACs confirmed by user and verifiable? See `/interview` gate checklist for the full per-step list. |
 | Step 6 | Spec exists? ACs confirmed? Not a "spec-only / defer" run? |
-| Step 8 | Design doc with GO? Test Design section present? |
+| Step 8 | Design doc with GO? Test Design section present? **Every note / minor / recommendation from the GO verdict written back into the design doc?** |
 | Step 8 start | Feature branch created? Run `git branch --show-current` before every `git commit` — must not be `master`. `base_commit` + `branch` recorded in progress file? |
 | Each subtask | `cargo build` ✅? Tests run? `.progress.md` updated? |
 | Step 9 | `cargo build` ✅? `cargo test` green? `cargo fmt -- --check` clean? `cargo clippy --workspace -- -D warnings` clean (note: `--workspace`, not bare)? `cargo doc --no-deps --workspace --all-features` clean (note: `--all-features`, not bare and not a hand-picked subset — every feature-gated public module/re-export must be enabled so intra-doc links resolve)? `actionlint` clean on every changed `.github/workflows/*.yml` (skip if none changed)? Any new `# Panics` doc section / `.unwrap()` / `.expect()` / `panic!` outside `#[cfg(test)]` → `ai-docs/panic-index.md` updated and staged (skip when no new production panics)? All ACs covered? |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,16 +95,17 @@ See [`ai-docs/code-style.md`](ai-docs/code-style.md) for the canonical reference
 
 ## Dependency Versions
 
-> **AXIOM — Query the live registry BEFORE writing any specific version string. Training data is stale.**
-> Whenever you write a specific version of a Cargo crate or a GitHub Action — anywhere (`Cargo.toml`, workflow file, issue body, spec, design doc, learning, any `ai-docs/**` page) — query the live source first. Treating remembered versions as authoritative has put wrong majors into specs twice in this repo (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`).
+> **AXIOM — Query the live registry BEFORE writing any specific version string OR asserting external-action behaviour. Training data is stale.**
+> Whenever you write a specific version of a Cargo crate or a GitHub Action — anywhere (`Cargo.toml`, workflow file, issue body, spec, design doc, learning, any `ai-docs/**` page) — query the live source first. Treating remembered versions as authoritative has put wrong majors into specs twice in this repo (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`). The same logic applies one level deeper: a third-party GitHub Action's **behaviour** (what env vars it exports, what files it produces, which defaults it sets) is also stale in training data and in marketplace blurbs — treating it as authoritative landed the wrong claim into spec + design once (PR #179 sccache: "action sets `RUSTC_WRAPPER` and `SCCACHE_GHA_ENABLED` by default" — false; `src/setup.ts` only exports `SCCACHE_PATH` + cache-service vars, README's "Rust code" subsection explicitly mandates the user set them).
 >
 > | If you need to write... | Run this first |
 > |---|---|
 > | A Cargo crate version | `curl -sS "https://crates.io/api/v1/crates/<name>" \| jq -r '.crate.max_stable_version'` |
 > | A GitHub Action version | `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` (and verify the action's Node runtime is current) |
 > | A version into a long-lived doc (won't be revisited for months) | Annotate `(verified current YYYY-MM-DD)` next to the version |
+> | A **load-bearing claim about an Action's behaviour** (env vars it exports, defaults it sets, files it produces — anything the spec or design relies on) | `gh api /repos/<owner>/<repo>/contents/action.yml --jq '.content' \| base64 -d` AND `gh api /repos/<owner>/<repo>/contents/src/setup.ts --jq '.content' \| base64 -d \| grep -inE 'exportVariable\|process\.env\|GITHUB_ENV\|saveState'` (or `src/main.ts` for run-step actions). Cite the source-line evidence in the design — README narrative alone is **not** evidence. |
 >
-> Then apply the pinning rule (below) to the **observed** version, never the remembered one.
+> Then apply the pinning rule (below) to the **observed** version, never the remembered one. If `setup.ts` / `main.ts` does not export the env vars your design assumed, set them explicitly in the workflow (per-job `env:` or `echo >> $GITHUB_ENV` after the action step) — don't rely on "the action probably sets it".
 
 When adding or editing dependencies in `Cargo.toml`:
 


### PR DESCRIPTION
## Summary
- **AGENTS.md `Dependency Versions` axiom strengthened** — the registry-query gate now fires not only for version strings but also for load-bearing claims about a third-party Action's **behaviour** (env vars it exports, defaults it sets, files it produces). New table row mandates `gh api .../action.yml` + `src/setup.ts` / `src/main.ts` source-line inspection. README narrative is explicitly **not** evidence. Proof point: PR #179 sccache (action does not export `RUSTC_WRAPPER` / `SCCACHE_GHA_ENABLED` despite the assumption that landed in the design doc).
- **Design-review GO-with-notes round-trip closure** — coordinated across three files so the gap is caught at multiple points:
  - `.claude/agents/design-review.md`: GO-verdict description now spells out that every note / minor / recommendation MUST be written back into the design doc before Step 8; verdicts append a `**Round-trip required:**` line when notes are non-empty.
  - `.claude/skills/task/SKILL.md`: Step 8 first-action requires verifying every GO-note has been incorporated into the design doc before implementation begins. Gate-checklist row mirrors the requirement.
  - `.claude/agents/self-review.md`: §2 Design conformance gains a REJECT-major bullet for notes that landed in code but not in the design.

Authorised by `/improve` invocation on 2026-05-13; both patterns at 2 recurrences in `ai-docs/learnings.md` (below the ≥3 hook-escalation threshold).

## Test plan
- [ ] AGENTS.md table row renders correctly in markdown preview
- [ ] Next `/task` invocation surfaces the new Step 8 GO-notes check in its checklist
- [ ] Re-run `/improve` in a fresh session for a clean-context eval (current eval was in-context only — flagged as a deviation in the agent report)
- [ ] `actionlint` n/a (no workflow changes)
- [ ] `cargo` gates n/a (instruction files only)