### PR TITLE
chore(tooling): sync ast-index on session start (update or rebuild)

### DIFF
--- a/.claude/rules/ast-index.md
+++ b/.claude/rules/ast-index.md
@@ -1,0 +1,129 @@
+# ast-index Rules
+
+Teach Claude Code to prefer `ast-index` over `grep` / bulk `Read`, outline
+before reading large files, and pass the same instructions to any subagent
+it spawns for code search.
+
+## Index hygiene
+
+The session-start hook in `.claude/settings.json` runs `ast-index update`
+(or `rebuild` if no index exists) every time a session opens, and the
+post-`git commit` hook refreshes the index after each commit. **Manual
+`ast-index update` is rarely needed** — only run it explicitly after a
+large external file change you want indexed before the next search (e.g.
+right after `git pull` or a checkout, mid-session).
+
+The project lives in a single workspace root — no `add-root` configuration
+is required.
+
+## Mandatory search rules
+
+1. **ALWAYS use `ast-index` FIRST** for any code-search task. This matches
+   the workspace-wide search-tool preference `ast-index > rg > grep`.
+2. **NEVER duplicate results** — if `ast-index` returned hits, that IS the
+   complete answer. Do not re-run `grep` / `rg` to "double-check".
+3. Use the `Grep` tool **only when** `ast-index` returned empty, or for
+   regex / string-literal patterns that are not symbol names.
+
+## Mandatory read rules
+
+1. **Before `Read`-ing any file over 500 lines, run `ast-index outline
+   <file>` first.**
+2. Use the outline to locate the specific symbol / line range you need,
+   then `Read` that slice via `offset` / `limit`.
+3. Never bulk-read large files without an outline — it wastes context and
+   produces worse answers.
+
+## Rules for subagents
+
+When you spawn a subagent for code search (via the `Agent` tool), the
+subagent does **not** inherit this file. Include the block below verbatim
+in the subagent's prompt:
+
+```
+Use `ast-index` via Bash for code search (NOT grep / the Grep tool):
+  ast-index search "query"           — universal search
+  ast-index file "Name"              — find a file by name fragment
+  ast-index symbol "Name"            — find a symbol definition
+  ast-index class "Name"             — find a class / trait / struct / enum
+  ast-index usages "Name"            — every usage of a symbol
+  ast-index callers "func"           — functions that call this one
+  ast-index implementations "Trait"  — concrete implementors of a trait
+  ast-index refs "Name"              — cross-references (defs + imports + usages)
+Use Grep ONLY if ast-index returned empty.
+
+Before Read-ing any file over 500 lines, FIRST run
+  ast-index outline <file>
+to get its structure, then Read only the targeted slice via offset/limit.
+Never bulk-read large files.
+```
+
+The `Explore` and `general-purpose` agents are the primary search agents in
+this project — give them the block above whenever they're tasked with
+locating code.
+
+## Command cheat sheet
+
+Grouped by intent. Full list and flags: `ast-index --help`.
+
+- **Search:** `search`, `file`, `symbol`, `class`
+- **Usages & flow:** `usages`, `callers`, `call-tree`, `refs`
+- **Hierarchy:** `implementations`, `hierarchy`, `extensions`
+- **Modules / deps:** `module`, `deps`, `dependents`, `api`, `unused-deps`
+- **Files:** `outline`, `imports`, `changed`
+- **Quality:** `todo`, `deprecated`, `unused-symbols`
+- **Index mgmt:** `rebuild`, `update`, `stats`
+
+## Common use cases
+
+Real Quartzite symbols — the agent makes better choices when it has
+concrete precedents to pattern-match against.
+
+- `ast-index usages "Palette"` — every place `Palette` is referenced
+  (constructors, fields, `&Palette` params, tests).
+- `ast-index implementations "Style"` — every concrete type that
+  implements the `Style` trait (e.g. `DefaultStyle`).
+- `ast-index callers "paint"` — who calls a `paint` method, without the
+  noise of definition lines.
+- `ast-index call-tree "draw" -d 3` — transitive caller tree up to depth
+  3. Use when tracing a paint bug back to its widget entry point.
+- `ast-index symbol "ColorRole"` — definition site of the `ColorRole`
+  enum (`quartzite-style-types/src/color_role.rs`).
+- `ast-index deps "quartzite-style"` — what `quartzite-style` depends on.
+- `ast-index dependents "quartzite-paint-api"` — what depends on
+  `quartzite-paint-api` (useful before a breaking change).
+- `ast-index changed` — symbols modified in your current branch vs
+  `master`. Great for "what am I actually changing?" PR-description
+  summaries.
+- `ast-index outline quartzite-style/src/default_style.rs` — structure of
+  a single file before reading it.
+- `ast-index todo` — all TODO / FIXME / HACK comments, grouped.
+- `ast-index deprecated` — every use of `#[deprecated]` across the
+  workspace.
+
+## Scoping searches
+
+All symbol-returning commands accept scope filters — use them to kill
+noise across the workspace:
+
+```bash
+ast-index usages "Palette" --module quartzite-style    # within one crate
+ast-index search "paint" --in-file default_style.rs    # within one file
+ast-index symbol "Style" --type class                  # class-kind only
+```
+
+## When `ast-index` returns empty
+
+Legitimate reasons:
+
+- Symbol genuinely doesn't exist in the workspace.
+- Index is stale — run `ast-index update` and retry (rare; the
+  session-start + post-commit hooks normally keep it fresh).
+- Symbol is generated by a macro (`derive`, `tracing::*_span!`,
+  `thiserror`, `rstest`, etc.) — `ast-index` does not expand macros. Fall
+  back to `rg` / `Grep` for the macro invocation.
+- You're searching for a string literal, not a symbol — use `rg` /
+  `Grep`.
+
+Do **not** fall back to bulk `Read` of files in these cases. Use `rg` /
+`Grep` with a specific pattern.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ast-index >/dev/null 2>&1; then if ast-index stats >/dev/null 2>&1; then ast-index update >/dev/null 2>&1 || true; else ast-index rebuild >/dev/null 2>&1 || true; fi; else true; fi",
+            "command": "if command -v ast-index >/dev/null 2>&1; then if ast-index stats >/dev/null 2>&1; then ast-index update >/dev/null 2>&1 || true; echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"ast-index: index updated\"}}'; else ast-index rebuild >/dev/null 2>&1 || true; echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"ast-index: index rebuilt\"}}'; fi; else echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"ast-index: not found\"}}'; fi",
             "timeout": 120,
             "statusMessage": "Syncing ast-index..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,17 @@
         "hooks": [
           {
             "type": "command",
+            "command": "if command -v ast-index >/dev/null 2>&1; then ast-index stats >/dev/null 2>&1 || ast-index rebuild; else echo 'ast-index not found'; fi",
+            "timeout": 120,
+            "statusMessage": "Checking ast-index..."
+          }
+        ],
+        "matcher": "startup"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"REQUIRED SESSION START to read rules from CLAUDE.md. Show user a summary of these rules\"}}'",
             "timeout": 30,
             "statusMessage": "Read session rules..."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ast-index >/dev/null 2>&1; then ast-index stats >/dev/null 2>&1 || ast-index rebuild >/dev/null 2>&1 || true; else true; fi",
