### PR TITLE
test(quartzite-runtime): skip pool_driver_drop_no_deadlock under Miri (timeout false-positive)

### DIFF
--- a/quartzite-runtime/src/timer_drivers.rs
+++ b/quartzite-runtime/src/timer_drivers.rs
@@ -431,7 +431,18 @@ mod tests {
     /// fix the pool thread never wakes and `handle.join()` deadlocks.
     /// A channel with a 10-second timeout converts the hang into an assertion
     /// failure so the test suite does not block indefinitely.
+    ///
+    /// Skipped under Miri: 2000 `PoolDriver::new()`+`drop()` iterations (each
+    /// spawning + joining a background thread) blow the 10-second wall-clock
+    /// budget under Miri's 10–30× interpreter overhead, producing a timeout
+    /// false-positive that looks like a real deadlock. The native `cargo test`
+    /// gate retains coverage; this test's value is wall-clock-bounded stress,
+    /// which is exactly what Miri can't preserve.
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "stress test — 2000 thread spawn+join iterations exceed Miri's interpreter budget"
+    )]
     fn pool_driver_drop_no_deadlock() {
         use std::sync::mpsc;
 


### PR DESCRIPTION
## Summary

Master Miri run [25975909856](https://github.com/maratik123/quartzite/actions/runs/25975909856) (post #426 leak-ignore fix) actually completed the Miri test phase for the first time. Headline result:

> **Tree Borrows itself: 269 tests passed clean** across 8 of 9 included crates. Zero aliasing or UB violations.

One single failure in `quartzite-runtime`:

```
test timer_drivers::tests::pool_driver_drop_no_deadlock ... FAILED

thread '…' panicked at quartzite-runtime/src/timer_drivers.rs:445:9:
PoolDriver::drop() deadlocked — running flag not protected by state mutex
```

The panic is the **test's own assertion**, not a Tree Borrows finding. The test:

```rust
std::thread::spawn(move || {
    for _ in 0..2000 {
        drop(PoolDriver::new());  // each spawns + joins a background thread
    }
    let _ = tx.send(());
});
assert!(
    rx.recv_timeout(std::time::Duration::from_secs(10)).is_ok(),
    "PoolDriver::drop() deadlocked — running flag not protected by state mutex"
);
```

2000 `PoolDriver::new()`+`drop()` cycles (each spawning + joining a background thread) under Miri's 10–30× interpreter overhead cannot complete in 10 seconds wall-clock. The `recv_timeout` fires → assertion panics → test fails. **No real deadlock**; this is a Miri-time-budget timeout false-positive.

## Fix

Gate the test with `#[cfg_attr(miri, ignore = "...")]`:

```rust
#[test]
#[cfg_attr(
    miri,
    ignore = "stress test — 2000 thread spawn+join iterations exceed Miri's interpreter budget"
)]
fn pool_driver_drop_no_deadlock() {
```

Standard Rust pattern for stress tests whose value is wall-clock-bounded throughput — exactly what Miri's interpreter cannot preserve.

The test's purpose (regression coverage for the TOCTOU race in `PoolDriver::drop()`'s `notify_all` / `condvar.wait` ordering) is **preserved by the native `cargo test` gate**, which runs the test natively at full speed. Only the Miri runner skips it.

## Verification

- `cargo test -p quartzite-runtime --lib timer_drivers` natively: test runs (3 passed, **0 ignored**); the cfg-gate only activates under Miri.
- `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings`: clean.

## Tracking

Refs #422. Third instance of the AC8 "documented exclusion per finding" pattern, this time at the test-source level rather than workflow level:

- #425 — workflow fix (`+nightly` → directory override)
- #426 — workflow fix (`-Zmiri-ignore-leaks` for `serial_test` shutdown leaks)
- **#???** (this PR) — test-source fix (`cfg_attr(miri, ignore = ...)` for time-budget-bound stress test)

After this merges, the next master Miri run should be **fully green** modulo the open `sdd`/Tree-Borrows int-to-ptr warning tracked in #427 (warning only, not a failure).

## Test plan

- [x] Native `cargo test -p quartzite-runtime --lib timer_drivers` passes; test executed (not ignored).
- [x] `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` clean.
- [x] `actionlint` N/A (no workflow files touched).
- [ ] Post-merge: next master Miri run completes the `cargo miri test` step **green** — 270+ tests passed Tree Borrows clean, 0 failed, 1 ignored (this test). Verifiable post-merge.

## Anti-patterns avoided

- ❌ Deleting the test. Its TOCTOU-regression value is real — just orthogonal to Miri's interpreter strengths.
- ❌ Reducing the iteration count (`2000` → `200`). Would weaken the native stress test for a Miri-specific reason; wrong axis.
- ❌ Raising the timeout (`10s` → `60s`). Same issue — bending the native test to accommodate Miri's slowness.
- ❌ Adding the ignore at the cargo level (e.g., `--skip`). Test-source-level cfg-gate is more discoverable and survives invocation changes.
- ❌ Skipping the entire `quartzite-runtime` crate from the Miri subset. Would lose the 86+ other passing tests' Tree Borrows coverage.
- ❌ Adding to `learnings.md`. CI logs are external content per the `/pr-ci-failed` / `/master-ci-failed` convention; the Miri-time-budget finding is bounded knowledge that lives well in the test's own doc-comment.