### PR TITLE
chore(improve): escalate /triage progress-file lifecycle + /task bare-issue routing

### DIFF
--- a/.claude/agents/triage-runner.md
+++ b/.claude/agents/triage-runner.md
@@ -6,7 +6,7 @@ model: opus
 
 # Triage Runner Agent
 
-You are a deep batched-mutation subagent invoked by the `/triage` skill. Your **mutation scope is strictly `ai-docs/deferred/**` writes + `gh issue create / edit` calls** — no code edits, no other instruction-file writes, no `ai-docs/learnings.md` writes (AGENTS.md *Boundary rule 2*), no edits to `AGENTS.md` / `.claude/**` / source files.
+You are a deep batched-mutation subagent invoked by the `/triage` skill. Your **mutation scope is strictly `ai-docs/deferred/**` writes + `gh issue create / edit` calls + writes to the run's progress file at `ai-docs/triage/triage-YYYY-MM-DD.progress.md`** (and `mkdir -p ai-docs/triage` on first run) — no code edits, no other instruction-file writes, no `ai-docs/learnings.md` writes (AGENTS.md *Boundary rule 2*), no edits to `AGENTS.md` / `.claude/**` / source files.
 
 The skill body (`.claude/skills/triage/SKILL.md`) is the user-facing description; this file is the operational spec — read it end-to-end before starting.
 
@@ -18,7 +18,8 @@ Read on session start:
 2. `ai-docs/deferred/widget-backlog.md`.
 3. `ai-docs/deferred/_inbox.md`.
 4. `ai-docs/deferred-items.md` (for end-of-run row-count update).
-5. Linked `Source` specs in `ai-docs/plans/done/` — read on demand for title/body drafting.
+5. `ai-docs/triage/triage-YYYY-MM-DD.progress.md` — if it exists for the current branch / date, the run resumes from its `## Next action` (see Phase 1.5 below). Mutation scope is extended to include this path AND its parent directory `ai-docs/triage/` (created on first run via `mkdir -p`); both are gitignored.
+6. Linked `Source` specs in `ai-docs/plans/done/` — read on demand for title/body drafting.
 
 Take content snapshots of every row you might mutate; the concurrent-edit guard (below) compares against these snapshots immediately before each write.
 
@@ -29,6 +30,31 @@ Take content snapshots of every row you might mutate; the concurrent-edit guard 
 Run `git branch --show-current`. If the output is `master`, halt with the message *"`/triage` mutates `ai-docs/deferred/**` and must run on a feature branch. Switch via `git checkout -b chore/triage-YYYY-MM-DD` or similar, then re-invoke."* Per AGENTS.md AXIOM 1.
 
 Else proceed.
+
+Also at Phase 1: probe `ai-docs/triage/triage-YYYY-MM-DD.progress.md` (or any `triage-*.progress.md` in `ai-docs/triage/` matching the current branch). If a progress file is present, **read it end-to-end** and skip the phases its `## Next action` records as already complete — resume from the recorded phase using its persisted dedupe map, bridge classifications, and candidate partitions instead of re-doing those passes. Do not silently overwrite a user-edited partition; treat the file as authoritative for everything it covers and only fill in the next phase.
+
+### Phase 1.5: Create / refresh progress file
+
+If Phase 1 did **not** find an existing progress file:
+
+```bash
+mkdir -p ai-docs/triage
+```
+
+Then create `ai-docs/triage/triage-YYYY-MM-DD.progress.md` using the canonical schema from `ai-docs/templates/progress-format.md`. Required header fields:
+
+- `**Branch:**` — output of `git branch --show-current`.
+- `**base_commit:**` — output of `git rev-parse HEAD`.
+- `**Last build:**` — N/A for `/triage` (no build step); record `N/A (triage skill — no build)`.
+
+Required body sections (populated as phases run, **not** upfront):
+
+- `## Phase 4 dedupe map summary` — `{number → {state, title}}` counts after Phase 4 lands.
+- `## Phase 4.5 bridge classifications` — type-1 / type-2 / type-3 lists plus per-conflict user resolutions as they're recorded.
+- `## Phase 6 / Phase 7 partitions` — approve / decline / skip (Phase 6) and sort / promote / drop / keep (Phase 7), including any user-edited tweaks (canonical example: "move row L179 from decline to promote").
+- `## Next action` — the phase the next subagent invocation should resume from. Always updated after every phase completes.
+
+The file is gitignored via `.gitignore` (`/ai-docs/triage/**/*.progress.md`); never staged in any commit emitted by this agent.
 
 ### Phase 2: Threshold gate
 
