### PR TITLE
chore: carve Boundary rule Exceptions for Escalated? maintenance

### DIFF
--- a/.claude/agents/learnings-escalation-audit.md
+++ b/.claude/agents/learnings-escalation-audit.md
@@ -1,6 +1,6 @@
 ---
 name: learnings-escalation-audit
-description: "Verifies that every entry in ai-docs/learnings.md has an accurate `Escalated?` field — the named target (AGENTS.md / skill / agent / hook / settings) actually contains the rule. Fixes drift in-place. Invoked by /ai-audit Phase 1. Does not write project code."
+description: "Verifies that every entry in ai-docs/learnings.md has an accurate `Escalated?` field — the named target (AGENTS.md / skill / agent / hook / settings) actually contains the rule. Fixes drift in-place (edits only the `Escalated?` line of affected entries; never touches date, category, description, what-happened, or rule text). Authorised by AGENTS.md § Corrections Log Boundary rule 1 Exception. Invoked by /ai-audit Phase 1. Does not write project code."
 model: opus
 ---
 
@@ -75,7 +75,7 @@ Record each entry's status:
 
 For each non-OK entry, propose ONE of:
 
-1. **Update `Escalated?` field only.** The rule landed somewhere else (e.g., the entry says `AGENTS.md` but the rule is now in `skill:code-review`). Fix the field to reflect reality.
+1. **Update `Escalated?` field only.** The rule landed somewhere else (e.g., the entry says `AGENTS.md` but the rule is now in `skill:code-review`). Fix the field to reflect reality. **Also fix obvious typos within the `Escalated?` value** — e.g., `AGENTS,md` → `AGENTS.md`, `skillcode-review` → `skill:code-review`, missing comma between two targets. Treat typo correction as drift, not as a rewrite.
 2. **Re-add the missing rule.** The rule was lost during a refactor. Add it back to the named target.
 3. **Surface to user.** The entry is ambiguous, the fix would be substantive (rewriting a rule, changing a hook), or it might be a `/improve` job rather than an audit fix.
 
@@ -85,7 +85,7 @@ Always surface category 3.
 
 ### Step 4: Apply approved field corrections
 
-For each category-1 fix, edit `ai-docs/learnings.md` in place — change only the `**Escalated?**` line for that entry. Preserve everything else exactly. Do **not** rewrite the date, what-happened, or rule fields.
+For each category-1 fix, edit `ai-docs/learnings.md` in place — change only the `**Escalated?**` line for that entry. Preserve everything else exactly. Do **not** rewrite the date, what-happened, or rule fields. This edit is authorised by **AGENTS.md § Corrections Log → Boundary rule 1 → Exception** (`Escalated?` field, agent-driven only); typo fixes within the `Escalated?` value are in scope of the same exception.
 
 ### Step 5: Cross-checks
 

--- a/.claude/agents/self-improve.md
+++ b/.claude/agents/self-improve.md
@@ -71,9 +71,17 @@ git checkout -b chore/YYYY-MM-DD-improve-<short-name>
 
 `git checkout -b` carries the (still-uncommitted) working tree over. Discovering you're on master *after* editing forces a reactive recovery — switching at commit time technically respects AGENTS.md "no commits on master" but breaks the spirit (working tree should never accumulate on master). Switch first, edit second.
 
-Number all proposals. Let user choose. Apply the selected:
-- Update `AGENTS.md` / skill / agent files via Edit
-- Update `Escalated?` field in `ai-docs/learnings.md` for processed entries
+Number all proposals. Let user choose.
+
+**Apply in two commits on the same feature branch:**
+
+1. **Commit A — instruction-file edits.** Apply the approved diffs to `AGENTS.md` / skill / agent / hook / `ai-docs/code-style.md` / `ai-docs/doc-convention.md` / `.claude/settings.json`. Stage explicitly by name. Run any applicable gates (`actionlint` on changed workflows, `cargo fmt -- --check` if a code-style example changed). Commit with a message describing the escalation.
+
+2. **Commit B — backfill `Escalated?`.** For each `ai-docs/learnings.md` entry whose pattern was just escalated in Commit A, edit ONLY the `**Escalated?**` line — replace the prior value (typically `no`) with the comma-separated list of targets actually modified. Do not touch any other line of the entry. Do not append new entries. Commit message: `chore(learnings): backfill Escalated? for entries <date1>, <date2>, ...`.
+
+   This edit is authorised by **AGENTS.md § Corrections Log → Boundary rule 1 → Exception** (`Escalated?` field, agent-driven only). All other lines of the entry remain immutable.
+
+   **Boundary rule 2 note:** Splitting into Commit A then Commit B keeps the PR diff legible (escalation substance separate from bookkeeping). The exception in Boundary rule 2 authorises both commits in the same `/improve` turn; it does NOT authorise appending NEW learning entries in the same turn.
 
 ### Step 6: Eval (REQUIRED after Step 5)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ Per source:
 > | `.claude/agents/triage-runner.md` | `.claude/skills/triage/SKILL.md` AND `.claude/skills/next/SKILL.md` (Triage group) |
 > | `.claude/skills/next/SKILL.md` | `.claude/skills/triage/SKILL.md` AND `.claude/agents/triage-runner.md` (Triage group) |
 > | `AGENTS.md` (rule add / exemption) | Run `grep -rn "<changed-keyword>" .claude/agents/ .claude/skills/ AGENTS.md` and apply the same change to every match. **For new pre-resolved rules** (the kind that should never reach a question): also add a corresponding entry to the Rule-5 substring blacklist in `.claude/agents/spec-writer.md` so the spec-writer subagent enforces it mechanically. |