+            "command": "if command -v ast-index >/dev/null 2>&1; then if ast-index stats >/dev/null 2>&1; then ast-index update >/dev/null 2>&1 || true; else ast-index rebuild >/dev/null 2>&1 || true; fi; else true; fi",
             "timeout": 120,
-            "statusMessage": "Checking ast-index..."
+            "statusMessage": "Syncing ast-index..."
           }
         ]
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,12 +5,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ast-index >/dev/null 2>&1; then ast-index stats >/dev/null 2>&1 || ast-index rebuild; else echo 'ast-index not found'; fi",
+            "command": "if command -v ast-index >/dev/null 2>&1; then ast-index stats >/dev/null 2>&1 || ast-index rebuild >/dev/null 2>&1 || true; else true; fi",
             "timeout": 120,
             "statusMessage": "Checking ast-index..."
           }
-        ],
-        "matcher": "startup"
+        ]
       },
       {
         "hooks": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ actionlint .github/workflows/<file>.yml   # required gate for any new/modified w
 >
 > Quick scan: `wc -c AGENTS.md CLAUDE.md .claude/skills/**/SKILL.md .claude/agents/**.md ai-docs/{code-style,doc-convention,context,agent-writing-style,corrections-log}.md`. Until `scripts/check-instruction-file-sizes.sh` lands as a pre-commit / CI gate, any `/task` whose work touches an instruction file should run this command before commit.
 
-Search: `rg <pattern> --type rust [-l | -C 3]`
+Search: `ast-index` first (see [`.claude/rules/ast-index.md`](.claude/rules/ast-index.md)); fall back to `rg <pattern> --type rust [-l | -C 3]` when `ast-index` returns empty.
 
 ## API Stability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,3 +318,16 @@ workspace agent-instruction file — and a corrections log lives at
 encouraged to read AGENTS.md but are not required to follow agent-only
 sections (`## Corrections Log`, `## Propagation Rule`) which exist for the
 agent workflow.
+
+### Code-search index (`ast-index`)
+
+Agent code-search runs through `ast-index` per
+[`.claude/rules/ast-index.md`](.claude/rules/ast-index.md). The upstream
+repository
+[`defendend/Claude-ast-index-search`](https://github.com/defendend/Claude-ast-index-search)
+hosts the installation instructions and the full command reference. Once
+the binary is on `PATH`, the `SessionStart` hook in
+[`.claude/settings.json`](.claude/settings.json) refreshes the index
+automatically on each session open. Human contributors do **not** need
+`ast-index` installed for `cargo build` / `cargo test` — it is an
+agent-only tool.


### PR DESCRIPTION
## Summary

**Session-start hook**

- Adds a `SessionStart` hook to `.claude/settings.json` that keeps the `ast-index` code-search index fresh on every session open
- If the index exists (`ast-index stats` exits 0): runs `ast-index update` (incremental, fast) → reports `ast-index: index updated`
- If the index is missing or corrupt (`ast-index stats` fails): runs `ast-index rebuild` (full reindex) → reports `ast-index: index rebuilt`
- If `ast-index` is not installed: no-op → reports `ast-index: not found`
- All paths exit 0 — the hook never blocks session start
- Each branch emits `hookSpecificOutput.additionalContext` so Claude sees the outcome at session start

**Search rules (49cb9f4)**

- New `.claude/rules/ast-index.md` — adapted from the upstream template at `defendend/Claude-ast-index-search examples/.claude/rules/ast-index.md`; iOS/Android/Kotlin/Perl blocks dropped, placeholder symbols replaced with real Quartzite ones (`Palette`, `Style`, `ColorRole`, `paint`, `quartzite-style`, `quartzite-paint-api`) verified via `ast-index symbol`, macro-fallback examples retuned to Rust (`derive`, `tracing::*_span!`, `thiserror`, `rstest`)
- AGENTS.md `Search:` pointer (line 72) updated to cite the new rule file and reflect the workspace `ast-index > rg > grep` preference (AGENTS.md 35399 → 35528 chars, stays in the 35k–39999 band)
- Rule file is on-demand, not auto-loaded

**Contributor pointer (bff2149)**

- New `Code-search index (ast-index)` subsection in `CONTRIBUTING.md` under `For agent-driven development` — links to the rule file, points at the upstream repository [`defendend/Claude-ast-index-search`](https://github.com/defendend/Claude-ast-index-search) for installation instructions, and clarifies that human contributors do not need `ast-index` for `cargo build` / `cargo test` (agent-only tool)

## Test plan

- [ ] Open a new Claude Code session — confirm `Syncing ast-index...` status message and `ast-index: index updated` in context
- [ ] Run `ast-index clear` then open a new session — confirm `ast-index: index rebuilt` in context
- [ ] Verify `ast-index stats` returns results without a manual rebuild after either path
- [ ] `realpath .claude/rules/ast-index.md` resolves from the AGENTS.md relative link
- [ ] `realpath` resolves the `.claude/rules/ast-index.md` and `.claude/settings.json` links from CONTRIBUTING.md