### PR TITLE
test(quartzite-runtime): skip tests/timer.rs under Miri (wall-clock-bounded integration suite)

### DIFF
--- a/quartzite-runtime/tests/timer.rs
+++ b/quartzite-runtime/tests/timer.rs
@@ -3,6 +3,21 @@
 //
 // All three driver backends are tested here together with ObjectTree insertion,
 // signals_blocked suppression, and single_shot semantics.
+//
+// Skipped under Miri at the file level: every assertion in this integration
+// suite is wall-clock-bounded (e.g. `wait_for_count(&counter, 1, 200ms)` after
+// a 30ms-interval timer, "ThreadDriver must fire at least once in 200 ms",
+// "AppDriver did not fire within 500 ms"). Miri's 10–30× interpreter
+// overhead can't preserve those budgets, producing timeout false-positives.
+// One such test (`unblock_signals_restores_tick`) already tripped master
+// Miri run 25976106489 (post #428); the others (`thread_driver_fires_at_interval`,
+// `app_driver_executes_on_event_loop_thread`, `app_driver_*_tick`) happened
+// to make their budgets in that run but carry the same latent risk.
+//
+// The native `cargo test` gate retains full coverage; the lib unit tests in
+// `src/timer.rs` and `src/timer_drivers.rs` still provide Tree Borrows
+// aliasing coverage on the Timer / Driver infrastructure under Miri.
+#![cfg(not(miri))]
 
 use std::{
     sync::{


### PR DESCRIPTION
## Summary

Master Miri run [25976106489](https://github.com/maratik123/quartzite/actions/runs/25976106489) (post #428) advanced further than ever:

> **380+ tests passed Tree Borrows clean** across 8 of 9 included crates. `quartzite-runtime --lib` showed `86 passed; 0 failed; 1 ignored` (the #428 cfg-gate took effect cleanly).

One new failure surfaced — this time in the `quartzite-runtime` integration suite:

```
test unblock_signals_restores_tick ... FAILED

thread 'unblock_signals_restores_tick' panicked at quartzite-runtime/tests/timer.rs:133:5:
must fire at least once after unblock
```

## Root cause

Same class as #428: wall-clock-bounded timer assertion that Miri's 10–30× interpreter overhead cannot preserve. The test:

```rust
let mut timer = Timer::new(Duration::from_millis(30));   // 30ms cadence
timer.connect_tick(move |_| { counter2.fetch_add(1, Ordering::SeqCst); });
timer.block_signals();
timer.start(Arc::new(ThreadDriver::new()));               // spawn background thread

thread::sleep(Duration::from_millis(80));                 // wait 2 intervals
assert_eq!(counter.load(...), 0, "no fires while blocked");

timer.unblock_signals();
assert!(
    wait_for_count(&counter, 1, Duration::from_millis(200)),
    "must fire at least once after unblock"
);
```

Under Miri the background `ThreadDriver` thread cannot fire even once in 200ms wall-clock.

## File-level fix (not per-test)

The audit of `tests/timer.rs` found **5–6 sibling tests** with the same wall-clock-bounded pattern:

- `thread_driver_fire_count_increments` — "Wait up to 500 ms for 3 fires" → asserts `fires >= 3`
- `unblock_signals_restores_tick` — "must fire at least once after unblock" → asserts via `wait_for_count(..., 200ms)`  **← the one that failed today**
- `thread_driver_fires_at_interval` — "ThreadDriver must fire at least once in 200 ms" → asserts `fires >= 1`
- `app_driver_executes_on_event_loop_thread` — "Wait until the probe fires (the event loop started) — up to 500 ms"
- `app_driver_*_tick` — "Wait for at least one tick — up to 500 ms"

The other 4 tests happened to make their budgets in this run but carry the same latent flakiness risk under Miri's scheduling. Rather than play whack-a-mole one test per master run, gate the whole file:

```rust
#![cfg(not(miri))]
```

at the top of `tests/timer.rs`. Miri compiles the file as an empty test binary; native `cargo test` runs all 10 tests at full wall-clock speed.

## Residual signal preserved

The lib unit tests under `quartzite-runtime/src/timer.rs` and `src/timer_drivers.rs` continue to provide Tree Borrows aliasing coverage on the `Timer` / `ThreadDriver` / `PoolDriver` / `AppDriver` infrastructure under Miri — verified by run #25976106489 which showed `quartzite-runtime --lib` passing 86 tests under TB with 1 ignored (`pool_driver_drop_no_deadlock`, the #428 fix). What we lose under Miri is integration coverage of the same code paths from the public API surface; the unit tests exercise the same data structures and dispatch logic.

## Verification

- `cargo test -p quartzite-runtime --test timer`: 10 passed, 0 ignored. Cfg gate only activates under Miri.
- `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings`: clean.

## Tracking

Refs #422. Fourth instance of the AC8 "documented exclusion per finding" pattern:

- #425 — workflow fix (`+nightly` → directory override)
- #426 — workflow fix (`-Zmiri-ignore-leaks`)
- #428 — test-source fix (`cfg_attr(miri, ignore)` on single unit test)
- **this PR** — file-level fix (`cfg(not(miri))` on whole integration suite)

After this merges, the next master Miri run should be **fully green** modulo the open `sdd` int-to-ptr warning tracked in #427.

## Test plan

- [x] Native `cargo test -p quartzite-runtime --test timer` passes; 10 tests run, 0 ignored.
- [x] `cargo build` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` clean.
- [x] `actionlint` N/A (no workflow files touched).
- [ ] Post-merge: next master Miri run completes the `cargo miri test` step **fully green** — 380+ tests pass TB clean, 1 ignored (the #428 unit test), 0 failed, the `tests/timer.rs` integration file skipped at compile time. Verifiable post-merge.

## Anti-patterns avoided

- ❌ Per-test cfg attributes on 5–6 tests. File-level gate is more discoverable and survives future test additions to the same file.
- ❌ Reducing timer intervals (`30ms` → `1ms`). Would weaken native cadence assertions.
- ❌ Removing the failing test. Its `block_signals` / `unblock_signals` regression value is real on the native gate.
- ❌ Adding to `learnings.md`. CI logs are external content per `/pr-ci-failed` / `/master-ci-failed` convention.
- ❌ Skipping the entire `quartzite-runtime` crate from the Miri subset. Would lose 86+ unit-test Tree Borrows coverage.