@@ -68,6 +94,8 @@ pagination. No mutations performed in this run.
 ```
 
 Otherwise build a local **`{number → {state, title}}`** map keyed by issue number — used by both the existing dedupe path AND Phase 4.5's bridge sweep. Derive a `{title → #N}` view from the same map for the title-match dedupe step below; the two views share storage and are built in one pass over the response.
+
+**Persist** the map's summary (total issue count, open count, closed count) into `ai-docs/triage/triage-YYYY-MM-DD.progress.md` under `## Phase 4 dedupe map summary`, then update `## Next action` to `Phase 4.5`. The full map need not be serialised — Phase 4.5 / Phase 7.5's re-checks rebuild the map from a fresh `gh issue list` call if the subagent restarts. The summary is for resume diagnostics + user spot-check.
 
 For each cell-iteration candidate, exact-title-match dedupe against the `{title → #N}` view. If the proposed title already matches an existing issue:
 
@@ -139,6 +167,8 @@ Action? (m)update md / (i)update issue / (k)keep both
 
 **Phase 4.5 is read-only on `ai-docs/deferred/**` until the user resolves conflicts.** Mutations happen one conflict at a time at user-decision time, with the concurrent-edit guard checked immediately before each write. No batched mutation pass — this matches Phase 7's drain shape.
 
+**Persist** the full type-1 / type-2 / type-3 lists into `## Phase 4.5 bridge classifications` of the progress file as they're produced; append each per-conflict user resolution (`update md` / `update issue` / `keep both` + the user's free-text reason for `keep both`) under the same section as the user works through prompts. Update `## Next action` to `Phase 5` once every conflict is resolved (or recorded as `keep both`).
+
 ### Phase 5: Draft titles and bodies
 
 For each cell-iteration candidate (NOT `_inbox.md` rows — those are drained in Phase 7):
@@ -184,6 +214,8 @@ User responds per row: approve / decline / skip-this-run.
 
 The Phase 6 user action is "approve" / "decline" — that single action IS the user's decision; no separate write-confirmation per row.
 
+**Persist** the Phase 6 partition into `## Phase 6 / Phase 7 partitions` of the progress file: list of approves (per-row `file + cell + drafted title`), list of declines (per-row `file + cell + Item`), list of skips (per-row `file + cell + Item`). Record user-edited tweaks verbatim ("user moved row L179 from decline to promote"). Update `## Next action` to `Phase 7` once the Phase 6 table is fully resolved.
+
 ### Phase 7: Drain `_inbox.md`
 
 Per-entry user prompt for every `_inbox.md` row tagged in Phase 3. For each row, present:
@@ -203,6 +235,8 @@ Actions:
 - **promote** → follow-up prompt: pick destination thematic file (numbered menu). **Append the row to the same approval queue collected in Phase 6** (Phase 6 deferred its creates exactly so this union is possible). The actual create + cell-4-write happens in Phase 7.5. On approval, the row will migrate to the chosen thematic file with `#N` in cell 4 + be removed from `_inbox.md`. On decline, migrate with `untracked` + remove.
 - **drop** → physically remove the row from `_inbox.md`. No migration. Reserved for legitimately-bad rows.
 - **keep** → leave the row in `_inbox.md` unchanged.
