### PR TITLE
docs: Rust LSP tooling subsection in CONTRIBUTING.md for agent-driven development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,25 +339,16 @@ semantic complement. Use it for queries that need type inference, trait
 resolution, or precise reference chasing — `goToDefinition`,
 `findReferences`, `goToImplementation`, `hover`, call hierarchy.
 
-**Human contributors.** Install `rust-analyzer` for your editor /
-JetBrains plugin / VS Code extension via the standard channel (most IDEs
-manage the binary automatically). The project requires no
-`rust-analyzer.toml`; defaults track the workspace `Cargo.toml`. Strict
-`-D warnings` and the workspace lint policy in the root `Cargo.toml`
-flow through automatically (`rust-analyzer` runs `cargo check` /
-`cargo clippy` under the hood).
-
-**Agents.** Claude Code exposes an embedded `LSP` Tool (deferred — load
-its schema once per session via `ToolSearch query="select:LSP"`). It
-routes through the locally-configured LSP server for the file type, so
-a `rust-analyzer` binary on `PATH` is required for any operation
-against `.rs` files. Operations available: `goToDefinition`,
-`findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`,
-`goToImplementation`, `prepareCallHierarchy`, `incomingCalls`,
-`outgoingCalls`. All operations take `filePath` + 1-based `line` +
-1-based `character`. Prefer `LSP` over `ast-index` whenever the
-question is semantic (e.g. "every `impl` of trait `Style`" → `LSP
-goToImplementation` beats `ast-index implementations` for a trait
-defined in a macro-generated context); fall back to `ast-index` when
-the LSP server returns no result or the symbol is macro-expanded
-beyond `rust-analyzer`'s reach.
+Claude Code exposes an embedded `LSP` Tool (deferred — load its schema
+once per session via `ToolSearch query="select:LSP"`). It routes through
+the locally-configured LSP server for the file type, so a
+`rust-analyzer` binary on `PATH` is required for any operation against
+`.rs` files. Operations available: `goToDefinition`, `findReferences`,
+`hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`,
+`prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`. All operations
+take `filePath` + 1-based `line` + 1-based `character`. Prefer `LSP`
+over `ast-index` whenever the question is semantic (e.g. "every `impl`
+of trait `Style`" → `LSP goToImplementation` beats `ast-index
+implementations` for a trait defined in a macro-generated context);
+fall back to `ast-index` when the LSP server returns no result or the
+symbol is macro-expanded beyond `rust-analyzer`'s reach.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,3 +331,33 @@ the binary is on `PATH`, the `SessionStart` hook in
 automatically on each session open. Human contributors do **not** need
 `ast-index` installed for `cargo build` / `cargo test` — it is an
 agent-only tool.
+
+### Rust LSP (`rust-analyzer`)
+
+`ast-index` is syntactic (tree-sitter-based); `rust-analyzer` is the
+semantic complement. Use it for queries that need type inference, trait
+resolution, or precise reference chasing — `goToDefinition`,
+`findReferences`, `goToImplementation`, `hover`, call hierarchy.
+
+**Human contributors.** Install `rust-analyzer` for your editor /
+JetBrains plugin / VS Code extension via the standard channel (most IDEs
+manage the binary automatically). The project requires no
+`rust-analyzer.toml`; defaults track the workspace `Cargo.toml`. Strict
+`-D warnings` and the workspace lint policy in the root `Cargo.toml`
+flow through automatically (`rust-analyzer` runs `cargo check` /
+`cargo clippy` under the hood).
+
+**Agents.** Claude Code exposes an embedded `LSP` Tool (deferred — load
+its schema once per session via `ToolSearch query="select:LSP"`). It
+routes through the locally-configured LSP server for the file type, so
+a `rust-analyzer` binary on `PATH` is required for any operation
+against `.rs` files. Operations available: `goToDefinition`,
+`findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`,
+`goToImplementation`, `prepareCallHierarchy`, `incomingCalls`,
+`outgoingCalls`. All operations take `filePath` + 1-based `line` +
+1-based `character`. Prefer `LSP` over `ast-index` whenever the
+question is semantic (e.g. "every `impl` of trait `Style`" → `LSP
+goToImplementation` beats `ast-index implementations` for a trait
+defined in a macro-generated context); fall back to `ast-index` when
+the LSP server returns no result or the symbol is macro-expanded
+beyond `rust-analyzer`'s reach.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,7 +343,9 @@ Claude Code exposes an embedded `LSP` Tool (deferred — load its schema
 once per session via `ToolSearch query="select:LSP"`). It routes through
 the locally-configured LSP server for the file type, so a
 `rust-analyzer` binary on `PATH` is required for any operation against
-`.rs` files. Operations available: `goToDefinition`, `findReferences`,
+`.rs` files — see
+[`rust-analyzer`'s upstream documentation](https://rust-analyzer.github.io/)
+for install instructions. Operations available: `goToDefinition`, `findReferences`,
 `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`,
 `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`. All operations
 take `filePath` + 1-based `line` + 1-based `character`. Prefer `LSP`


### PR DESCRIPTION
## Summary

Adds a `### Rust LSP (rust-analyzer)` subsection at the end of `## For agent-driven development` in [`CONTRIBUTING.md`](CONTRIBUTING.md), mirroring the existing `### Code-search index (ast-index)` subsection's single-body shape.

Subsection content (post-review):

- **Intro paragraph** — positions `rust-analyzer` as the semantic complement to `ast-index` (syntactic / tree-sitter); use it for queries needing type inference, trait resolution, or precise reference chasing.
- **Agent-context body** — Claude Code exposes an embedded `LSP` Tool (deferred — loaded once per session via `ToolSearch query="select:LSP"`). It routes through the locally-configured `rust-analyzer` binary on `PATH`; install instructions live at [`rust-analyzer`'s upstream documentation](https://rust-analyzer.github.io/). 9 operations enumerated (`goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`); all take `filePath` + 1-based `line` + 1-based `character`. Preference rule vs `ast-index`: semantic → `LSP`; syntactic → `ast-index`; macro-expanded → fall back to `ast-index`.

The original draft included a separate **Human contributors** paragraph; reviewer feedback (round 1) noted that human-side install guidance is out of place under `## For agent-driven development`, so that paragraph was dropped. Round 2 added the upstream-docs link per reviewer request.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Manual read of `CONTRIBUTING.md` § For agent-driven development to confirm subsection placement, internal-link integrity, and consistent voice with the sibling `### Code-search index (ast-index)` block.

No Rust source changes; docs-only PR (`actionlint` / panic-index / unsafe-index SKIPPED).