### PR TITLE
fix(docs): install libfontconfig1-dev in Docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,12 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          # libfontconfig1-dev: required by parley (yeslogic-fontconfig-sys)
+          sudo apt-get install -y libfontconfig1-dev
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features
         env:


### PR DESCRIPTION
## Summary

Every push to `master` since commit `bdeca71` has triggered a **red `Docs` workflow** run. The `Build docs` job runs `cargo doc --no-deps --workspace --all-features` on a bare `ubuntu-latest` runner without `libfontconfig1-dev` installed, and `yeslogic-fontconfig-sys` (transitive: `parley` → `vello` → `quartzite-renderer`) panics in its `build.rs` when `pkg-config` cannot find `fontconfig.pc`.

Commit `bdeca71` ("*ci: install libfontconfig1-dev on all Linux CI jobs*") added the install step to `ci.yml`, `coverage.yml`, `base_benchmarks.yml`, and `fork_pr_benchmarks_run.yml` but **missed `docs.yml`**. Because `docs.yml` triggers on `push: master` only (not on PRs), the regression was invisible at PR-merge time: PR CI green, master `Docs` red on every merge commit, and the `gh-pages` deploy step has been silently skipping (`needs: build` gate).

**Fix:** insert the canonical `Install Linux dependencies` step between `Cache dependencies` and `Build docs`, mirroring `ci.yml:71-76`.

```diff
       - name: Cache dependencies
         …
         restore-keys: ${{ runner.os }}-cargo-
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          # libfontconfig1-dev: required by parley (yeslogic-fontconfig-sys)
+          sudo apt-get install -y libfontconfig1-dev
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features
```

**Why no tracking issue:** this is a CI hotfix surfaced by direct user observation, not by a GitHub Issue. The PR body is the artefact of record.

## Test plan

- [x] `actionlint .github/workflows/docs.yml` — exit 0.
- [x] `cargo fmt -- --check`, `cargo build`, `cargo clippy --workspace -- -D warnings`, `cargo test` — all clean (no Rust source touched; sanity gate).
- [x] Diff scope: 6-line insertion in one file. `git diff master --stat`: `.github/workflows/docs.yml | 6 ++++++` (1 file, +6/-0).
- [x] All five Linux workflows (`ci.yml`, `coverage.yml`, `base_benchmarks.yml`, `fork_pr_benchmarks_run.yml`, **`docs.yml`**) now install `libfontconfig1-dev`. Verified by `grep -l libfontconfig1-dev .github/workflows/*.yml`.
- [ ] **Post-merge:** watch the next push to `master` trigger the `Docs` workflow and confirm it goes green (the `Deploy to GitHub Pages` job, currently always-skipped, should fire for the first time since `bdeca71`).

**Verification rationale (no pre-merge runtime check):** `docs.yml` triggers on `push: master` only, so a normal PR push cannot re-run the Docs workflow against the fix. Four other Linux workflows (`ci.yml`, `coverage.yml`, `base_benchmarks.yml`, `fork_pr_benchmarks_run.yml`) install the same package on the same runner image and build the same dependency graph — they all pass. The install line is high-confidence proven; the only thing the merge changes for `docs.yml` is the install step's presence/absence.