### PR TITLE
chore(improve): AGENTS.md Workflow AXIOM unifying self-review-before-push + Escalated? backfill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,20 @@ When adding or editing dependencies in `Cargo.toml`:
 >
 > The upstream tracking **issue**'s title and body are the user's original problem statement — do not rewrite them. Communicate scope changes via `gh issue comment` instead.
 
+> **AXIOM — Every code-producing commit on a feature branch with an open PR (or about-to-be-opened PR) must pass `self-review` before `git push`.**
+> The per-skill rules already exist (`/task` Step 10, `/pr-commented` Step 5, `/pr-ci-failed` Step 5, `/master-ci-failed` Step 5, `/bugfix` Step 6). This AXIOM names them as instances of a single workspace rule, so the next surface that doesn't yet have its own per-skill step still falls under the rule.
+>
+> | If the commit is... | Action |
+> |---|---|
+> | Initial implementation in `/task` | `/task` Step 10 — spawn `self-review` |
+> | Reviewer-comment fix in `/pr-commented` | `/pr-commented` Step 5 — spawn `self-review` |
+> | CI-failure fix in `/pr-ci-failed` / `/master-ci-failed` | per-skill `self-review` step |
+> | Bugfix in `/bugfix` (standalone or detoured from `/task`) | `/bugfix` Step 6 — spawn `self-review` |
+> | Ad-hoc / out-of-skill fix on a feature branch with an open PR | Spawn `self-review` manually over `git diff <merge-base>..HEAD` before `git push` |
+> | Docs-only / instruction-file-only commit (no `.rs` diff) | Self-review optional; still required if the diff touches any user-facing artefact |
+>
+> APPROVE = push. REJECT = fix on the same branch and re-run; after 3 REJECTs in a row, surface and stop without pushing.
+
 > **AXIOM — `ai-docs/deferred/_inbox.md` is written ONLY by `/task` Step 12 and `/triage`.**
 > Hand-edits to `_inbox.md` defeat the propagation contract that Issue A2 sets up — they hide rows from the parser and conflict with future Step-12 appends.
 >

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1090,7 +1090,7 @@ The cost of doing nothing is asymmetric: 30 seconds of cleanup at merge time vs.
 
 - **`/pr-commented`, `/triage`, `/interview`, `/improve`, `/ai-audit`** — each already has its own self-review protocol (`/pr-commented` Step 5; the others have agent-driven review built into their workflow). The gap is `/bugfix`-specific.
 
-**Escalated?** skill:bugfix
+**Escalated?** skill:bugfix, AGENTS.md
 
 ### 2026-05-14 — process — ROADMAP.md must be regenerated before pushing to a PR
 
@@ -1106,7 +1106,7 @@ The cost of doing nothing is asymmetric: 30 seconds of cleanup at merge time vs.
 
 **Rule:** After Step 9.5, always spawn the self-review agent (Step 10) before proceeding to Step 12. The verdict (APPROVE / REJECT) gates whether Step 12 is entered. Do not skip this step even when all gate commands pass — the self-review agent checks design conformance, edge cases, and nits that automated gates cannot catch.
 
-**Escalated?** skill:task
+**Escalated?** skill:task, AGENTS.md
 
 ### 2026-05-14 — process — too many subtasks taken without /context-reset leads to compaction before all tasks finish
 


### PR DESCRIPTION
## Summary

`/improve` audit run after PR #362 merged surfaced **Pattern P4** — *self-review skipped before push* — with **3 occurrences in 3 different surfaces** over the past week, each escalated to a different per-skill target. The next surface that doesn't yet have its own per-skill step would repeat the same failure. This PR adds a workspace-level AXIOM that names the rule once and enumerates all 6 surfaces (5 per-skill + 1 ad-hoc / out-of-skill catch-all + 1 docs-only carve-out).

## P5 side-note investigation (Commit C from PR #362)

The Commit-C side note hypothesised that `.claude/agents/self-improve.md` *"grants 'all tools'"* and the prior `self-improve` agent's *"no `Agent` tool"* report was a reasoning error. **Investigation result: the side note was wrong**, but the rule it codified (pause-and-surface before substituting a primitive) is correct. `.claude/agents/self-improve.md` omits the `tools:` frontmatter field (which by convention means "inherit all"), but the runtime tool set actually exposed to this agent class lacks an `Agent` / subagent-dispatch primitive — the `Task*` family available via ToolSearch is queue management, not subagent spawning. The diagnostic root cause is **harness-exposed tool absence**, not subagent reasoning error.

