### PR TITLE
fix(master-ci): install libfontconfig1-dev for Miri widgets --lib (run 25977570342)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -71,6 +71,14 @@ jobs:
       # and fail with `'cargo-miri' is not installed`.
       - name: cargo miri setup
         run: cargo miri setup
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          # libfontconfig1-dev: required by parley (yeslogic-fontconfig-sys),
+          # reached via `cargo miri test --lib -p quartzite-widgets` from the
+          # v2 widening; ubuntu-latest runner does not include it.
+          sudo apt-get install -y libfontconfig1-dev
       # The explicit -p list mirrors the FFI-free audit recorded in
       # ai-docs/plans/done/2026-05-17-miri-master-push-job.design.md and must be
       # re-audited whenever a workspace member is added or removed.


### PR DESCRIPTION
## Summary

The post-#432 master Miri run failed at the `cargo miri test (widgets --lib)` step — not on a Tree Borrows finding, but because the GHA `ubuntu-latest` image lacks the `fontconfig` system library that transitive build dep `yeslogic-fontconfig-sys v6.0.1` needs (`parley` → `fontique` → `yeslogic-fontconfig-sys`). The v1 subset's narrower `widgets --test` lanes never reached that dep.

Fix: add an `Install Linux dependencies` step that `apt-get install -y libfontconfig1-dev`, matching the pattern already used in `ci.yml` (build/test/clippy jobs) and `docs.yml`.

## Failing master run

https://github.com/maratik123/quartzite/actions/runs/25977570342

Class: build (runner-environment lane behaviour)
Master commit: `e1425507c38b770870553ae28d99da603bace07a`

## Local reproducer

n/a — no-reproduce path. The dev host has `libfontconfig1-dev` installed (`pkg-config --exists fontconfig` returns 0) and the nightly miri toolchain is not present locally, so the runner-environment-only failure cannot be replicated on the dev box. User pre-authorised the YAML fix via the `/master-ci-failed` invocation arg; record kept in `ai-docs/master-ci/25977570342.progress.md`.

## Test plan

- [x] `actionlint .github/workflows/miri.yml` clean (AGENTS.md workflow-edit gate)
- [x] No Rust source touched → `cargo build` / `cargo test` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` unaffected
- [x] No `.spec.md` in diff → Spec-Amendment recipe does not fire
- [x] Step name + placement + inline-comment style match the existing workspace pattern (`ci.yml` 3×, `docs.yml`)
- [x] `self-review` APPROVE round 1
- [ ] Post-merge: next master Miri push run completes the `widgets --lib` step (and the four other widened steps that share the widgets dep cone) without the fontconfig-sys panic

**Tracked in run:** 25977570342