### PR TITLE
fix(ci/miri): use rustup override instead of `+nightly` alias

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -43,14 +43,22 @@ jobs:
           which cargo
           cargo --version
           rustc --version
-      - name: cargo +nightly miri setup
-        run: cargo +nightly miri setup
+      # `setup-rust-toolchain@v1` installs `nightly-2026-05-01` and sets it as
+      # the rustup override for this directory, so plain `cargo miri …` (no
+      # `+nightly`) resolves to the pinned toolchain with miri + rust-src
+      # already installed. The `+nightly` syntax bypasses the override and
+      # asks rustup for the literal `nightly` channel alias — which the
+      # pre-installed pinned toolchain does NOT register, so rustup would
+      # silently download a fresh latest-nightly without the miri component
+      # and fail with `'cargo-miri' is not installed`.
+      - name: cargo miri setup
+        run: cargo miri setup
       # The explicit -p list mirrors the FFI-free audit recorded in
       # ai-docs/plans/done/2026-05-17-miri-master-push-job.design.md and must be
       # re-audited whenever a workspace member is added or removed.
-      - name: cargo +nightly miri test (FFI-free crate subset)
+      - name: cargo miri test (FFI-free crate subset)
         run: |
-          cargo +nightly miri test \
+          cargo miri test \
             -p quartzite-core \
             -p quartzite-geometry \
             -p quartzite-paint-api \


### PR DESCRIPTION
## Summary

The first post-merge Miri run on master (run `25975599284`, ran 23:18 UTC right after #424 merged) failed at the `cargo +nightly miri setup` step with:

```
info: syncing channel updates for nightly-x86_64-unknown-linux-gnu
info: latest update on 2026-05-16 for version 1.97.0-nightly (d7f14d3d8 2026-05-15)
info: downloading 3 components
error: 'cargo-miri' is not installed for the toolchain 'nightly-x86_64-unknown-linux-gnu'.
help: run `rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri` to install it
```

## Root cause

`cargo +<channel>` is documented to **resolve to the literal channel** and **bypass** any rustup override in the current directory. `actions-rust-lang/setup-rust-toolchain@v1` installs the toolchain specified in `with: toolchain: nightly-2026-05-01` and sets it as the rustup **override** for the working directory — but it does **NOT** register the shorter `nightly` alias.

So when the workflow ran `cargo +nightly miri setup`:

1. rustup saw no `nightly` toolchain installed locally
2. downloaded a fresh latest-nightly on demand (`1.97.0-nightly d7f14d3d8 2026-05-15`)
3. ran `miri setup` against THAT toolchain
4. failed because miri wasn't installed on the freshly-downloaded toolchain — only on the pre-installed pinned `nightly-2026-05-01`

The job's `continue-on-error: true` (v1 policy from #422) masked the failure at the workflow conclusion level (workflow reported "success" because of the flag), but the job's `cargo +nightly miri setup` step shows `failure` and the actual `cargo miri test` step shows `skipped`.

## Fix

Drop the `+nightly` prefix from both step names and both `run:` commands. With the override active, plain `cargo miri setup` and `cargo miri test` resolve to `nightly-2026-05-01` (which has miri + rust-src already installed by `setup-rust-toolchain@v1`).

Added a 7-line comment above the setup step recording the rationale so a future maintainer doesn't restore the `+nightly` prefix when trying to be explicit.

## Tracking

Refs #422 (the originating spec/design). Not "Closes" because #422 was already closed by #424 — this PR is a post-merge follow-up rather than a re-opening.

## Spec drift note

The merged spec at `ai-docs/plans/done/2026-05-17-miri-master-push-job.spec.md` AC2 includes the literal wording "runs `cargo +nightly miri test`". That wording was a draft formula, not a binding contract — the spec's intent ("Miri runs against the FFI-free crate subset under the pinned nightly") is preserved by the fix. The merged spec itself is **not** amended (it lives in `done/` as historical record; the post-merge PR body is the appropriate place to record the drift).

## Test plan

- [x] `actionlint .github/workflows/miri.yml` exit 0 (per AGENTS.md AXIOM — gates `git add` on workflow files)
- [x] `cargo build` clean (no Rust changes; sanity gate)
- [x] `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` / `cargo doc` not affected (markdown-only diff in the workflow file)
- [ ] Post-merge: the next master push (this PR's merge) triggers the workflow under the fix and either passes Miri OR surfaces real findings instead of failing at `miri setup`. **Verifiable post-merge only.**
- [x] Self-review on the 1-file diff: change minimal (`+nightly` → empty in 2 step names + 2 run blocks; 7-line rationale comment added); spec intent preserved; no `learnings.md` edit per CI-skill convention; pre-commit on feature branch (not master).

## Anti-patterns avoided

- ❌ Not amending the merged spec in `done/` — `done/**` is historical and the drift is bounded; the merged spec stays as authored.
- ❌ Not editing `ai-docs/learnings.md` — CI logs are external content per the convention shared by `/pr-ci-failed`, `/master-ci-failed`, `/pr-commented`. The structural finding (`cargo +<channel>` vs rustup override interaction) is a legitimate learning class, but the strict reading of Boundary Rule 2 (no in-flow learnings outside `/task` Steps 8–12) keeps `learnings.md` clean here.
- ❌ Not flipping `continue-on-error: false` in this PR — that flip is the deferred follow-up to #422 keyed to N consecutive Miri-clean master runs; this fix is the prerequisite for those runs to start happening, but the flip itself stays deferred.