### PR TITLE
fix(ci/miri): add `-Zmiri-disable-isolation` (tracing_subscriber needs clock_gettime)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,7 +32,16 @@ jobs:
       #   detector flags every such entry on test-binary exit, drowning out
       #   real findings. Tree Borrows itself remains active for UB/aliasing
       #   detection; only the leak-checker is disabled.
-      MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks
+      # `-Zmiri-disable-isolation`: `tracing_subscriber`'s default fmt-time
+      #   layer calls `SystemTime::now()` → `clock_gettime(CLOCK_REALTIME)`
+      #   from inside `tracing::warn!` event formatting. Miri's default
+      #   isolation mode blocks the host syscall and the std `.unwrap()` on
+      #   line 107 of `std/src/sys/pal/unix/time.rs` then panics. Disabling
+      #   isolation lets the syscall return the real host time; tests that
+      #   warn through `tracing` (e.g. quartzite-style-dispatch's resolver-
+      #   miss test) then complete. Tree Borrows itself remains active for
+      #   UB/aliasing detection; only host-syscall isolation is relaxed.
+      MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks -Zmiri-disable-isolation
     steps:
       - uses: actions/checkout@v6
       - name: Export ImageVersion  # See #340


### PR DESCRIPTION
## Summary

Master Miri run [25976298970](https://github.com/maratik123/quartzite/actions/runs/25976298970) (post #429) advanced again:

> **381+ tests passed Tree Borrows clean** across all 9 included crates (including the post-#429 `tests/timer.rs` integration-file skip taking effect cleanly).

New finding surfaced in `quartzite-style-dispatch`:

```
test dispatch::tests::resolver_miss_mid_tree_skips_subtree_and_warns ...

error: unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled
  --> std/src/sys/pal/unix/time.rs:107:22
   |
107 |         cvt(unsafe { libc::clock_gettime(clock, t.as_mut_ptr()) }).unwrap();
```

## Root cause

Not Tree Borrows, not a timeout, not a leak. **Miri's default isolation mode** blocks host syscalls; `tracing_subscriber`'s default fmt-time layer calls `SystemTime::now()` to timestamp events, which calls `clock_gettime(CLOCK_REALTIME)`, which gets blocked, which makes the `.unwrap()` on line 107 of `std/src/sys/pal/unix/time.rs` panic.

Stack: `dispatch_paint → tracing::warn! → tracing_subscriber::fmt::format::Format::format_event → fmt::time::SystemTime::format_time → SystemTime::now → clock_gettime → blocked`.

The failing test is `dispatch::tests::resolver_miss_mid_tree_skips_subtree_and_warns` — it uses `tracing_test` to capture a `tracing::warn!` emitted by `dispatch_paint` when a resolver misses mid-tree. The dispatch code under test is **not** the problem; the timestamp formatter in the tracing-subscriber layer used by the test harness is.

## Fix

Miri itself names two remediations in its help text:
- `MIRIFLAGS=-Zmiri-disable-isolation` — allow host syscalls
- `MIRIFLAGS=-Zmiri-isolation-error=warn` — return error code instead of unsupported-op

The second doesn't help here because `SystemTime::now` does `.unwrap()` on the result — the std-side warn-and-continue path doesn't exist. So the fix is `-Zmiri-disable-isolation`:

```yaml
MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks -Zmiri-disable-isolation
```

with a 10-line inline comment explaining the `tracing_subscriber` interaction.

## Trade-off

Tests under Miri can now (in principle) read host time, env vars, files, etc. We don't intentionally do any of those in test code; any accidental dependency that surfaces under disabled-isolation Miri would manifest identically under native `cargo test`. Tree Borrows itself stays active for UB / aliasing detection; only host-syscall isolation is relaxed.

## AC8 pattern

Fifth instance of the "documented MIRIFLAGS adjustment per finding" pattern:

| PR | Disposition | Layer |
|---|---|---|
| #425 | `+nightly` → directory override | workflow `run:` |
| #426 | `-Zmiri-ignore-leaks` | workflow `env:` MIRIFLAGS |
| #428 | `cfg_attr(miri, ignore)` on unit test | test source |
| #429 | `#![cfg(not(miri))]` on integration file | test source |
| **this** | `-Zmiri-disable-isolation` | workflow `env:` MIRIFLAGS |

## Tracking

Refs #422.

## Test plan

- [x] `actionlint .github/workflows/miri.yml` exit 0
- [x] `cargo build` clean
- [x] Self-review on 1-file diff: 10-line inline comment + one `MIRIFLAGS` extension; pre-commit on feature branch; no `learnings.md` edit; no scope creep.
- [ ] Post-merge: next master Miri run completes the `cargo miri test` step **fully green** — 382+ tests pass TB clean modulo the `sdd` int-to-ptr warning tracked in #427. **Verifiable post-merge.**

## Anti-patterns avoided

- ❌ Disabling Miri entirely. Tree Borrows works against this codebase (382+ tests clean) — we'd lose the signal.
- ❌ Switching `tracing_test`'s formatter to a wall-clock-free one. Substantive code change unrelated to the CI gate, and would weaken `tracing_test`'s value (timestamps are part of what real users see in `tracing` logs).
- ❌ `cfg(not(miri))` on the failing test. The test is exercising real dispatch + warn-on-miss logic; a narrower fix would lose Miri coverage of that logic. Workspace-wide `-Zmiri-disable-isolation` is the appropriate granularity.
- ❌ Adding to `learnings.md`. CI logs are external content per the `/pr-ci-failed`/`/master-ci-failed` convention.