### PR TITLE
ci(#340): rotate cache-shared-key to -v2 to invalidate cargo-bin caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: ${{ runner.os }}-stable
+          cache-shared-key: ${{ runner.os }}-stable-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -97,7 +97,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: ${{ runner.os }}-stable
+          cache-shared-key: ${{ runner.os }}-stable-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -129,7 +129,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-          cache-shared-key: ${{ runner.os }}-stable
+          cache-shared-key: ${{ runner.os }}-stable-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -174,7 +174,7 @@ jobs:
           # cache-shared-key is distinct from the `*-stable` key used by
           # build/test/clippy/docs to avoid cache thrash with the existing
           # test job.
-          cache-shared-key: ${{ runner.os }}-stable-gpu
+          cache-shared-key: ${{ runner.os }}-stable-gpu-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install Linux GPU stack
         if: runner.os == 'Linux'
@@ -365,7 +365,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: ${{ runner.os }}-stable
+          cache-shared-key: ${{ runner.os }}-stable-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -413,7 +413,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: ${{ runner.os }}-stable-features-${{ matrix.features }}
+          cache-shared-key: ${{ runner.os }}-stable-features-${{ matrix.features }}-v2
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run sccache-cache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           # the parsed-lockfile hash to cacheKey internally, leaving the
           # restoreKey lockfile-agnostic — reproduces today's restore-keys
           # partial-prefix semantics. See design § Q3.
-          cache-shared-key: ${{ runner.os }}-cargo-coverage
+          cache-shared-key: ${{ runner.os }}-cargo-coverage-v2
       - name: Install Linux GPU stack
         # Mirror the gpu-tests Linux lane so the GPU code paths in
         # `quartzite-renderer::render_harness` and the widget snapshot

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           # the parsed-lockfile hash to cacheKey internally, leaving the
           # restoreKey lockfile-agnostic — reproduces today's restore-keys
           # partial-prefix semantics. See design § Q3.
-          cache-shared-key: ${{ runner.os }}-cargo
+          cache-shared-key: ${{ runner.os }}-cargo-v2
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary

One-shot cache invalidation for the residual #340 flake that re-appeared on master after PR #342's toolchain-action swap.

The macOS `Clippy` job on master run [25875983734](https://github.com/maratik123/quartzite/actions/runs/25875983734/job/76043245284) failed with the original symptom (`error: unexpected argument 'clippy' found — Usage: rustup-init[EXE]`). A `gh run rerun --failed` of the same job [passed without code changes](https://github.com/maratik123/quartzite/actions/runs/25875983734) — proving the bug is now occasional, not constant.

**Root cause (revised):** The bundled `Swatinem/rust-cache` inside `actions-rust-lang/setup-rust-toolchain@v1` has `cache-bin: true` by default, which caches `~/.cargo/bin/`. If any prior run captured `rustup-init` at `~/.cargo/bin/cargo` (the original macOS-runner shenanigan), the cache restore overwrites the freshly-installed cargo on subsequent runs. The action's `Setup Rust Caching` step runs *after* `rustup toolchain install` (verified against the action's `action.yml`).

**Fix in this PR:** append `-v2` to every `cache-shared-key:` value across the workflows. This invalidates the potentially-poisoned existing caches; the first post-merge runs will populate fresh `-v2` caches from clean toolchain installs.

| File | Job | Before | After |
|---|---|---|---|
| `ci.yml` | build / test / clippy / docs | `${{ runner.os }}-stable` | `${{ runner.os }}-stable-v2` |
| `ci.yml` | gpu-tests | `${{ runner.os }}-stable-gpu` | `${{ runner.os }}-stable-gpu-v2` |
| `ci.yml` | features | `${{ runner.os }}-stable-features-${{ matrix.features }}` | `${{ runner.os }}-stable-features-${{ matrix.features }}-v2` |
| `coverage.yml` | coverage | `${{ runner.os }}-cargo-coverage` | `${{ runner.os }}-cargo-coverage-v2` |
| `docs.yml` | build | `${{ runner.os }}-cargo` | `${{ runner.os }}-cargo-v2` |

This is a **one-shot mitigation**, not a root-cause fix. If the flake recurs on `-v2` caches, the next-level fix is `cache-bin: false` on the toolchain action (which disables `~/.cargo/bin/` caching entirely; cost: ~5–10s on Coverage runs to reinstall `cargo-llvm-cov`).

## Tracking

Refs #340 (re-opened to track this residual flake).

## Test plan

- [ ] `actionlint` clean on all 3 modified workflow files (verified locally)
- [ ] First master-only run after merge: macOS Clippy passes (the cache miss should force a clean install)
- [ ] Subsequent runs: macOS Clippy continues to pass on the warm `-v2` caches