### PR TITLE
chore(settings): drop no-op Write(...) permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,9 +101,6 @@
       "Edit(./**)",
       "Edit(~/.claude/**)",
       "Edit(.claude/**)",
-      "Write(./**)",
-      "Write(~/.claude/**)",
-      "Write(.claude/**)",
       "Bash(cargo *)",
       "Bash(git *)",
       "Bash(gh *)",
@@ -118,19 +115,14 @@
     "deny": [
       "Read(.idea/**)",
       "Edit(.idea/**)",
-      "Write(.idea/**)",
       "Read(**/.env)",
       "Read(**/.env.*)",
       "Edit(**/.env)",
       "Edit(**/.env.*)",
-      "Write(**/.env)",
-      "Write(**/.env.*)",
       "Read(**/secrets*)",
       "Read(**/.secrets*)",
       "Edit(**/secrets*)",
-      "Edit(**/.secrets*)",
-      "Write(**/secrets*)",
-      "Write(**/.secrets*)"
+      "Edit(**/.secrets*)"
     ]
   }
 }


### PR DESCRIPTION
## Problem

At session start the harness warned on all 8 `Write(...)` entries in `.claude/settings.json`:

> Permission allow rule (.claude/settings.json): `Write(./**)` is not matched by file permission checks — only `Edit(path)` rules are. Use `Edit(./**)` instead (Edit rules cover all file-editing tools).

File permission checks only evaluate `Edit(path)` rules; `Edit` already covers every file-editing tool, `Write` included. The `Write(...)` entries never matched anything.

## Change

Removed all 8 warned entries. Each had an exact `Edit(...)` sibling already present, so the **effective permission set is unchanged**:

| List | Removed | Already covered by |
|---|---|---|
| `allow` | `Write(./**)`, `Write(~/.claude/**)`, `Write(.claude/**)` | matching `Edit(...)` |
| `deny` | `Write(.idea/**)`, `Write(**/.env)`, `Write(**/.env.*)`, `Write(**/secrets*)`, `Write(**/.secrets*)` | matching `Edit(...)` |

The `PostToolUse` hook matcher `"Write|Edit"` is deliberately untouched — hook matchers match **tool names**, not permission paths, so `Write` is still correct there.

## Verification

- `jq -e '.permissions' .claude/settings.json` — JSON parses; resulting `allow` / `deny` arrays are as intended.
- Propagation grep for `Write(` across `.claude/`, `AGENTS.md`, `ai-docs/` — one hit only, in `ai-docs/plans/done/2026-05-31-triage-deferred-jsonl.design.md:136`. Left as-is: `plans/done/` is a historical artefact, not a live instruction file.