### PR TITLE
chore: /ai-audit — Phase 1 drift fix + AGENTS.md pre-emptive extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,16 +109,7 @@ See [`ai-docs/code-style.md`](ai-docs/code-style.md) for the canonical reference
 ## Dependency Versions
 
 > **AXIOM — Query the live registry BEFORE writing any specific version string OR asserting external-action behaviour. Training data is stale.**
-> Whenever you write a specific version of a Cargo crate or a GitHub Action — anywhere (`Cargo.toml`, workflow file, issue body, spec, design doc, learning, any `ai-docs/**` page) — query the live source first. Treating remembered versions as authoritative has put wrong majors into specs twice in this repo (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`). The same logic applies one level deeper: a third-party GitHub Action's **behaviour** (what env vars it exports, what files it produces, which defaults it sets) is also stale in training data and in marketplace blurbs — treating it as authoritative landed the wrong claim into spec + design once (PR #179 sccache: "action sets `RUSTC_WRAPPER` and `SCCACHE_GHA_ENABLED` by default" — false; `src/setup.ts` only exports `SCCACHE_PATH` + cache-service vars, README's "Rust code" subsection explicitly mandates the user set them).
->
-> | If you need to write... | Run this first |
-> |---|---|
-> | A Cargo crate version | `curl -sS "https://crates.io/api/v1/crates/<name>" \| jq -r '.crate.max_stable_version'` |
-> | A GitHub Action version | `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` (and verify the action's Node runtime is current) |
-> | A version into a long-lived doc (won't be revisited for months) | Annotate `(verified current YYYY-MM-DD)` next to the version |
-> | A **load-bearing claim about an Action's behaviour** (env vars it exports, defaults it sets, files it produces — anything the spec or design relies on) | `gh api /repos/<owner>/<repo>/contents/action.yml --jq '.content' \| base64 -d` AND `gh api /repos/<owner>/<repo>/contents/src/setup.ts --jq '.content' \| base64 -d \| grep -inE 'exportVariable\|process\.env\|GITHUB_ENV\|saveState'` (or `src/main.ts` for run-step actions). Cite the source-line evidence in the design — README narrative alone is **not** evidence. |
->
-> Then apply the pinning rule (below) to the **observed** version, never the remembered one. If `setup.ts` / `main.ts` does not export the env vars your design assumed, set them explicitly in the workflow (per-job `env:` or `echo >> $GITHUB_ENV` after the action step) — don't rely on "the action probably sets it".
+> Treating remembered versions or remembered Action behaviour as authoritative has shipped wrong majors and false load-bearing claims more than once in this repo. See [`ai-docs/dependency-versions.md`](ai-docs/dependency-versions.md) for the per-artifact lookup table (Cargo crate / GitHub Action / Action behaviour-verification recipe). Apply the pinning rule (below) to the **observed** version, never the remembered one.
 
 When adding or editing dependencies in `Cargo.toml`:
 
@@ -230,6 +221,7 @@ Interpret user phrasing literally and conservatively. When uncertain — ask, do
 | `ai-docs/workflow.md` | Extracted narrative passages from `AGENTS.md` § *Workflow* (PR review comment resolution GraphQL recipe). Read on demand. |
 | `ai-docs/corrections-log.md` | Extracted carve-outs from `AGENTS.md` § *Corrections Log* (Boundary rule 1 / 2 Exception bodies + entry-format field glossary). Read on demand. |
 | `ai-docs/key-decisions.md` | Extracted Key Design Decisions detail bodies from `ai-docs/context.md` § Key Design Decisions (implementation-detail rows). Read on demand. |
+| `ai-docs/dependency-versions.md` | Live-lookup reference for Cargo / GitHub Action versions and Action behaviour verification — extracted from `AGENTS.md` § *Dependency Versions* AXIOM. Read on demand when writing a specific version string or a load-bearing claim about an Action's behaviour. |
 | `ai-docs/agent-writing-style.md` | Style for binary rules in instruction files (dual-model readability) — read on demand and when editing any of `AGENTS.md`, `.claude/skills/**`, `.claude/agents/**`, `ai-docs/code-style.md`, `ai-docs/doc-convention.md` |
 | `ai-docs/templates/` | Shared reference templates consumed by multiple skills / agents. Multi-consumer reference material lives here (project-level reference, not Claude Code configuration). Single-consumer skill templates remain inside the owning skill directory per the Claude Code [supporting-files pattern](https://code.claude.com/docs/en/skills#add-supporting-files). |
 | `ai-docs/templates/progress-format.md` | Canonical `.progress.md` format spec — template + required vs optional fields + lifecycle. Consumed by `/task`, `/code-review`, `/pr-commented`, `review-findings`, `self-review`. |

--- a/ai-docs/dependency-versions.md
+++ b/ai-docs/dependency-versions.md
@@ -1,0 +1,18 @@
+# Dependency Versions — live-lookup reference
+
+This page extracts the live-lookup table from [`AGENTS.md` § Dependency Versions](../AGENTS.md#dependency-versions). The AXIOM headline and pinning bullets stay in AGENTS.md.
+
+## Why query live first
+
+Whenever you write a specific version of a Cargo crate or a GitHub Action — anywhere (`Cargo.toml`, workflow file, issue body, spec, design doc, learning, any `ai-docs/**` page) — query the live source first. Treating remembered versions as authoritative has put wrong majors into specs twice in this repo (`criterion 0.5` vs. live `0.8`; `actions/deploy-pages@v4` vs. live `@v5`). The same logic applies one level deeper: a third-party GitHub Action's **behaviour** (what env vars it exports, what files it produces, which defaults it sets) is also stale in training data and in marketplace blurbs — treating it as authoritative landed the wrong claim into spec + design once (PR #179 sccache: "action sets `RUSTC_WRAPPER` and `SCCACHE_GHA_ENABLED` by default" — false; `src/setup.ts` only exports `SCCACHE_PATH` + cache-service vars, README's "Rust code" subsection explicitly mandates the user set them).
+
+## Lookup table
+
+| If you need to write... | Run this first |
+|---|---|
+| A Cargo crate version | `curl -sS "https://crates.io/api/v1/crates/<name>" \| jq -r '.crate.max_stable_version'` |
+| A GitHub Action version | `gh api /repos/<owner>/<repo>/releases --jq '.[0].tag_name'` (and verify the action's Node runtime is current) |
+| A version into a long-lived doc (won't be revisited for months) | Annotate `(verified current YYYY-MM-DD)` next to the version |
+| A **load-bearing claim about an Action's behaviour** (env vars it exports, defaults it sets, files it produces — anything the spec or design relies on) | `gh api /repos/<owner>/<repo>/contents/action.yml --jq '.content' \| base64 -d` AND `gh api /repos/<owner>/<repo>/contents/src/setup.ts --jq '.content' \| base64 -d \| grep -inE 'exportVariable\|process\.env\|GITHUB_ENV\|saveState'` (or `src/main.ts` for run-step actions). Cite the source-line evidence in the design — README narrative alone is **not** evidence. |
+
+Then apply the pinning rule (in AGENTS.md) to the **observed** version, never the remembered one. If `setup.ts` / `main.ts` does not export the env vars your design assumed, set them explicitly in the workflow (per-job `env:` or `echo >> $GITHUB_ENV` after the action step) — don't rely on "the action probably sets it".

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1098,7 +1098,7 @@ The cost of doing nothing is asymmetric: 30 seconds of cleanup at merge time vs.
 
 **Rule:** After updating `ai-docs/plans/INDEX.md` (or any other source file that feeds into `ROADMAP.md`), run `./scripts/gen-roadmap.sh` and stage the resulting `ROADMAP.md` in the same commit, before pushing to the PR branch.
 
-**Escalated?** hook, settings
+**Escalated?** hook
 
 ### 2026-05-14 — process — self-review loop (Step 10) was skipped before creating the PR
 


### PR DESCRIPTION
## Summary

- **Phase 1** — fixed one `Escalated?` drift in `ai-docs/learnings.md`: entry `2026-05-14 — process — ROADMAP.md must be regenerated` had `Escalated? hook, settings`. The `settings` token did not resolve to any non-hook `permissions.allow` / `permissions.deny` / `env` entry; enforcement is purely the `PostToolUse|Write|Edit` hook in `.claude/settings.json` that fires on `ai-docs/plans/INDEX.md` edits. Field updated to `Escalated? hook` (authorised by AGENTS.md § Corrections Log Boundary rule 1 Exception).
- **Phase 2** — checklist A–L pass; one `minor` finding applied. AGENTS.md was at 34,712 chars (288 below the 35,000-char early-warning trigger). Per user direction, pre-emptive extraction: verbose Dependency Versions AXIOM body (intro paragraph + 4-row live-lookup table for Cargo crates / GitHub Actions / Action behaviour-verification) moved to new `ai-docs/dependency-versions.md`. AGENTS.md keeps the AXIOM headline + four pinning-syntax bullets; `## Dependency Versions` heading preserved so `AGENTS.md § Dependency Versions` cross-references in `ai-docs/code-style.md`, `ai-docs/considerations-link-reading.md`, `ai-docs/learnings.md`, and merged plan docs continue to resolve.
- **Net AGENTS.md size:** 34,712 → 33,214 chars (1,786 below trigger).

## Test plan

- [x] `jq . .claude/settings.json` — JSON valid post-edit (no hook changes; sanity check)
- [x] Anchor-aware cross-reference recheck across all instruction files — all relative links and heading slugs resolve (only false positive: regex catching an external `https://github.com/...` URL in `ai-docs/doc-convention.md`)
- [x] Skill / agent frontmatter unchanged
- [x] Propagation grep on "Dependency Versions" — every reference points to the preserved AGENTS.md anchor; no sister-file drift
- [x] `wc -c` sweep — every instruction file under 35k after edits