+
+**Persist** the Phase 7 partition under the same `## Phase 6 / Phase 7 partitions` section of the progress file (append a Phase 7 subsection): per-row action (sort / promote / drop / keep) + chosen thematic destination when applicable. Update `## Next action` to `Phase 7.5` once every `_inbox.md` row has been actioned.
 
 ### Phase 7.5: Combined `gh issue create` pass
 
@@ -250,9 +284,17 @@ Emit the run-output summary per the skill body's *Run-output summary* section. S
 
 Phase 8 is read-only across `ai-docs/deferred/*.md` after the count rewrite — no further row mutations.
 
+**Progress-file cleanup (final action of the run).** After the run summary emits successfully, delete `ai-docs/triage/triage-YYYY-MM-DD.progress.md`:
+
+```bash
+rm -f ai-docs/triage/triage-YYYY-MM-DD.progress.md
+```
+
+This mirrors the `/pr-merged` `scripts/cleanup-progress.sh` mechanic for `/task` / `/pr-commented` files — the progress file exists only for the duration of the multi-turn run, and a stale file on the next run would resume from out-of-date state. If the run aborted before Phase 8 (watchdog, branch-check failure, concurrent-edit unrecoverable abort), leave the file in place — that is exactly the resume-target case Phase 1 reads.
+
 ## Anti-patterns
 
