### PR TITLE
fix(miri): add #![cfg(not(miri))] to timer_single_shot_app.rs

### DIFF
--- a/ai-docs/learnings.md
+++ b/ai-docs/learnings.md
@@ -1455,3 +1455,10 @@ Without `Write` / `Edit`, the agent's only file-writing path is `Bash(cat > 'ai-
 **Rule:** Design Amendment MUST route through the `design` subagent (same as Step 6), not be applied directly by the orchestrator. The orchestrator only owns: (1) surfacing the amendment to the user, (2) spawning `design` subagent with the amendment description, (3) spawning `design-review` on the result. Fix the skill recipe to say "spawn the `design` subagent to apply the amendment" rather than "update the design doc." The existing learning about orchestrator writing the design file directly (2026-05-24, process) is a related instance of the same pattern.
 **Kind:** correction
 **Escalated?** no
+
+### 2026-05-24 — testing — new integration test file with wall-clock-bounded assertions missing #![cfg(not(miri))]
+
+**What happened:** `quartzite-runtime/tests/timer_single_shot_app.rs` was added as a separate binary for the AC11 single-shot test without the `#![cfg(not(miri))]` per-file gate. Its sibling `timer.rs` already had the gate for the same reason (interpreter budget — 500 ms wall-clock timeout). The missing tag caused Miri CI run 26357397751 to fail with "AppDriver single_shot must fire at least once".
+**Rule:** Every new integration test file whose assertions are wall-clock-bounded (timeouts, `thread::sleep`-dependent polls) MUST carry `#![cfg(not(miri))]` + the policy comment block (miri-policy.md per-file fallback template) at creation time. Don't add the file and fix the tag in a follow-up; add both in the same commit.
+**Kind:** correction
+**Escalated?** no

--- a/quartzite-runtime/tests/timer_single_shot_app.rs
+++ b/quartzite-runtime/tests/timer_single_shot_app.rs
@@ -2,6 +2,14 @@
 
 // Separate binary so the Application singleton is fresh (no conflict with timer.rs).
 // Tests AC11: single_shot fires exactly once when using AppDriver.
+//
+// Skipped under Miri at the file level: interpreter budget. The whole-file
+// shape is required (not per-test `cfg_attr`) because every assertion is
+// wall-clock-bounded (500 ms timeout after a 30 ms-interval timer); Miri's
+// 10–30× interpreter overhead cannot preserve those budgets, producing
+// timeout false-positives. Alternative coverage: native `cargo test` exercises
+// this file on the standard test job.
+#![cfg(not(miri))]
 
 use std::{
     sync::{


### PR DESCRIPTION
## Summary

- `quartzite-runtime/tests/timer_single_shot_app.rs` was missing `#![cfg(not(miri))]`
- The test uses wall-clock-bounded assertions (500 ms timeout after a 30 ms timer); Miri's 10–30× interpreter overhead cannot satisfy those budgets, producing a false-positive failure
- Follows the same per-file fallback pattern as the sibling `timer.rs` exemplar documented in `ai-docs/miri-policy.md`
- Fixes Miri CI failure in run [26357397751](https://github.com/maratik123/quartzite/actions/runs/26357397751/job/77586548695): `test single_shot_app_driver_fires_exactly_once ... FAILED` / "AppDriver single_shot must fire at least once"

## Test plan

- [x] `cargo test -p quartzite-runtime --test timer_single_shot_app` passes natively (1 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Miri CI run should show `timer_single_shot_app` binary as 0 passed / 1 ignored / 0 failed