+> | `AGENTS.md` "Corrections Log" section (Boundary rules 1 / 2, entry format, `Escalated?` semantics) | `.claude/agents/self-improve.md` AND `.claude/agents/learnings-escalation-audit.md` (Corrections-Log group — the two agents that read/write `learnings.md` must match the rules they enforce) |
 > | Any other instruction file | Run the same grep — the Procedure (below) catches lingering references |
 
 When editing any instruction file (`AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `.claude/settings.json`), propagate the change to every related file in the same operation — before reporting done.
@@ -213,6 +214,7 @@ When editing any instruction file (`AGENTS.md`, `.claude/skills/**`, `.claude/ag
 - **Review group:** `.claude/skills/code-review/SKILL.md` (workflow) ↔ `.claude/agents/review-findings.md` (findings producer) ↔ `.claude/agents/self-review.md` (fix validator)
 - **Triage group:** `.claude/skills/triage/SKILL.md` (skill body) ↔ `.claude/agents/triage-runner.md` (subagent — `model: opus`) ↔ `.claude/skills/next/SKILL.md` (the *Candidates needing `/triage`* section text references `/triage`).
 - **Interview group:** `.claude/skills/interview/SKILL.md` (orchestrator) ↔ `.claude/agents/spec-writer.md` (subagent — `model: opus`) ↔ `AGENTS.md` (Rule-5 substring-blacklist source-of-truth — every new pre-resolved-rule addition to AGENTS.md must spawn a corresponding blacklist entry in `spec-writer.md`).
+- **Corrections-Log group:** `AGENTS.md` § Corrections Log (Boundary rules 1 / 2, entry format, `Escalated?` semantics) ↔ `.claude/agents/self-improve.md` (writes during `/improve`) ↔ `.claude/agents/learnings-escalation-audit.md` (writes during `/ai-audit` Phase 1).
 
 > The former `task` ↔ `task-issue` group collapsed when `task-issue` was merged into `task` — both entry modes now live in `.claude/skills/task/SKILL.md`. Grep across `.claude/skills/` and `.claude/agents/` per the procedure below to catch any lingering references.
 
@@ -262,6 +264,13 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 > - you are tempted to "tidy up" or "consolidate" the file
 >
 > The history of corrections (including superseded and wrong ones) is itself the artefact `/improve` audits. Editing past entries destroys that history.
+>
+> **Exception — `Escalated?` field, agent-driven only.** The `Escalated?` line of an existing entry MAY be updated, **and only**:
+>
+> - by the `self-improve` agent (invoked via `/improve`), after the named instruction-file change has landed, to replace the prior value with the comma-separated list of targets actually modified; OR
+> - by the `learnings-escalation-audit` agent (invoked via `/ai-audit` Phase 1), to fix drift between the field and the named target (target file no longer contains the rule, OR `Escalated? no` despite the rule existing in a target file). The audit MAY also fix obvious typos within the `Escalated?` value (e.g., `AGENTS,md` → `AGENTS.md`, `skillcode-review` → `skill:code-review`, missing comma between two targets).
+>
+> All other lines of the entry (date, category, description, **What happened**, **Rule**) remain immutable. New learning entries are still append-only. Manual user edits to `Escalated?` are NOT authorised by this exception — invoke `/ai-audit` or explicitly request the change.
 
 ### Boundary rule 2 — writing to `learnings.md` triggers NO other rule-file edits in the same turn
 
@@ -281,6 +290,8 @@ On non-obvious correction or confirmed approach, write to `ai-docs/learnings.md`
 > 2. The user explicitly asks ("escalate this", "update AGENTS.md", "add to skill X").
 >
 > The Propagation Rule fires only when you are *already* editing an instruction file for an independent reason — it does not authorise pre-emptive escalation triggered by a fresh `learnings.md` entry. The same applies in reverse: if the user corrects a behaviour and asks you to record it, write to `learnings.md` only — do not also "fix" `AGENTS.md` or `code-style.md` in the same turn.
+>
+> **Exception — `/improve` and `/ai-audit` workflows.** During a `/improve` run, the `self-improve` agent MAY update the `Escalated?` field of the specific entries it just escalated **after** the instruction-file edit has been staged (separate commit on the same feature branch). During `/ai-audit` Phase 1, the `learnings-escalation-audit` agent MAY both fix `Escalated?` and edit the named target file to align them. These exceptions apply to **existing-entry `Escalated?` updates only** — NEW learning entries STILL cannot be appended in the same turn as instruction-file edits (Rule 2's main protection — "I wrote a learning, therefore I'm authorised to escalate it" — stays intact).
 
 ### Entry format
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -892,7 +892,7 @@ If the action's setup script doesn't export the env vars your design assumed it 
 - Cite the source-line evidence in the design's "Implementation steps" section, not just the README's claim.
 - During the self-review phase, the reviewer checks: "did the design verify the action's behaviour against source, or only against README narrative?"
 
-**Escalated?** no
+**Escalated?** AGENTS.md
 
 ### 2026-05-10 — documentation — enable all feature-gated optional features when running cargo doc, and in package.metadata.docs.rs, to get full doc coverage
 
@@ -947,4 +947,4 @@ All three must be kept in sync whenever a new optional feature adds public API w
 
 **How to apply:** After receiving a design-review GO verdict, scan the verdict text for notes or minor issues. For each one: (a) update the relevant section of the design document (API table, helper list, risk table, etc.); (b) verify the design doc now matches the intended code. Only then proceed to implementation. This takes < 5 minutes and prevents spec/design divergence from the first commit.
 
-**Escalated?** no
+**Escalated?** AGENTS.md, agent:design-review, agent:self-review, skill:task


### PR DESCRIPTION
## Summary

Codifies a contract that already existed in `.claude/agents/learnings-escalation-audit.md` (front-matter: *"Fixes drift in-place"*) but was technically forbidden by the unqualified Boundary rules in AGENTS.md. The mismatch surfaced after the previous `/improve` run (PR #298) flagged that the two newly-escalated learning entries' `Escalated?` fields could not be updated without violating Boundary rule 1.

Three commits on this branch, each independently reviewable:

1. **`08b0578` — `chore(agents.md): carve-outs`** — adds Exception blocks to Boundary rules 1 and 2 in `AGENTS.md`, plus a new **Corrections-Log sync group** in the Propagation Rule (covering `AGENTS.md` § Corrections Log ↔ `self-improve.md` ↔ `learnings-escalation-audit.md`).
2. **`70e4044` — `chore(agents): align self-improve and learnings-escalation-audit`** — `self-improve.md` Step 5 now explicitly splits into Commit A (instruction-file edits) and Commit B (backfill `Escalated?`), both cite the new Exception. `learnings-escalation-audit.md` front-matter is tightened (precise definition of "drift" and "in-place"); typo-fix scope (e.g., `AGENTS,md` → `AGENTS.md`) is now in-scope; Step 4 cites the Exception.
3. **`2c6fe0a` — `chore(learnings): backfill Escalated?`** — the two previously-stale learning entries (2026-05-08 sccache, 2026-05-13 GO-notes round-trip) get their `Escalated?` fields updated to reflect the escalations that landed in PR #298. Only the `**Escalated?**` lines change; date / category / description / What happened / Rule remain immutable per the new Exception's scope.

## Design choices

- **Narrow exception, two named gates.** Only the `Escalated?` line, only `self-improve` (via `/improve`) and `learnings-escalation-audit` (via `/ai-audit`). Everything else about `learnings.md` stays absolute.
- **Two-commit split inside `/improve`.** Instruction edits and `Escalated?` backfill go in separate commits on the same branch — escalation substance kept distinct from bookkeeping in the PR diff.
- **Typo-fix scope for the audit.** `learnings-escalation-audit` may also fix obvious typos within the `Escalated?` value — treated as drift rather than as a rewrite.
- **Backfill bundled here.** Per user request, the one-off backfill (commit 3) lives in the same PR as the rule edits (commits 1 + 2) rather than in a follow-up PR.

## Test plan

- [ ] AGENTS.md renders cleanly (Exception blocks under each Boundary rule; new Corrections-Log sync-group row; new sync-group bullet under "Sync groups (canonical)")
- [ ] `learnings-escalation-audit.md` front-matter remains a single line and is grep-friendly for the audit subagent description loader
- [ ] `self-improve.md` Step 5 → Step 6 ordering still makes sense (eval after both commits land)
- [ ] Next `/improve` run that escalates a learning produces two commits (A: edits, B: backfill) per the new contract
- [ ] Next `/ai-audit` Phase 1 run fixes any `Escalated?` typos it finds without touching other entry fields
- [ ] `cargo`/`actionlint` gates n/a (instruction files only — no code, no workflow YAML)

## What this does NOT change

- New `learnings.md` entries remain append-only at the end of the file.
- `/improve` still cannot append new learning entries in the same turn as instruction-file edits.
- User-driven manual `learnings.md` edits remain bound by both Boundary rules (no exception for ad-hoc human edits).
- Correction history (date, category, description, "What happened", "Rule") stays immutable everywhere.