-- **Do NOT** write to any file outside `ai-docs/deferred/**` (this explicitly excludes `ai-docs/learnings.md`, `AGENTS.md`, `.claude/**`, source files, `Cargo.toml`).
+- **Do NOT** write to any file outside `ai-docs/deferred/**` or `ai-docs/triage/triage-YYYY-MM-DD.progress.md` (this explicitly excludes `ai-docs/learnings.md`, `AGENTS.md`, `.claude/**`, source files, `Cargo.toml`). The progress file is the sole exception — gitignored, local-only, deleted at Phase 8.
 - **Do NOT** run multiple `gh issue list` calls per session — exactly one bulk call per run.
 - **Do NOT** silently overwrite a row when the content snapshot mismatches — abort with the unified diff.
 - **Do NOT** auto-approve declined rows; the decline marker is implicit-by-decline (the user's decline IS the action that triggers the write), but the user MUST make that decline call explicitly.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -48,6 +48,42 @@ If `$ARGUMENTS` contains words like "activate", "start", "proceed" **and** a mat
 
 ---
 
+## ⚡ Third: bare-issue activation of a matching deferred spec
+
+> **AXIOM — When `$ARGUMENTS` is a bare gh issue number, search deferred specs for `**Tracked in:** #N` BEFORE launching the interview.**
+> The keyword trigger above ("activate", "start", "proceed") does NOT fire on a bare integer, so `/task 47` would otherwise enter the interview machinery and create a spurious `*.state.md` file even when `ai-docs/plans/deferred/2026-05-01-paint-style.spec.md` already carries `**Tracked in:** #47`. Catch this case here.
+>
+> | If `$ARGUMENTS` resolves to... | Action |
+> |---|---|
+> | A bare issue number (`/task 47` or `/task #47`) AND a deferred spec exists with `**Tracked in:** #N` matching that number | Run this phase's activation sequence below — do NOT launch the interview, do NOT create a state file. |
+> | A bare issue number AND no matching deferred spec | Fall through to the Steps 1–5 interview phase (the issue's body becomes the interview seed). |
+> | Free text / keyword-triggered activation / empty args | Skip this phase; the active-task probe above (if applicable) or Steps 1–5 cover those entry modes. |
+
+Activation sequence (bare-issue → matching deferred spec):
+
+1. Parse `$ARGUMENTS` — strip leading `#`, confirm it's a positive integer `N`.
+2. Load issue body: `gh issue view <N> --json title,body,state,labels` (also used to surface the issue's `blocked` label per the separate AGENTS.md learning, when that rule fires).
+3. Grep deferred specs for the tracking reference:
+   ```bash
+   grep -l "^\*\*Tracked in:\*\* #<N>\b" ai-docs/plans/deferred/*.spec.md
+   ```
+   If grep returns **zero matches**: fall through to Steps 1–5 (interview-driven flow). The issue body loaded in step 2 is available as context for the interview.
+   If grep returns **one match**: continue with step 4.
+   If grep returns **multiple matches** (unexpected — `**Tracked in:**` should be 1:1 with an issue): surface the list to the user and ask which spec to activate before proceeding.
+4. Move the matched spec (and its `*.design.md` / `*.progress.md` siblings if present) from `ai-docs/plans/deferred/` to `ai-docs/plans/`:
+   ```bash
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.spec.md ai-docs/plans/
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.design.md ai-docs/plans/     # if exists
+   mv ai-docs/plans/deferred/YYYY-MM-DD-name.progress.md ai-docs/plans/   # if exists
+   ```
+5. Update `ai-docs/plans/INDEX.md`: move the plan row from **Deferred plans** to **Active plans**; status `🟢 ready` (or `🟡 spec-only` if no design exists yet).
+6. Surface the spec's existing `## Acceptance Criteria` table to the user verbatim and ask: *"Confirm these ACs, or revise before continuing?"* — wait for the user's response before proceeding. Any revisions must be applied to the spec file before Step 6 launches.
+7. **Do NOT run the interview.** **Do NOT create an `*.state.md` interview state file.** **Do NOT re-resolve the tracking issue** — the spec's existing `**Tracked in:** #<N>` is authoritative.
+8. If a `.progress.md` was moved (rare — a prior `/task` run on this spec was interrupted): treat the activated task as a resume and jump to the RESUME path's `## Next action`.
+9. Otherwise jump directly to **Step 6** (design phase) — the spec exists, ACs are confirmed, the interview phase is satisfied.
+
+---
+
 ### Steps 1–5: Spec creation (delegated to `/interview`)
 
 `/task` does not duplicate the interview workflow. Scope extraction, key-decision confirmation, tracking-issue resolution, spec writing, and the cross-link comment are owned by `/interview` (`.claude/skills/interview/SKILL.md`). Treat these five steps as a single delegated phase.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -8,6 +8,23 @@ allowed-tools: Bash(gh issue create *) Bash(gh issue edit *) Bash(gh issue close
 
 Launch the `triage-runner` subagent. The subagent reads `.claude/agents/triage-runner.md` for full instructions.
 
+## Progress file
+
+A multi-turn `/triage` run persists state to `ai-docs/triage/triage-YYYY-MM-DD.progress.md` (local-only / gitignored under `/ai-docs/triage/**/*.progress.md`). The file mirrors the canonical schema at `ai-docs/templates/progress-format.md` and stores:
+
+- Phase 4 dedupe map summary (`{number → {state, title}}` counts).
+- Phase 4.5 bridge classifications (type-1 / type-2 / type-3 lists + per-conflict user resolutions as they land).
+- Phase 6 / Phase 7 candidate partitions (approve / decline / sort / promote / drop / keep — including any user-edited tweaks to the proposed split).
+- `## Next action` — the phase the next subagent invocation should resume from.
+
+Lifecycle (mirrors `/task` and `/pr-commented` progress files):
+
+- **Created** by `triage-runner` at Phase 1.5 (after the branch check, before threshold gate). If the file already exists on the current branch when the subagent starts, it is read at Phase 1 and the run resumes from `## Next action` instead of restarting from scratch.
+- **Extended** by the subagent as each phase produces durable state (dedupe map, classifications, partitions, per-conflict resolutions).
+- **Deleted** by `triage-runner` after Phase 8's run summary emits successfully — same shape as `/pr-merged`'s `scripts/cleanup-progress.sh` mechanic for `/task` / `/pr-commented` files.
+
+Subagent context isolation makes classification state unrecoverable across invocations unless persisted; the progress file is what makes a `/triage` run resumable across compaction or fresh-subagent spawn.
+
 ## Trigger and threshold
 
 Default threshold is **≥ 3 unhandled rows** across the 10 row sources. Tunable via `/triage [N]` — passing `N` overrides the default. Below the threshold the subagent exits with a brief status report; no approval prompt opens.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ librust_out.rlib
 # deleted by /pr-merged. Never committed.
 /ai-docs/plans/**/*.progress.md
 /ai-docs/pr-comments/
+# /triage runs persist resume state to ai-docs/triage/triage-YYYY-MM-DD.progress.md.
+# Created by the triage-runner subagent at Phase 1.5, deleted at Phase 8.
+/ai-docs/triage/**/*.progress.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,7 @@ Interpret user phrasing literally and conservatively. When uncertain — ask, do
 | `ai-docs/plans/*.design.md` | Active task design documents |
 | `ai-docs/plans/*.progress.md` | Active task progress / handoff state — **local-only (gitignored)**. Created by `/task`, extended by `/pr-commented` across reviewer-comment rounds, deleted by `/pr-merged` after the PR merges. Never committed. |
 | `ai-docs/pr-comments/pr-<N>.progress.md` | Fallback progress file when `/pr-commented` runs on a PR not produced by `/task` (rare). **Local-only (gitignored)**. Deleted by `/pr-merged`. |
+| `ai-docs/triage/triage-YYYY-MM-DD.progress.md` | `/triage` resume state for multi-turn runs (dedupe map summary, bridge classifications, Phase 6 / 7 partitions, `## Next action`). **Local-only (gitignored)**. Created by `triage-runner` at Phase 1.5; extended through Phases 4–7; deleted at Phase 8 after the run summary emits. |
 | `ai-docs/plans/done/` | Completed plans (spec + design, implemented) |
 | `ai-docs/plans/deferred/` | Blocked or future plans |
 | `ai-docs/deferred/_inbox.md` | triage queue — rows from completed specs awaiting `/triage` classification (writers: `/task` Step 12 and `/triage` only). |

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -915,7 +915,7 @@ All three must be kept in sync whenever a new optional feature adds public API w
 
 **Rule:** The `/task` deferred-activation keyword check ("activate", "start", "proceed") fires only on those literal words in the arg. When the arg is a bare issue number, load the issue body first, then check whether any deferred spec already has `**Tracked in:** #N` matching that issue. If found, treat it as "already have a spec" — move it to `ai-docs/plans/`, update `INDEX.md`, confirm ACs with the user, and skip to Step 6. Do not run the interview and do not create a state file.
 
-**Escalated?** no
+**Escalated?** skill:task
 
 ### 2026-05-10 — documentation — prefer inline form `[`Foo`](path)` over reference form `[`Foo`][path]` for intra-doc links
 
@@ -961,7 +961,7 @@ All three must be kept in sync whenever a new optional feature adds public API w
 
 **How to apply:** when amending `.claude/skills/triage/SKILL.md` and `.claude/agents/triage-runner.md`, add (a) progress-file creation as Phase 1.5 (after the branch check, before Phase 2 dedupe), (b) progress-file resume read at Phase 1 if the file already exists for the current branch, (c) progress-file deletion after the final run summary emits, and (d) Propagation-Rule sync into the Triage group (skill ↔ agent ↔ `/next` skill). Mirror the cleanup-on-merge mechanic from `/pr-merged`'s `scripts/cleanup-progress.sh`.
 
-**Escalated?** no
+**Escalated?** skill:triage, agent:triage-runner, AGENTS.md
 
 ### 2026-05-13 — process — `/task` on a `blocked`-labelled gh issue must reconcile blockers before proceeding
 


### PR DESCRIPTION
## Summary

`/improve` run on 2026-05-13. Escalates two learning entries to project-level instruction files.

### Escalation 1 — `/triage` progress-file lifecycle (2026-05-13 entry)

Subagent context isolation forced a re-paste workaround in today's earlier `/triage` runs (PR #319). Now codified:

- **`.claude/skills/triage/SKILL.md`** — new "Progress file" subsection above "Trigger and threshold"; documents create-at-1.5 / extend-through-4–7 / delete-at-8 lifecycle.
- **`.claude/agents/triage-runner.md`** — extended mutation scope; new `Inputs §5` reading `ai-docs/triage/triage-YYYY-MM-DD.progress.md`; new `Phase 1.5` (mkdir + create with canonical schema); per-phase persistence writes at end of Phase 4 / 4.5 / 6 / 7; cleanup `rm -f` at end of Phase 8.
- **`.gitignore`** — new `/ai-docs/triage/**/*.progress.md` entry.
- **`AGENTS.md`** Agent Docs table — row for the new progress-file path so future readers can find it.

### Escalation 2 — `/task <N>` bare-issue activation of matching deferred spec (2026-05-09 entry)

`/task 47` was running the interview machinery + creating a spurious `*.state.md`, even though `ai-docs/plans/deferred/2026-05-01-paint-style.spec.md` already had `**Tracked in:** #47`. Now codified:

- **`.claude/skills/task/SKILL.md`** — new "⚡ Third: bare-issue activation of a matching deferred spec" phase between the existing deferred-plan-activation step and Steps 1–5. AXIOM block + 9-step activation sequence; explicitly bars interview launch + `*.state.md` creation when a deferred spec already tracks issue `#N`.

### `Escalated?` backfill (Commit B — `9bb06fd`)

Per Boundary Rule 1's Exception (self-improve agent path), the `Escalated?` lines of the two specific entries were updated to reflect the targets that landed in Commit A:

- 2026-05-09 `/task` bare-issue entry → `skill:task`.
- 2026-05-13 `/triage` progress-file entry → `skill:triage, agent:triage-runner, AGENTS.md`.

No other `learnings.md` lines were touched; no new entries appended.

### Propagation check

- **Triage sync group** (`triage SKILL.md` ↔ `triage-runner.md` ↔ `next SKILL.md`): both primary files updated; `/next` skill needed no change (does not handle subagent execution state).
- **Task/Design sync group** (`task SKILL.md` ↔ `design.md` ↔ `design-review.md`): the design-side files contain no references to bare-issue / deferred-spec routing — no propagation needed.
- **Rule-5 substring blacklist** in `spec-writer.md`: not extended — bare-issue activation is a routing rule, not a spec-question pattern.

### Deferred this round (intentionally not escalated)

- 2026-05-08 doctest `cfg_attr` injection (single occurrence)
- 2026-05-08 generic-fn split parameter-less refinement (single occurrence)
- 2026-05-10 inline intra-doc link form (single occurrence, style preference)
- 2026-05-11 investigate local FAILED before pushing (single occurrence, hard to enforce mechanically)
- 2026-05-13 `/task` blocked-label reconciliation (proactive, no incident yet)
- Older one-off architecture / code-style entries

These stay `Escalated? no` and are candidates for a future `/improve` round once they recur.

### Eval

Structural PASS — the agent traced both failure modes (lost classification state across subagent invocations; spurious `*.state.md` on bare-issue `/task <N>`) through the new phases and confirmed they are intercepted. Live execution eval (spawn a fresh `triage-runner`, ask it to resume a partway-completed run) requires user-driven invocation; this PR is the gate to enabling that test.

## Test plan

- [x] Diff stat: 6 files (`.claude/agents/triage-runner.md`, `.claude/skills/task/SKILL.md`, `.claude/skills/triage/SKILL.md`, `.gitignore`, `AGENTS.md`, `ai-docs/learnings.md`); +104 / −5
- [x] No project code touched (Rust source unchanged)
- [x] No workflow files touched (`actionlint` not required)
- [x] `Escalated?` backfill follows Boundary Rule 1's Exception — only the two named lines changed; entries' `What happened` / `Rule` / dates immutable
- [x] Triage group sync verified; Task/Design group sync verified; Rule-5 blacklist not extended (justified)
- [ ] Live eval: invoke `/triage` from a fresh session, halt mid-classification, re-invoke — verify resume-from-progress-file works end-to-end (post-merge follow-up)
- [ ] Live eval: invoke `/task <N>` on an issue with a matching deferred spec — verify the activation phase fires instead of the interview (post-merge follow-up)