### PR TITLE
fix(master-ci): add crate-level doc comments to bench files (run 26007473956)

### DIFF
--- a/benches/macro_object.rs
+++ b/benches/macro_object.rs
@@ -1,3 +1,5 @@
+//! Benchmarks for the derive-macro `Object` implementation.
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use quartzite::core::{Object, ObjectBase, Signal, Value};
 use quartzite::macros::Object as DeriveObject;

--- a/quartzite-core/benches/signal_property.rs
+++ b/quartzite-core/benches/signal_property.rs
@@ -1,3 +1,5 @@
+//! Benchmarks for signal emission and property read/write operations.
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use quartzite_core::{
     AsObject, ObjectBase, Signal, Value,

--- a/quartzite-runtime/benches/object_tree.rs
+++ b/quartzite-runtime/benches/object_tree.rs
@@ -1,3 +1,5 @@
+//! Benchmarks for object-tree traversal and runtime operations.
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use quartzite_core::{
     AsObject, ObjectBase, Value,


### PR DESCRIPTION
## Summary

The workspace-level `missing_docs = "deny"` lint propagates to bench binary targets via `[lints] workspace = true`. All three bench files lacked a crate-level `//!` doc comment, so `cargo bench --workspace` failed with `error: missing documentation for the crate` when compiled under `-D warnings`.

## Failing master run

https://github.com/maratik123/quartzite/actions/runs/26007473956

Class: doc
Master commit: cb8942b8fb77c8cf3d058411b92189e540a0dd08

## Local reproducer

`RUSTFLAGS="-D warnings -D missing-docs" cargo bench --workspace --no-run` — re-ran GREEN after the fix.

## Test plan

- [x] `cargo build` / `cargo test` / `cargo fmt -- --check` / `cargo clippy --workspace -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings -D missing-docs" cargo bench --workspace --no-run` clean
- [x] `self-review` APPROVE round 1

**Tracked in run:** 26007473956

Closes #465 (follow-up: extend clippy CI to cover `--benches` so such regressions are caught on PRs rather than post-merge)