### PR TITLE
fix(ci/miri): add `-Zmiri-ignore-leaks` (Tree Borrows passed; serial_test leaks at shutdown)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -23,7 +23,16 @@ jobs:
     # tracked as a deferred follow-up to #422.
     continue-on-error: true
     env:
-      MIRIFLAGS: -Zmiri-tree-borrows
+      # `-Zmiri-tree-borrows`: aliasing model per spec / design Round 2.
+      # `-Zmiri-ignore-leaks`: `serial_test` (used by quartzite-core, runtime,
+      #   style-dispatch) keys a global `scc::HashMap<String, Mutex>` by
+      #   test name and never frees it — intentional, since test names live
+      #   for the program's lifetime and `scc`/`sdd` use epoch-based
+      #   reclamation that doesn't run at shutdown. Miri's strict-leak
+      #   detector flags every such entry on test-binary exit, drowning out
+      #   real findings. Tree Borrows itself remains active for UB/aliasing
+      #   detection; only the leak-checker is disabled.
+      MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks
     steps:
       - uses: actions/checkout@v6
       - name: Export ImageVersion  # See #340


### PR DESCRIPTION
## Summary

Master run [25975735824](https://github.com/maratik123/quartzite/actions/runs/25975735824) (the first Miri run after #425's toolchain-selection fix) actually executed Miri this time. Headline result:

> **Tree Borrows itself: 135 tests in `quartzite-core` passed clean.** Zero aliasing violations.

The job then failed at test-binary shutdown with three "memory leaked" errors. All three traced back into `serial_test`'s code-lock infrastructure:

```
error: memory leaked: alloc86260 (Rust heap, size: 64, align: 8), allocated here:
  --> sdd-3.0.10/src/ref_counted.rs:19:21        (RefCounted::new_shared)

error: memory leaked: alloc86201 (Rust heap, size: 192, align: 1), allocated here:
  --> scc-2.4.0/src/hash_table/bucket_array.rs:84:36  (BucketArray::new — alloc_zeroed)

error: memory leaked: alloc86458 (Rust heap, size: 56, align: 8), allocated here:
  --> .rustup/.../alloc/src/sync.rs:427:25       (Arc::new)
```

…all chained `serial_test::local_serial_core → scc::hash_map::HashMap::entry → check_new_key` from `connect::tests::auto_cross_thread_posts_to_dispatcher`. `serial_test` keys a global `HashMap<String, Mutex>` by test name and never frees it: test names live for the program's lifetime, and `scc` / `sdd` use epoch-based reclamation that doesn't run at shutdown. This is intentional in those crates — Miri's strict-leak detector flags every entry on exit.

## Fix

Add `-Zmiri-ignore-leaks` to `MIRIFLAGS`:

```yaml
MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks
```

Tree Borrows itself **remains active** for UB and aliasing detection — only the leak-checker is disabled.

## Scope of impact

Four crates in the Miri-tested subset use `serial_test`:
- `quartzite-core`
- `quartzite-runtime`
- `quartzite-style-dispatch`
- `quartzite-style` (excluded from Miri anyway)

Per-test allowlisting isn't practical: every `#[serial(…)]` annotation triggers the same `scc::HashMap` registration. Workspace-wide `-Zmiri-ignore-leaks` is the only sensible knob.

## Trade-off

- **Loss:** real memory leaks in our own code won't be caught by Miri.
- **Mitigation:** for v1, `continue-on-error: true` is still the master-side safety net. Leak detection is genuinely useful and we may revisit (e.g., by switching `serial_test` to a non-`scc`-backed alternative, or by adding a separate `cargo miri test` invocation against a crate-subset that doesn't use `serial_test`) if/when we add code that warrants per-allocation leak tracking.

## AC8 pattern match

The original spec (#422 / `2026-05-17-miri-master-push-job.spec.md`) AC8 said:

> The first push … produces a CI artifact: green Miri pass OR a list of findings (one issue opened per finding, OR a documented `# Miri: <reason>` exclusion / `MIRIFLAGS` adjustment per finding with that decision recorded in the PR description).

This PR is exactly the "documented `MIRIFLAGS` adjustment" branch — the finding (serial_test shutdown leaks) gets a documented `MIRIFLAGS` flag + inline comment + PR-description record, not a new issue. AC8's expected pattern, exercised.

## Tracking

Refs #422. Not "Closes" because #422 was already closed by #424; this is a post-merge follow-up.

## Test plan

- [x] `actionlint .github/workflows/miri.yml` exit 0
- [x] `cargo build` clean
- [ ] Post-merge: next master Miri run completes the `cargo miri test` step. Either green (Tree Borrows clean across all 9 included crates with leaks ignored) OR a list of **real** Tree Borrows findings on which we can act. **Verifiable post-merge.**
- [x] Self-review on 1-file diff: `MIRIFLAGS` value extended; 10-line inline comment records (a) what the new flag does, (b) why it's needed (`serial_test` + `scc` + `sdd`), (c) what's preserved (Tree Borrows itself). No `learnings.md` edit per CI-skill convention.

## Anti-patterns avoided

- ❌ Disabling Miri entirely. Tree Borrows actually works against this codebase and found nothing in 135 tests — we'd lose that signal.
- ❌ Excluding the 4 `serial_test`-using crates from the Miri subset. That would gut `quartzite-core`'s coverage, which is the workhorse crate and the primary value of the Miri job.
- ❌ Per-test `#[ignore]` annotations. `serial_test` leaks are global infrastructure, not per-test.
- ❌ Switching `serial_test` to a different test-isolation crate. That's a substantive code change unrelated to the CI job and out of scope.
- ❌ Adding to `learnings.md`. CI logs are external content per the `/pr-ci-failed` / `/master-ci-failed` convention; the structural finding (`scc`/`sdd` shutdown-leak pattern) is bounded knowledge that lives well in the workflow comment.