This finding will be appended as a new dated `learnings.md` entry in a follow-up turn (Boundary rule 2 main body forbids same-turn append + instruction-file edits inside this `/improve` run).

## What landed (2 commits)

**Commit A `cec8f92`** — `AGENTS.md` `## Workflow` AXIOM:

> *"Every code-producing commit on a feature branch with an open PR (or about-to-be-opened PR) must pass `self-review` before `git push`."*

6-row table enumerating the surfaces:
- `/task` Step 10
- `/pr-commented` Step 5
- `/pr-ci-failed` Step 5
- `/master-ci-failed` Step 5
- `/bugfix` Step 6.5
- **Ad-hoc / out-of-skill fix on a feature branch with an open PR** — spawn `self-review` manually over `git diff <merge-base>..HEAD` before push (NEW catch-all surface)
- **Docs-only / instruction-file-only commit (no `.rs` diff)** — self-review optional; still required if the diff touches any user-facing artefact (NEW carve-out)

Path A1 form chosen (smaller AXIOM body) to keep AGENTS.md under the 40k hard cap. Final size 39,775 chars (225 chars headroom).

**Commit B `a51cca1`** — `learnings.md` `Escalated?` backfill (Boundary rule 1 Exception):

| Entry | Old | New |
|---|---|---|
| 2026-05-13 — `/bugfix` Step 6 lacks self-review | `skill:bugfix` | `skill:bugfix, AGENTS.md` |
| 2026-05-14 — self-review loop (Step 10) was skipped | `skill:task` | `skill:task, AGENTS.md` |

The 2026-05-15 *"CI-fix code changes require self-review"* entry already carried `Escalated? AGENTS.md` — the new AXIOM is exactly what that value now refers to. No change.

## Char-cap audit

| File | Before | After | Cap |
|---|---|---|---|
| `AGENTS.md` | 38,470 | 39,775 | ≤ 40,000 ✓ (in 35k–40k proactive-extraction band; 225-char headroom to hard cap) |

## Eval results (main-thread clean-context dispatch, per Step 6 contract)

Self-improve correctly **paused-and-surfaced** at Step 6 (its tool list lacks `Agent`); main thread (which has `Agent`) ran the 3 clean-context evals.

| Pattern | Verdict | Evidence |
|---|---|---|
| 1 — Standalone `/bugfix` Step 6 | **PASS** | Agent cited BOTH `/bugfix` SKILL.md Step 6.5 AND the new AGENTS.md AXIOM as required gates; refused to push on 4-green-gates alone. |
| 2 — Ad-hoc / out-of-skill fix on a feature branch | **PASS** | Agent identified the "Ad-hoc / out-of-skill fix" table row in the new AXIOM; correctly required `self-review` manually over `git diff <merge-base>..HEAD` despite 5 green gates + 4-line scope. |
| 3 — Docs-only commit (carve-out edge case) | **PASS** | Agent identified the "Self-review optional" row and correctly reasoned `ai-docs/context.md` is internal project context (NOT a user-facing artefact); the optional classification applied cleanly. |

## Test plan

- [x] `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` clean (no-op on doc-only diff).
- [x] AGENTS.md size 39,775 chars under 40k hard cap; in proactive-extraction band.
- [x] AGENTS.md AXIOM inserts cleanly between AXIOM 2 (PR-body read) and the `_inbox.md` AXIOM; no other AGENTS.md content shifted.
- [x] `learnings.md` Commit B edits respect Boundary rule 1 Exception (only `Escalated?` lines modified; rule / What happened / Why / date / category bodies unchanged).
- [x] All 3 clean-context evals PASS.
- [x] `self-improve` Step 6 contract — degradation surfaced before substitution per Commit-C rule from PR #362 (rule from prior `/improve` run working as designed).

## Out of scope

- Hook escalation in `.claude/settings.json` — Pattern P4 is at 3 occurrences with NO unifying rule yet. New AGENTS.md AXIOM is the first workspace-level intervention; hook escalation revisits if a 4th occurrence happens post-AXIOM.
- P5 finding (self-improve's missing `Agent` primitive) — appended as a new dated `learnings.md` entry in a follow-up turn (Boundary rule 2 main body).
- Updating `.claude/agents/self-improve.md` Step 6 contract to acknowledge the missing primitive and route eval responsibility to the parent thread — separate `/task` follow-up.