### PR TITLE
chore(instructions): /ai-audit fixes — broken xref + Escalated? backfill correction

### DIFF
--- a/.claude/skills/context-reset/SKILL.md
+++ b/.claude/skills/context-reset/SKILL.md
@@ -71,7 +71,7 @@ Three callout variants address the three structurally-different probe shapes:
 - **Variant B** — `/bugfix`, `/interview`. Probe is a fixed-glob (`ai-docs/bugfix/trace-*.md` or `<spec_path>.state.md`); when a single in-flight artefact exists the callout reads it and applies a per-skill resume rule (skip-Step-1 for `/bugfix` on a confirmed trace; resume from the recorded `round:` for `/interview`).
 - **Variant C** — `/context-reset` itself. No own durable surface; routes to whichever parent skill (`/task` / `/code-review` / `/pr-commented`) is active. The callout above this section is Variant C.
 
-The variant-distinguishing phrases that the char-cap / variant-identity audit greps for are kept in the design doc only (`ai-docs/plans/2026-05-14-sonnet-skill-reentry-protocol.design.md` § *Risks* row "Per-skill callout variants drift over time"), so the audit's expected hit-count of 1 per skill is preserved.
+The variant-distinguishing phrases that the char-cap / variant-identity audit greps for are kept in the design doc only (`ai-docs/plans/done/2026-05-14-sonnet-skill-reentry-protocol.design.md` § *Risks* row "Per-skill callout variants drift over time"), so the audit's expected hit-count of 1 per skill is preserved.
 
 ### Why the callout cross-links here
 

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -983,7 +983,7 @@ All three must be kept in sync whenever a new optional feature adds public API w
 
 **How to apply:** add a Phase 0.5 step to `.claude/skills/task/SKILL.md` (between the branch check and the issue-body fetch) running the four-step reconciliation above. The check fires only when the resolved input is a gh issue (bare-number `/task <N>` or deferred-spec activation with a populated `**Tracked in:** #N`); free-text `/task` invocations with no issue reference skip the check entirely. Propagate the change through the Task/Design sync group per AGENTS.md's Propagation Rule, and add the matching pre-resolved-rule entry to the Rule-5 substring blacklist in `.claude/agents/spec-writer.md` so the spec-writer subagent does not surface the `blocked`-label question.
 
-**Escalated?** skill:pr-merged
+**Escalated?** no
 
 ### 2026-05-13 — process — stale `.progress.md` after a merge mis-routes the next `/task` into the RESUME path
 


### PR DESCRIPTION
## Summary

`/ai-audit` run on 2026-05-16 (post-PR-#367 merge). Single commit `1f3fe2a` lands two fixes — one from each phase. All other Phase 2 checks (Propagation Rule sync groups, frontmatter, hooks, `Escalated?` / `Superseded by:` field coherence) pass.

## What landed

| Phase | File:line | Old | New | Reason |
|---|---|---|---|---|
| **Phase 1** (escalation audit subagent) | `ai-docs/learnings.md:986` (entry *"/task on a blocked-labelled gh issue must reconcile blockers before proceeding"*) | `Escalated? skill:pr-merged` | `Escalated? no` | PR #365's backfill was wrong: the rule's `**How to apply:**` targets `skill:task` Phase 0.5 (never implemented), not `/pr-merged`. `no` is the honest disposition; future `/improve` can fan the rule to its intended target. Boundary rule 1 Exception authorises the in-place fix. |
| **Phase 2** (instruction audit, Checklist A) | `.claude/skills/context-reset/SKILL.md:74` | `ai-docs/plans/2026-05-14-sonnet-skill-reentry-protocol.design.md` | `ai-docs/plans/done/2026-05-14-sonnet-skill-reentry-protocol.design.md` | Cross-reference to the archival sonnet-skill-reentry design doc was missing the `done/` prefix. The file moved to `done/` at PR #349's Step 12 finalise; this prose lagged. Now resolves. |

## Tracking

No upstream issue — `/ai-audit` workflow output.

## Audit summary (informational)

- **Phase 1:** 90 entries audited; 88 OK; 1 mismatch (fixed); 0 broken; 5 `Superseded by:` refs all resolve.
- **Phase 2 Checklist A** (cross-reference integrity): 1 broken ref found and fixed (above).
- **Phase 2 Checklist B/C** (conflicts, dead refs): clean.
- **Phase 2 Checklist D/E** (skill/agent frontmatter): all 14 skills + 8 agents valid; `name:` fields match basenames.
- **Phase 2 Checklist F** (hooks): `.claude/settings.json` valid via `jq .`; events (SessionStart / PreToolUse / PostToolUse) canonical; timeouts reasonable (5–60 s).
- **Phase 2 Checklist G** (Propagation Rule coherence): all 19 named sync-group members exist.
- **Phase 2 Checklist L** (Corrections-Log field coverage): both `Escalated?` AND `Superseded by:` covered in all 4 mandatory locations.
- **Phase 2 Checklist K** (skill-directory layout): `pr-ci-failed/SKILL.md` (358 lines) + `master-ci-failed/SKILL.md` (403 lines) above the 200-line threshold but per the counter-rule (orchestration guidance with placeholders, NOT self-contained bash recipes), they are NOT extraction candidates.
- **AGENTS.md** unchanged at 39,775 chars (225-char headroom to 40k hard cap; PR #363's Path A2 follow-up still pending).

## Test plan

- [x] `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` clean (no-op on doc-only diff).
- [x] `jq . .claude/settings.json` — PASS (settings.json unchanged this PR; verified once during audit).
- [x] Re-verify the L986 fix: `sed -n '985,987p' ai-docs/learnings.md` shows `**Escalated?** no` post-edit.
- [x] Re-verify the context-reset xref fix: `grep -n "2026-05-14-sonnet-skill-reentry-protocol" .claude/skills/context-reset/SKILL.md` shows the corrected `done/` path.
- [x] All web docs fetched per Phase 2 Step 2.1 (skills, sub-agents, hooks-guide).

## Out of scope

- Updating the historical archived design doc at `ai-docs/plans/done/2026-05-14-sonnet-skill-reentry-protocol.design.md:4` (also has a missing-`done/` sister-spec reference) — `done/` design docs are historical artefacts; rewriting them violates the precedent.
- AGENTS.md size extraction follow-up (Path A2 from PR #363).
- New rule proposals — `/improve`'s scope, not `/ai-audit`'s.