### PR TITLE
feat(task): add ⚡ Fourth — blocked-label reconciliation preamble

### DIFF
--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -125,7 +125,7 @@ These are invariants. Violating any of them is a defect:
 If a draft question OR a draft spec body contains any of the substrings below (case-insensitive), **discard the question / drop the body sentence** and apply the documented rule silently. Mechanical check before returning `ask` or `ready`:
 
 ```bash
-printf '%s\n' "<draft questions> <draft spec body>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers|would add.*dep|introduce.*as.*dep|pull in .* as.*dep|avoid.*as.*dep|not currently a depend'
+printf '%s\n' "<draft questions> <draft spec body>" | grep -iE 'backward.compat|back.?compat|compat.shim|deprecat|keep.old|should.*panic|panic.or.return|for.users|existing.callers|would add.*dep|introduce.*as.*dep|pull in .* as.*dep|avoid.*as.*dep|not currently a depend|blocked.label|blocked.by.#'
 ```
 
 | Forbidden substring (case-insensitive) | Documented answer to apply silently |
@@ -136,6 +136,7 @@ printf '%s\n' "<draft questions> <draft spec body>" | grep -iE 'backward.compat|
 | `should X panic`, `panic or return`, `should it panic`, `panic vs return`, `should this panic` | AGENTS.md § *API Naming* + *Library safety idioms*: non-panicking by default; `try_*` returning `Result`/`Option` |
 | `for users`, `for downstream`, `existing callers` | AGENTS.md § *API Stability*: no downstream clients yet |
 | `would add`, `introduce <X> as a dep`, `pull in <X>`, `avoid <X> as a dep`, `<X> is not currently a dependency` | AGENTS.md § *Dependency Versions* AXIOM (presence dimension): run `grep -r '<X>' --include='Cargo.toml' .` + `cargo tree --invert <X>` before writing. Drop the claim if hits exist; rewrite naming the actual concern. |
+| `blocked label`, `Blocked by #` | `.claude/skills/task/SKILL.md` § *⚡ Fourth*: `/task` reconciles `blocked`-labelled gh issues automatically (enumerate blockers → query state → remove stale label or pause for direction). Spec-writer must NOT surface the `blocked`-label question — the orchestrator owns it. |
 
 Any hit → rewrite or drop the question (for question-shape rules) or rewrite the body sentence (for the presence-of-dep rule, which can appear in any spec section). Do not return `ask` or `ready` until grep returns empty against your draft. If the orchestrator reports a Rule-5 violation, a re-spawn will be requested.
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -81,6 +81,24 @@ Activation sequence (bare-issue → matching deferred spec): parse `$ARGUMENTS` 
 
 ---
 
+## ⚡ Fourth: blocked-label reconciliation
+
+> **Guard sentence.** Fires when the resolved input is a gh issue — bare-number `/task <N>` (whether `⚡ Third` matched a deferred spec or fell through), OR `⚡ Second`/`⚡ Third` activated a deferred spec whose `**Tracked in:** #N` points to a real issue. Free-text `/task` invocations with no issue reference skip this preamble entirely. Runs AFTER `⚡ Third` and BEFORE Steps 1–5 / Step 6.
+
+If the resolved issue's `labels` array (already fetched by `⚡ Third` step 2) contains `blocked`, reconcile before proceeding:
+
+1. Enumerate blockers from the issue body — `Blocked by #M` / `Depends on #M` references. Treat any free-text blocker ("blocked on the auth rewrite") with no `#M` form as an unresolvable open blocker for step 4.
+2. Query each `#M` blocker: `gh issue view <M> --json state`.
+3. **All blockers CLOSED** → `gh issue edit <N> --remove-label blocked` (the stale label removal is part of the deliverable; it keeps `/next` / `/triage` filter accuracy honest), then continue with the normal flow.
+4. **At least one blocker OPEN, or any unresolvable free-text reference** → pause and ask the user one of:
+   - which blockers to wait on (do **not** start work);
+   - which blockers to disregard for this issue (closed-as-not-planned, unrelated cross-ref) — if zero open blockers remain after the user's answer, proceed with step 3 (remove the label);
+   - or whether to start work anyway accepting the risk — in this case do **NOT** remove the label (the issue is still semantically blocked; the user is overriding the gate explicitly).
+
+Never proceed silently when any blocker is open. The `blocked` label is the project's gate signal; starting `/task` past it without reconciliation defeats the gate and risks producing a spec/design that hits the unresolved dependency mid-implementation.
+
+---
+
 ### Steps 1–5: Spec creation (delegated to `/interview`)
 
 `/task` does not duplicate the interview workflow. Treat Steps 1–5 as a single delegated phase. If a saved spec already exists under `ai-docs/plans/`, confirm with the user and skip to Step 6. Otherwise invoke `Skill(skill="interview", args="$ARGUMENTS")` — the interview handles entry-mode detection, scope confirmation, clarifying-question rounds, tracking-issue resolution, spec writing, and the cross-link comment. Spec-only runs move the spec to `ai-docs/plans/deferred/` and stop. **Before Step 6:** confirm the spec exists at `ai-docs/plans/YYYY-MM-DD-name.spec.md` and the user has approved its `## Acceptance Criteria`. Full delegation narrative: `reference.md` § Steps 1–5 — spec creation delegation (detail).

--- a/.claude/skills/task/reference.md
+++ b/.claude/skills/task/reference.md
@@ -42,7 +42,7 @@ If `$ARGUMENTS` contains words like "activate", "start", "proceed" **and** a mat
 Activation sequence (bare-issue → matching deferred spec):
 
 1. Parse `$ARGUMENTS` — strip leading `#`, confirm it's a positive integer `N`.
-2. Load issue body: `gh issue view <N> --json title,body,state,labels` (also used to surface the issue's `blocked` label per the separate AGENTS.md learning, when that rule fires).
+2. Load issue body: `gh issue view <N> --json title,body,state,labels`. The `labels` field feeds `⚡ Fourth` (blocked-label reconciliation) on the next preamble.
 3. Grep deferred specs for the tracking reference:
    ```bash
    grep -l "^\*\*Tracked in:\*\* #<N>\b" ai-docs/plans/deferred/*.spec.md

--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -983,7 +983,7 @@ All three must be kept in sync whenever a new optional feature adds public API w
 
 **How to apply:** add a Phase 0.5 step to `.claude/skills/task/SKILL.md` (between the branch check and the issue-body fetch) running the four-step reconciliation above. The check fires only when the resolved input is a gh issue (bare-number `/task <N>` or deferred-spec activation with a populated `**Tracked in:** #N`); free-text `/task` invocations with no issue reference skip the check entirely. Propagate the change through the Task/Design sync group per AGENTS.md's Propagation Rule, and add the matching pre-resolved-rule entry to the Rule-5 substring blacklist in `.claude/agents/spec-writer.md` so the spec-writer subagent does not surface the `blocked`-label question.
 
-**Escalated?** no
+**Escalated?** skill:task, agent:spec-writer
 
 ### 2026-05-13 — process — stale `.progress.md` after a merge mis-routes the next `/task` into the RESUME path
 


### PR DESCRIPTION
## Summary

- Escalates the 2026-05-13 `learnings.md` entry: `/task` on a `blocked`-labelled gh issue must now enumerate blockers, auto-remove the stale label when all are closed, or pause for direction when any remain open.
- New `## ⚡ Fourth: blocked-label reconciliation` preamble in `.claude/skills/task/SKILL.md` — fires after `⚡ Third`, before Steps 1–5 / Step 6, only when the resolved input is a gh issue.
- Matching Rule-5 substrings (`blocked label`, `Blocked by #`) added to `.claude/agents/spec-writer.md` so the spec-writer agent does not surface the blocked-label question — the orchestrator owns it.
- `reference.md:45` forward-reference cleaned up to point at the new `⚡ Fourth` preamble (no more "when that rule fires" conditional).
- `Escalated?` field flipped from `no` → `skill:task, agent:spec-writer` (Boundary rule 1 Exception, `/improve` flow — see AGENTS.md § Learning Log).

## Test plan

- [x] `wc -c` confirms instruction file sizes still under the 40,000-char cap (`SKILL.md` 24,646 / `spec-writer.md` 15,585 / `AGENTS.md` 37,673 unchanged).
- [x] Propagation grep across `.claude/agents/`, `.claude/skills/`, `ai-docs/agent-writing-style.md` covered: only `next/SKILL.md` mentions `blocked` (independent filter, no sync needed) and `task/reference.md:45` (updated in this PR).
- [x] Rule-5 grep substring tested mentally: `blocked.by.#` requires literal `#` → avoids false positives on legitimate engineering uses of "blocked by".
- [ ] Future `/task <N>` on a `blocked`-labelled issue runs the 4-step reconciliation (manual smoke when a blocked issue next appears).